### PR TITLE
spike: probe macOS Accessibility context detection (#28)

### DIFF
--- a/prototypes/context-detection-spike/README.md
+++ b/prototypes/context-detection-spike/README.md
@@ -1,0 +1,67 @@
+# Context-detection spike (issue #28)
+
+PROTOTYPE. Throwaway code that answers one question. Not a native helper, not
+production, no tests, do not build on this file.
+
+## The question
+
+Can the frontmost app and the focused field type be detected reliably enough,
+across the apps developers actually use, for context-awareness to carry the
+product? The useful output is not "it works" but a map of where it fails,
+because that decides whether the per-mode formatting can be trusted silently
+or needs a visible indicator and a manual override.
+
+This is neither of the prototype skill's two standard shapes (a clickable state
+model, or UI variants). The question is empirical and about a real OS API
+against real apps, so the artifact is an instrumentation probe instead.
+
+## What the probe measures
+
+Two layers, recorded separately, because they fail for different reasons:
+
+1. **Frontmost app** via `NSWorkspace.shared.frontmostApplication`. Needs no
+   permission at all.
+2. **Focused element** via `AXUIElementCopyAttributeValue(..., kAXFocusedUIElementAttribute)`.
+   Needs Accessibility trust, and needs the app to actually publish an
+   accessibility tree.
+
+For the focused element it records `AXRole`, `AXSubrole`, `AXRoleDescription`,
+the focused title, the window title, whether `AXValue` and `AXSelectedText` are
+readable, and on failure **the exact `AXError`**. The error code is the answer,
+not noise: `kAXErrorAPIDisabled` (we are not trusted), `kAXErrorNoValue`
+(nothing focused), `kAXErrorCannotComplete` (app did not answer),
+`kAXErrorAttributeUnsupported` (app has no such concept) are four different
+verdicts with four different product consequences.
+
+`--poke` additionally sets `AXManualAccessibility` on the frontmost app before
+reading it. Chromium and Electron apps withhold their accessibility tree until
+something asks; whether this knob flips VS Code and the Electron chat apps is
+the single check most likely to decide the issue.
+
+## Running it
+
+```sh
+./run.sh            # poll every 400ms, print on change, tee into logs/
+./run.sh --poke     # same, with AXManualAccessibility set per app
+./run.sh --prompt   # trigger the Accessibility permission prompt first
+./sweep.sh          # activate a list of apps in turn, so the app-level half
+                    # of the map collects itself while the probe runs
+swift probe.swift --once   # single sample
+```
+
+The probe prints `AXIsProcessTrusted()` on startup. If that is `false`, every
+focused-element read returns `kAXErrorAPIDisabled` and the run tells you
+nothing about the apps.
+
+**Whatever app launches the probe is the process that needs the grant**, not
+the probe itself. The reliable route is to run `./run.sh --prompt` from
+Terminal.app, approve the prompt, and grant Terminal under
+System Settings > Privacy & Security > Accessibility.
+
+Field focus mostly needs a human clicking into a real text field. `sweep.sh`
+only automates which app is in front, plus whatever focus an app lands on by
+itself when activated.
+
+## Results
+
+See [RESULTS.md](RESULTS.md).

--- a/prototypes/context-detection-spike/RESULTS.md
+++ b/prototypes/context-detection-spike/RESULTS.md
@@ -1,0 +1,113 @@
+# Results map (issue #28)
+
+Status: **partial**. Layer 1 measured. Layer 2 blocked pending an Accessibility
+grant, see "What is still missing" at the bottom. Every cell below is a real
+observation from `logs/`; nothing here is inferred. Cells that were not measured
+say so.
+
+Machine: macOS 15 (Darwin 24.6.0), Apple Silicon, Swift 6.1.2.
+Run: `logs/sweep-untrusted.log`, 2026-08-22.
+
+## Layer 1: frontmost app detection
+
+`NSWorkspace.shared.frontmostApplication`, no permission required. Ten apps
+activated in turn by `sweep.sh`, probe polling at 400ms.
+
+| App | Kind | Detected | Bundle id reported | Correct |
+| --- | --- | --- | --- | --- |
+| Terminal | native terminal | yes | `com.apple.Terminal` | yes |
+| TextEdit | native (easy case) | yes | `com.apple.TextEdit` | yes |
+| Notes | native (easy case) | yes | `com.apple.Notes` | yes |
+| Safari | browser (WebKit) | yes | `com.apple.Safari` | yes |
+| Google Chrome | browser (Blink) | yes | `com.google.Chrome` | yes |
+| Visual Studio Code | Electron editor | yes | `com.microsoft.VSCode` | yes |
+| Cursor | Electron editor | yes | `com.todesktop.230313mzl4w4u92` | yes, but see note |
+| Obsidian | Electron | yes | `md.obsidian` | yes |
+| WhatsApp | Electron chat | yes | `net.whatsapp.WhatsApp` | yes |
+| Finder | native | yes | `com.apple.finder` | yes |
+
+**Layer 1 verdict: 10 of 10, no failures, no permission needed.** Electron makes
+no difference here. Whatever else is uncertain, "which app is in front" is not.
+
+Two findings that matter for the real helper:
+
+1. **The naive implementation silently lies.** A command-line process that polls
+   `frontmostApplication` on a `Thread.sleep` loop keeps reporting whichever app
+   was frontmost when it launched, forever. That value is refreshed by
+   notifications delivered on the run loop. The first run of this spike produced
+   exactly one record, VS Code, for a ten-app sweep. Fixed by pumping
+   `RunLoop.current.run(mode:before:)` instead of sleeping. A native helper that
+   gets this wrong fails in the worst way: confidently wrong context, no error.
+2. **Bundle ids are not always human-readable.** Cursor ships as
+   `com.todesktop.230313mzl4w4u92` (ToDesktop packaging). Any app-to-mode
+   mapping keyed on bundle id needs a lookup table with opaque ids in it, and
+   cannot fall back on pattern-matching the id string.
+
+## Layer 2: focused-element detection
+
+`AXUIElementCopyAttributeValue(..., kAXFocusedUIElementAttribute)`.
+
+Measured so far, from an **untrusted** process:
+
+| App | Focused role | AXValue readable | Error | Notes |
+| --- | --- | --- | --- | --- |
+| Visual Studio Code | not reported | no | `kAXErrorAPIDisabled` | process not trusted |
+| all others | not measured | not measured | not measured | blocked by the same grant |
+
+System-wide focus (`AXUIElementCreateSystemWide`) returned
+`kAXErrorCannotComplete` rather than `kAXErrorAPIDisabled` under the same
+conditions, so the two entry points do not even report the untrusted state
+identically. Worth remembering when writing the helper's error handling.
+
+**This tells us nothing about any app yet.** `kAXErrorAPIDisabled` is the
+permission wall, not an app failure. Reporting these rows as app failures would
+be worse than reporting nothing, because the formatting modes would be built on
+a false map.
+
+## Coverage limits on this machine
+
+The issue asks for a specific spread. What exists here:
+
+| Target from the issue | Available | Substitute used |
+| --- | --- | --- |
+| native terminal | yes | Terminal.app |
+| Electron terminal | **no** | none installed (no Hyper, iTerm, Warp, Ghostty). VS Code's integrated terminal is the closest available proxy and needs a human to focus it |
+| VS Code | yes | VS Code, plus Cursor and Windsurf as second and third Electron editors |
+| JetBrains IDE | **no** | none installed. Not testable here |
+| browser text field | yes | Safari and Chrome, needs a human to click into a field |
+| Slack | **no** | not installed. WhatsApp and Microsoft Teams are the available Electron chat proxies |
+| native macOS app | yes | TextEdit, Notes, Finder |
+
+JetBrains and a standalone Electron terminal are genuinely untested here and
+should not be guessed at. JetBrains in particular is known to gate its Swing
+editor surface behind an in-app accessibility setting, which is a different
+product answer ("works only if the user turns a knob on") from either working
+or failing, and needs its own row once someone has an IDE installed.
+
+## What is still missing
+
+One human action unblocks everything below: grant Accessibility to the process
+that launches the probe (run `./run.sh --prompt` from Terminal.app, approve,
+then re-run). After that:
+
+1. Re-run the sweep trusted, and record role, subrole, value readability and
+   error code per app.
+2. Click into a real text field in each app (browser input, VS Code editor, VS
+   Code integrated terminal, chat composer) and record what focus reports.
+3. Re-run with `--poke` and diff against the trusted run, to see whether
+   `AXManualAccessibility` changes what the Electron apps expose. Record per app
+   whether the knob was needed, because "works only if we poke it" is a distinct
+   answer.
+4. Install a JetBrains IDE and a standalone Electron terminal, or mark them
+   permanently untested and carry the risk explicitly.
+
+## Answer to the issue
+
+Not yet answerable in full. What is settled:
+
+- The **app-level** half of context awareness is reliable, free, and needs no
+  permission. Per-app mode selection ("terminal mode in Terminal, prose mode in
+  Slack") is safe to build on.
+- The **field-level** half is entirely unmeasured and is where the risk sits.
+  The product thesis rests on this half, so the issue stays open until the
+  trusted runs above are done.

--- a/prototypes/context-detection-spike/logs/sweep-untrusted.log
+++ b/prototypes/context-detection-spike/logs/sweep-untrusted.log
@@ -1,0 +1,241 @@
+OpenStream context-detection spike (issue #28) - PROTOTYPE, throwaway
+AXIsProcessTrusted() = false
+NOT TRUSTED: every focused-element read below will fail with kAXErrorAPIDisabled.
+Grant Accessibility to the app running this process, then re-run.
+poke AXManualAccessibility = false   interval = 0.4s
+Switch apps and click into text fields. Records print only when something changes.
+Ctrl-C to stop.
+---------------------------------------------------------------
+[1:11:38 pm] frontmost app     : Obsidian
+            bundle id         : md.obsidian  (pid 45115)
+            AX trusted        : NO
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorAPIDisabled>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorAPIDisabled>
+            focused subrole   : <kAXErrorAPIDisabled>
+            role description  : <kAXErrorAPIDisabled>
+            focused title     : <kAXErrorAPIDisabled>
+            AXValue readable  : <kAXErrorAPIDisabled>
+            AXSelectedText    : <kAXErrorAPIDisabled>
+---------------------------------------------------------------
+[1:11:40 pm] frontmost app     : Terminal
+            bundle id         : com.apple.Terminal  (pid 44102)
+            AX trusted        : NO
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorAPIDisabled>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorAPIDisabled>
+            focused subrole   : <kAXErrorAPIDisabled>
+            role description  : <kAXErrorAPIDisabled>
+            focused title     : <kAXErrorAPIDisabled>
+            AXValue readable  : <kAXErrorAPIDisabled>
+            AXSelectedText    : <kAXErrorAPIDisabled>
+---------------------------------------------------------------
+[1:11:45 pm] frontmost app     : TextEdit
+            bundle id         : com.apple.TextEdit  (pid 47950)
+            AX trusted        : NO
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorAPIDisabled>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorAPIDisabled>
+            focused subrole   : <kAXErrorAPIDisabled>
+            role description  : <kAXErrorAPIDisabled>
+            focused title     : <kAXErrorAPIDisabled>
+            AXValue readable  : <kAXErrorAPIDisabled>
+            AXSelectedText    : <kAXErrorAPIDisabled>
+---------------------------------------------------------------
+[1:11:48 pm] frontmost app     : Notes
+            bundle id         : com.apple.Notes  (pid 44523)
+            AX trusted        : NO
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorAPIDisabled>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorAPIDisabled>
+            focused subrole   : <kAXErrorAPIDisabled>
+            role description  : <kAXErrorAPIDisabled>
+            focused title     : <kAXErrorAPIDisabled>
+            AXValue readable  : <kAXErrorAPIDisabled>
+            AXSelectedText    : <kAXErrorAPIDisabled>
+---------------------------------------------------------------
+[1:11:49 pm] frontmost app     : Obsidian
+            bundle id         : md.obsidian  (pid 45115)
+            AX trusted        : NO
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorAPIDisabled>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorAPIDisabled>
+            focused subrole   : <kAXErrorAPIDisabled>
+            role description  : <kAXErrorAPIDisabled>
+            focused title     : <kAXErrorAPIDisabled>
+            AXValue readable  : <kAXErrorAPIDisabled>
+            AXSelectedText    : <kAXErrorAPIDisabled>
+---------------------------------------------------------------
+[1:11:51 pm] frontmost app     : Safari
+            bundle id         : com.apple.Safari  (pid 44573)
+            AX trusted        : NO
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorAPIDisabled>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorAPIDisabled>
+            focused subrole   : <kAXErrorAPIDisabled>
+            role description  : <kAXErrorAPIDisabled>
+            focused title     : <kAXErrorAPIDisabled>
+            AXValue readable  : <kAXErrorAPIDisabled>
+            AXSelectedText    : <kAXErrorAPIDisabled>
+---------------------------------------------------------------
+[1:11:53 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : NO
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorAPIDisabled>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorAPIDisabled>
+            focused subrole   : <kAXErrorAPIDisabled>
+            role description  : <kAXErrorAPIDisabled>
+            focused title     : <kAXErrorAPIDisabled>
+            AXValue readable  : <kAXErrorAPIDisabled>
+            AXSelectedText    : <kAXErrorAPIDisabled>
+---------------------------------------------------------------
+[1:11:54 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : NO
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorAPIDisabled>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorAPIDisabled>
+            focused subrole   : <kAXErrorAPIDisabled>
+            role description  : <kAXErrorAPIDisabled>
+            focused title     : <kAXErrorAPIDisabled>
+            AXValue readable  : <kAXErrorAPIDisabled>
+            AXSelectedText    : <kAXErrorAPIDisabled>
+---------------------------------------------------------------
+[1:11:58 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : NO
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorAPIDisabled>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorAPIDisabled>
+            focused subrole   : <kAXErrorAPIDisabled>
+            role description  : <kAXErrorAPIDisabled>
+            focused title     : <kAXErrorAPIDisabled>
+            AXValue readable  : <kAXErrorAPIDisabled>
+            AXSelectedText    : <kAXErrorAPIDisabled>
+---------------------------------------------------------------
+[1:12:01 pm] frontmost app     : Cursor
+            bundle id         : com.todesktop.230313mzl4w4u92  (pid 44651)
+            AX trusted        : NO
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorAPIDisabled>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorAPIDisabled>
+            focused subrole   : <kAXErrorAPIDisabled>
+            role description  : <kAXErrorAPIDisabled>
+            focused title     : <kAXErrorAPIDisabled>
+            AXValue readable  : <kAXErrorAPIDisabled>
+            AXSelectedText    : <kAXErrorAPIDisabled>
+---------------------------------------------------------------
+[1:12:04 pm] frontmost app     : Obsidian
+            bundle id         : md.obsidian  (pid 45115)
+            AX trusted        : NO
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorAPIDisabled>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorAPIDisabled>
+            focused subrole   : <kAXErrorAPIDisabled>
+            role description  : <kAXErrorAPIDisabled>
+            focused title     : <kAXErrorAPIDisabled>
+            AXValue readable  : <kAXErrorAPIDisabled>
+            AXSelectedText    : <kAXErrorAPIDisabled>
+---------------------------------------------------------------
+[1:12:05 pm] frontmost app     : Cursor
+            bundle id         : com.todesktop.230313mzl4w4u92  (pid 44651)
+            AX trusted        : NO
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorAPIDisabled>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorAPIDisabled>
+            focused subrole   : <kAXErrorAPIDisabled>
+            role description  : <kAXErrorAPIDisabled>
+            focused title     : <kAXErrorAPIDisabled>
+            AXValue readable  : <kAXErrorAPIDisabled>
+            AXSelectedText    : <kAXErrorAPIDisabled>
+---------------------------------------------------------------
+[1:12:07 pm] frontmost app     : ‎WhatsApp
+            bundle id         : net.whatsapp.WhatsApp  (pid 670)
+            AX trusted        : NO
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorAPIDisabled>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorAPIDisabled>
+            focused subrole   : <kAXErrorAPIDisabled>
+            role description  : <kAXErrorAPIDisabled>
+            focused title     : <kAXErrorAPIDisabled>
+            AXValue readable  : <kAXErrorAPIDisabled>
+            AXSelectedText    : <kAXErrorAPIDisabled>
+---------------------------------------------------------------
+[1:12:08 pm] frontmost app     : Cursor
+            bundle id         : com.todesktop.230313mzl4w4u92  (pid 44651)
+            AX trusted        : NO
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorAPIDisabled>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorAPIDisabled>
+            focused subrole   : <kAXErrorAPIDisabled>
+            role description  : <kAXErrorAPIDisabled>
+            focused title     : <kAXErrorAPIDisabled>
+            AXValue readable  : <kAXErrorAPIDisabled>
+            AXSelectedText    : <kAXErrorAPIDisabled>
+---------------------------------------------------------------
+[1:12:10 pm] frontmost app     : Finder
+            bundle id         : com.apple.finder  (pid 681)
+            AX trusted        : NO
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorAPIDisabled>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorAPIDisabled>
+            focused subrole   : <kAXErrorAPIDisabled>
+            role description  : <kAXErrorAPIDisabled>
+            focused title     : <kAXErrorAPIDisabled>
+            AXValue readable  : <kAXErrorAPIDisabled>
+            AXSelectedText    : <kAXErrorAPIDisabled>
+---------------------------------------------------------------
+[1:12:13 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : NO
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorAPIDisabled>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorAPIDisabled>
+            focused subrole   : <kAXErrorAPIDisabled>
+            role description  : <kAXErrorAPIDisabled>
+            focused title     : <kAXErrorAPIDisabled>
+            AXValue readable  : <kAXErrorAPIDisabled>
+            AXSelectedText    : <kAXErrorAPIDisabled>
+---------------------------------------------------------------
+[1:12:15 pm] frontmost app     : ‎WhatsApp
+            bundle id         : net.whatsapp.WhatsApp  (pid 670)
+            AX trusted        : NO
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorAPIDisabled>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorAPIDisabled>
+            focused subrole   : <kAXErrorAPIDisabled>
+            role description  : <kAXErrorAPIDisabled>
+            focused title     : <kAXErrorAPIDisabled>
+            AXValue readable  : <kAXErrorAPIDisabled>
+            AXSelectedText    : <kAXErrorAPIDisabled>
+---------------------------------------------------------------
+[1:12:16 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : NO
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorAPIDisabled>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorAPIDisabled>
+            focused subrole   : <kAXErrorAPIDisabled>
+            role description  : <kAXErrorAPIDisabled>
+            focused title     : <kAXErrorAPIDisabled>
+            AXValue readable  : <kAXErrorAPIDisabled>
+            AXSelectedText    : <kAXErrorAPIDisabled>

--- a/prototypes/context-detection-spike/logs/trustcheck-terminal.log
+++ b/prototypes/context-detection-spike/logs/trustcheck-terminal.log
@@ -1,0 +1,20 @@
+OpenStream context-detection spike (issue #28) - PROTOTYPE, throwaway
+AXIsProcessTrusted() = false
+NOT TRUSTED: every focused-element read below will fail with kAXErrorAPIDisabled.
+Grant Accessibility to the app running this process, then re-run.
+poke AXManualAccessibility = false   interval = 0.4s
+Switch apps and click into text fields. Records print only when something changes.
+Ctrl-C to stop.
+---------------------------------------------------------------
+[1:13:41 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : NO
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorAPIDisabled>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorAPIDisabled>
+            focused subrole   : <kAXErrorAPIDisabled>
+            role description  : <kAXErrorAPIDisabled>
+            focused title     : <kAXErrorAPIDisabled>
+            AXValue readable  : <kAXErrorAPIDisabled>
+            AXSelectedText    : <kAXErrorAPIDisabled>

--- a/prototypes/context-detection-spike/probe.swift
+++ b/prototypes/context-detection-spike/probe.swift
@@ -1,0 +1,240 @@
+// PROTOTYPE - throwaway spike for issue #28 ("Can context-awareness be detected
+// reliably enough to carry the product?"). Not production code, not a native
+// helper, not tested. It exists to produce a map of where macOS Accessibility
+// context detection works, where it lies, and where it returns nothing.
+//
+// Run:  swift probe.swift            (poll, print on change)
+//       swift probe.swift --prompt   (same, but ask for Accessibility trust first)
+//       swift probe.swift --poke     (same, but set AXManualAccessibility on each
+//                                     frontmost app before reading it - the knob
+//                                     Chromium/Electron apps gate their a11y tree behind)
+//       swift probe.swift --once     (single sample, then exit)
+
+import Foundation
+import AppKit
+import ApplicationServices
+
+// ---------------------------------------------------------------- arguments
+let args = Set(CommandLine.arguments.dropFirst())
+let wantPrompt = args.contains("--prompt")
+let wantPoke = args.contains("--poke")
+let onceOnly = args.contains("--once")
+let intervalSeconds = 0.4
+
+// ---------------------------------------------------------------- AX helpers
+
+func axErrorName(_ e: AXError) -> String {
+    switch e {
+    case .success: return "success"
+    case .failure: return "kAXErrorFailure"
+    case .illegalArgument: return "kAXErrorIllegalArgument"
+    case .invalidUIElement: return "kAXErrorInvalidUIElement"
+    case .invalidUIElementObserver: return "kAXErrorInvalidUIElementObserver"
+    case .cannotComplete: return "kAXErrorCannotComplete"
+    case .attributeUnsupported: return "kAXErrorAttributeUnsupported"
+    case .actionUnsupported: return "kAXErrorActionUnsupported"
+    case .notificationUnsupported: return "kAXErrorNotificationUnsupported"
+    case .notImplemented: return "kAXErrorNotImplemented"
+    case .notificationAlreadyRegistered: return "kAXErrorNotificationAlreadyRegistered"
+    case .notificationNotRegistered: return "kAXErrorNotificationNotRegistered"
+    case .apiDisabled: return "kAXErrorAPIDisabled"
+    case .noValue: return "kAXErrorNoValue"
+    case .parameterizedAttributeUnsupported: return "kAXErrorParameterizedAttributeUnsupported"
+    case .notEnoughPrecision: return "kAXErrorNotEnoughPrecision"
+    @unknown default: return "kAXErrorUnknown(\(e.rawValue))"
+    }
+}
+
+/// Reads one attribute. Returns either the value or the exact AXError name,
+/// because "which flavour of nothing" is the actual deliverable of this spike.
+func copyAttr(_ element: AXUIElement, _ attribute: String) -> (value: CFTypeRef?, error: AXError) {
+    var out: CFTypeRef?
+    let err = AXUIElementCopyAttributeValue(element, attribute as CFString, &out)
+    return (out, err)
+}
+
+func stringAttr(_ element: AXUIElement, _ attribute: String) -> String {
+    let (value, err) = copyAttr(element, attribute)
+    if err != .success { return "<\(axErrorName(err))>" }
+    guard let value = value else { return "<nil>" }
+    if let s = value as? String { return s.isEmpty ? "<empty>" : s }
+    if let n = value as? NSNumber { return n.stringValue }
+    return "<non-string value>"
+}
+
+/// Can we read the text out of this element at all? Separate from "is there a role",
+/// because an element with a role but no readable value is still useless to us.
+func valueReadability(_ element: AXUIElement) -> String {
+    let (value, err) = copyAttr(element, kAXValueAttribute as String)
+    if err != .success { return "no (\(axErrorName(err)))" }
+    guard let value = value else { return "no (nil)" }
+    if let s = value as? String { return "yes (\(s.count) chars)" }
+    return "yes (non-string)"
+}
+
+func selectedTextReadability(_ element: AXUIElement) -> String {
+    let (value, err) = copyAttr(element, kAXSelectedTextAttribute as String)
+    if err != .success { return "no (\(axErrorName(err)))" }
+    guard let s = value as? String else { return "no (non-string)" }
+    return "yes (\(s.count) chars)"
+}
+
+/// The Chromium / Electron knob. Setting AXManualAccessibility on the application
+/// element is what makes those apps build and expose their a11y tree at all.
+@discardableResult
+func pokeManualAccessibility(_ appElement: AXUIElement) -> String {
+    let err = AXUIElementSetAttributeValue(appElement,
+                                           "AXManualAccessibility" as CFString,
+                                           kCFBooleanTrue)
+    return axErrorName(err)
+}
+
+// ---------------------------------------------------------------- sampling
+
+struct Sample {
+    var frontApp: String
+    var bundleID: String
+    var pid: String
+    var trusted: String
+    var pokeResult: String
+    var systemWideFocus: String
+    var appFocusRole: String
+    var appFocusSubrole: String
+    var appFocusRoleDescription: String
+    var appFocusTitle: String
+    var readableValue: String
+    var readableSelection: String
+    var windowTitle: String
+
+    /// What changes trigger a new log record. Deliberately excludes the value
+    /// length, so typing into one field does not spam the log.
+    var identity: String {
+        [bundleID, pid, systemWideFocus, appFocusRole, appFocusSubrole,
+         appFocusRoleDescription, appFocusTitle, windowTitle].joined(separator: "|")
+    }
+}
+
+func sampleNow() -> Sample {
+    let trusted = AXIsProcessTrusted()
+    var s = Sample(frontApp: "<none>", bundleID: "<none>", pid: "<none>",
+                   trusted: trusted ? "yes" : "NO",
+                   pokeResult: wantPoke ? "<not attempted>" : "<skipped>",
+                   systemWideFocus: "<not read>",
+                   appFocusRole: "<not read>", appFocusSubrole: "<not read>",
+                   appFocusRoleDescription: "<not read>", appFocusTitle: "<not read>",
+                   readableValue: "<not read>", readableSelection: "<not read>",
+                   windowTitle: "<not read>")
+
+    // Layer 1: frontmost app. Needs no Accessibility permission whatsoever.
+    guard let app = NSWorkspace.shared.frontmostApplication else { return s }
+    s.frontApp = app.localizedName ?? "<unnamed>"
+    s.bundleID = app.bundleIdentifier ?? "<no bundle id>"
+    s.pid = String(app.processIdentifier)
+
+    // Layer 2: focused element. Needs Accessibility trust, and needs the app to
+    // actually publish a tree.
+    let appElement = AXUIElementCreateApplication(app.processIdentifier)
+    if wantPoke {
+        s.pokeResult = pokeManualAccessibility(appElement)
+    }
+
+    let systemWide = AXUIElementCreateSystemWide()
+    let (swFocus, swErr) = copyAttr(systemWide, kAXFocusedUIElementAttribute as String)
+    if swErr != .success {
+        s.systemWideFocus = "<\(axErrorName(swErr))>"
+    } else if let swFocus = swFocus {
+        let el = swFocus as! AXUIElement
+        s.systemWideFocus = stringAttr(el, kAXRoleAttribute as String)
+    } else {
+        s.systemWideFocus = "<nil>"
+    }
+
+    let (focused, focusErr) = copyAttr(appElement, kAXFocusedUIElementAttribute as String)
+    if focusErr != .success || focused == nil {
+        let reason = (focused == nil && focusErr == .success) ? "<nil>" : "<\(axErrorName(focusErr))>"
+        s.appFocusRole = reason
+        s.appFocusSubrole = reason
+        s.appFocusRoleDescription = reason
+        s.appFocusTitle = reason
+        s.readableValue = reason
+        s.readableSelection = reason
+    } else {
+        let el = focused as! AXUIElement
+        s.appFocusRole = stringAttr(el, kAXRoleAttribute as String)
+        s.appFocusSubrole = stringAttr(el, kAXSubroleAttribute as String)
+        s.appFocusRoleDescription = stringAttr(el, kAXRoleDescriptionAttribute as String)
+        s.appFocusTitle = stringAttr(el, kAXTitleAttribute as String)
+        s.readableValue = valueReadability(el)
+        s.readableSelection = selectedTextReadability(el)
+    }
+
+    let (window, winErr) = copyAttr(appElement, kAXFocusedWindowAttribute as String)
+    if winErr != .success || window == nil {
+        s.windowTitle = "<\(axErrorName(winErr))>"
+    } else {
+        s.windowTitle = stringAttr(window as! AXUIElement, kAXTitleAttribute as String)
+    }
+    return s
+}
+
+// ---------------------------------------------------------------- output
+
+func stamp() -> String {
+    let f = DateFormatter()
+    f.dateFormat = "HH:mm:ss"
+    return f.string(from: Date())
+}
+
+func emit(_ s: Sample) {
+    print("""
+    ---------------------------------------------------------------
+    [\(stamp())] frontmost app     : \(s.frontApp)
+                bundle id         : \(s.bundleID)  (pid \(s.pid))
+                AX trusted        : \(s.trusted)
+                AXManualAccess.   : \(s.pokeResult)
+                window title      : \(s.windowTitle)
+                system-wide focus : \(s.systemWideFocus)
+                focused role      : \(s.appFocusRole)
+                focused subrole   : \(s.appFocusSubrole)
+                role description  : \(s.appFocusRoleDescription)
+                focused title     : \(s.appFocusTitle)
+                AXValue readable  : \(s.readableValue)
+                AXSelectedText    : \(s.readableSelection)
+    """)
+    fflush(stdout)
+}
+
+// ---------------------------------------------------------------- main
+
+if wantPrompt {
+    let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true] as CFDictionary
+    _ = AXIsProcessTrustedWithOptions(options)
+}
+
+print("OpenStream context-detection spike (issue #28) - PROTOTYPE, throwaway")
+print("AXIsProcessTrusted() = \(AXIsProcessTrusted())")
+if !AXIsProcessTrusted() {
+    print("NOT TRUSTED: every focused-element read below will fail with kAXErrorAPIDisabled.")
+    print("Grant Accessibility to the app running this process, then re-run.")
+}
+print("poke AXManualAccessibility = \(wantPoke)   interval = \(intervalSeconds)s")
+print("Switch apps and click into text fields. Records print only when something changes.")
+print("Ctrl-C to stop.")
+
+if onceOnly {
+    emit(sampleNow())
+    exit(0)
+}
+
+var lastIdentity = ""
+while true {
+    let s = sampleNow()
+    if s.identity != lastIdentity {
+        lastIdentity = s.identity
+        emit(s)
+    }
+    // Must pump the run loop, not sleep. NSWorkspace.frontmostApplication is
+    // updated by notifications delivered on the run loop; a process that only
+    // sleeps keeps reporting whichever app was frontmost when it launched.
+    RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(intervalSeconds))
+}

--- a/prototypes/context-detection-spike/run.sh
+++ b/prototypes/context-detection-spike/run.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# PROTOTYPE - throwaway spike for issue #28. Starts the probe and tees everything
+# into a timestamped log so the run can be read back later.
+#
+#   ./run.sh            poll and log
+#   ./run.sh --poke     poll with AXManualAccessibility set on each frontmost app
+#   ./run.sh --prompt   trigger the macOS Accessibility permission prompt first
+#
+# Whatever terminal or editor you launch this from is the process that needs
+# Accessibility trust (System Settings > Privacy & Security > Accessibility).
+set -u
+cd "$(dirname "$0")"
+mkdir -p logs
+LOG="logs/probe-$(date +%Y%m%d-%H%M%S).log"
+echo "logging to $LOG"
+swift probe.swift "$@" 2>&1 | tee "$LOG"

--- a/prototypes/context-detection-spike/sweep.sh
+++ b/prototypes/context-detection-spike/sweep.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# PROTOTYPE - throwaway spike for issue #28. Walks the frontmost app through a
+# list of target apps via AppleScript activation while the probe polls, so the
+# app-level half of the map can be collected without a human clicking around.
+#
+# Field focus mostly still needs a human clicking into a text field. This only
+# automates "which app is in front", plus whatever focus the app lands on by
+# itself when activated.
+set -u
+cd "$(dirname "$0")"
+
+APPS=(
+  "Terminal"
+  "TextEdit"
+  "Notes"
+  "Safari"
+  "Google Chrome"
+  "Visual Studio Code"
+  "Cursor"
+  "Obsidian"
+  "WhatsApp"
+  "Finder"
+)
+
+RETURN_TO="${RETURN_TO:-Visual Studio Code}"
+
+for app in "${APPS[@]}"; do
+  if osascript -e "tell application \"$app\" to activate" >/dev/null 2>&1; then
+    echo "### activated: $app"
+  else
+    echo "### NOT TESTABLE HERE: $app (activation failed / not installed)"
+  fi
+  sleep 3
+done
+
+osascript -e "tell application \"$RETURN_TO\" to activate" >/dev/null 2>&1
+echo "### sweep done, returned to $RETURN_TO"


### PR DESCRIPTION
Throwaway instrumentation probe for issue #28. Polls frontmost app and focused element, records the exact AXError on failure, and can set AXManualAccessibility to test whether Electron apps expose a tree when poked.

Layer 1 (frontmost app, no permission needed) measured across 10 apps including Electron: 10 of 10 correct. Layer 2 (focused element) is blocked pending an Accessibility grant and is recorded as unmeasured, not as failing.

Two findings already worth carrying into the native helper: polling frontmostApplication without pumping the run loop reports a stale app forever, and some Electron apps ship opaque bundle ids (Cursor is com.todesktop.230313mzl4w4u92).