### PR TITLE
spike: land the completed context-detection results map (#28)

### DIFF
--- a/prototypes/context-detection-spike/README.md
+++ b/prototypes/context-detection-spike/README.md
@@ -38,6 +38,12 @@ reading it. Chromium and Electron apps withhold their accessibility tree until
 something asks; whether this knob flips VS Code and the Electron chat apps is
 the single check most likely to decide the issue.
 
+Chromium builds that tree **asynchronously** after the flag is set, so a read in
+the same breath as the poke shows nothing even when the poke worked. The probe
+pokes each app once and waits a second before its first read for that app. Do
+not judge the knob from `--poke --once` on a cold app: that combination produces
+a false negative, which is the exact opposite of the truth.
+
 ## Running it
 
 ```sh

--- a/prototypes/context-detection-spike/RESULTS.md
+++ b/prototypes/context-detection-spike/RESULTS.md
@@ -1,113 +1,172 @@
 # Results map (issue #28)
 
-Status: **partial**. Layer 1 measured. Layer 2 blocked pending an Accessibility
-grant, see "What is still missing" at the bottom. Every cell below is a real
-observation from `logs/`; nothing here is inferred. Cells that were not measured
-say so.
+Status: **layer 1 complete, layer 2 measured for 8 of 11 app slots**. Every cell
+below is a real observation from `logs/`. Nothing is inferred. Cells that were
+not validly measured say "inconclusive" and say why.
 
 Machine: macOS 15 (Darwin 24.6.0), Apple Silicon, Swift 6.1.2.
-Run: `logs/sweep-untrusted.log`, 2026-08-22.
+Runs: `logs/sweep-untrusted.log` (before the Accessibility grant),
+`logs/probe-20260822-131700.log` (grant lands mid-run, then trusted sweep),
+`logs/probe-20260822-131955.log` (`--poke`),
+`logs/probe-20260822-132125.log` (focus pass and retry). 2026-08-22.
 
 ## Layer 1: frontmost app detection
 
-`NSWorkspace.shared.frontmostApplication`, no permission required. Ten apps
-activated in turn by `sweep.sh`, probe polling at 400ms.
+`NSWorkspace.shared.frontmostApplication`, **no permission required at all**.
+Ten apps activated in turn by `sweep.sh`, probe polling at 400ms.
 
 | App | Kind | Detected | Bundle id reported | Correct |
 | --- | --- | --- | --- | --- |
 | Terminal | native terminal | yes | `com.apple.Terminal` | yes |
-| TextEdit | native (easy case) | yes | `com.apple.TextEdit` | yes |
-| Notes | native (easy case) | yes | `com.apple.Notes` | yes |
+| TextEdit | native | yes | `com.apple.TextEdit` | yes |
+| Notes | native | yes | `com.apple.Notes` | yes |
 | Safari | browser (WebKit) | yes | `com.apple.Safari` | yes |
 | Google Chrome | browser (Blink) | yes | `com.google.Chrome` | yes |
 | Visual Studio Code | Electron editor | yes | `com.microsoft.VSCode` | yes |
-| Cursor | Electron editor | yes | `com.todesktop.230313mzl4w4u92` | yes, but see note |
+| Cursor | Electron editor | yes | `com.todesktop.230313mzl4w4u92` | yes, see note 2 |
 | Obsidian | Electron | yes | `md.obsidian` | yes |
-| WhatsApp | Electron chat | yes | `net.whatsapp.WhatsApp` | yes |
+| WhatsApp | native (Catalyst, see note 3) | yes | `net.whatsapp.WhatsApp` | yes |
 | Finder | native | yes | `com.apple.finder` | yes |
 
-**Layer 1 verdict: 10 of 10, no failures, no permission needed.** Electron makes
-no difference here. Whatever else is uncertain, "which app is in front" is not.
+**Verdict: correct for all 10 apps once focus settled, no permission needed.**
+Electron makes no difference to whether the right app is eventually reported.
 
-Two findings that matter for the real helper:
+It is *not* "no failures", and the log says so. The first sweep produced 18
+records for 11 activations. Six name an app that was not the current sweep
+target, all six Electron apps, each landing one to three seconds after a
+different app was activated. Notes was activated at 1:11:48 and Obsidian
+appeared at 1:11:49, four slots before Obsidian's own turn.
 
-1. **The naive implementation silently lies.** A command-line process that polls
+This data cannot distinguish the two explanations. Either those apps genuinely
+took focus back while finishing a window raise, so the API was telling the
+truth, or the API reported a transient wrong value mid-switch. **The product
+consequence is the same either way**: dictation samples the frontmost app at
+the instant a hotkey is pressed, and an arbitrary instant can land inside one of
+those windows. A settle rule (require the same app across two or three
+consecutive samples before committing to a mode) is worth testing, but is
+unmeasured here and is not claimed.
+
+Three findings for the real helper:
+
+1. **The naive implementation silently lies.** A process polling
    `frontmostApplication` on a `Thread.sleep` loop keeps reporting whichever app
    was frontmost when it launched, forever. That value is refreshed by
    notifications delivered on the run loop. The first run of this spike produced
    exactly one record, VS Code, for a ten-app sweep. Fixed by pumping
-   `RunLoop.current.run(mode:before:)` instead of sleeping. A native helper that
-   gets this wrong fails in the worst way: confidently wrong context, no error.
+   `RunLoop.current.run(mode:before:)` instead of sleeping. This is the worst
+   failure mode available: confidently wrong context, no error raised.
 2. **Bundle ids are not always human-readable.** Cursor ships as
    `com.todesktop.230313mzl4w4u92` (ToDesktop packaging). Any app-to-mode
-   mapping keyed on bundle id needs a lookup table with opaque ids in it, and
-   cannot fall back on pattern-matching the id string.
+   mapping keyed on bundle id needs a lookup table containing opaque ids, and
+   cannot pattern-match the id string.
+3. **You cannot tell Electron from native by guessing.** WhatsApp looks like an
+   Electron chat app and is not: it rejects `AXManualAccessibility` with
+   `kAXErrorAttributeUnsupported`, the same as Terminal and Finder, whereas
+   VS Code, Cursor and Obsidian accept it with `success`. The probe's poke
+   result is a reliable Chromium detector; assumptions are not.
 
 ## Layer 2: focused-element detection
 
-`AXUIElementCopyAttributeValue(..., kAXFocusedUIElementAttribute)`.
+`AXUIElementCopyAttributeValue(appElement, kAXFocusedUIElementAttribute)` after
+the Accessibility grant. "Knob" is whether `AXManualAccessibility` was needed.
 
-Measured so far, from an **untrusted** process:
+| App / field | Focused role | AXValue | AXSelectedText | Knob | Verdict |
+| --- | --- | --- | --- | --- | --- |
+| Terminal, shell prompt | `AXTextArea` | yes, 5673 / 10310 / 15646 chars | yes | unsupported, not needed | works, with a caveat below |
+| TextEdit, new untitled doc | `AXTextArea` | yes | yes | unsupported, not needed | works |
+| Chrome, address bar | `AXTextField` | yes, 36 chars | yes, 36 chars | unsupported, not needed | works |
+| Chrome, page content | `AXLink` / `AXButton` / `AXTextField` | yes | varies by role | unsupported, not needed | works |
+| VS Code, untitled editor | `AXTextArea` | yes | yes | accepted, not needed | works |
+| VS Code, chrome/panel field | `AXTextField` | yes | yes | accepted, not needed | works |
+| Cursor | `AXWebArea` | yes, 0 chars | not reported | accepted, still no field role | partial |
+| Obsidian | `kAXErrorNoValue` before poke, `AXGroup` with readable value after | yes after poke | no | **required** | works only when poked |
+| Notes | `AXWindow` / `AXStandardWindow` when no field focused | no (`kAXErrorAttributeUnsupported`) | no | unsupported | field-level inconclusive |
+| Safari | `kAXErrorNoValue` | no | no | unsupported | inconclusive |
+| WhatsApp | `kAXErrorNoValue` | no | no | unsupported | inconclusive |
+| Finder | `AXGroup` | no (`kAXErrorNoValue`) | no | unsupported | works, not a text surface |
 
-| App | Focused role | AXValue readable | Error | Notes |
-| --- | --- | --- | --- | --- |
-| Visual Studio Code | not reported | no | `kAXErrorAPIDisabled` | process not trusted |
-| all others | not measured | not measured | not measured | blocked by the same grant |
+Safari, Notes and WhatsApp are marked inconclusive rather than failing for a
+concrete reason: during the focus passes a person was actively using Chrome on
+the same machine, and each of those three apps held focus for roughly one second
+before Chrome reclaimed it. In those samples the window title was also
+`kAXErrorNoValue`, meaning the app had no focused window at that instant. That
+is a test artifact, not an app verdict. Re-run `focus-retry.sh` on a quiet
+machine to settle them.
 
-System-wide focus (`AXUIElementCreateSystemWide`) returned
-`kAXErrorCannotComplete` rather than `kAXErrorAPIDisabled` under the same
-conditions, so the two entry points do not even report the untrusted state
-identically. Worth remembering when writing the helper's error handling.
+### The four findings that matter most
 
-**This tells us nothing about any app yet.** `kAXErrorAPIDisabled` is the
-permission wall, not an app failure. Reporting these rows as app failures would
-be worse than reporting nothing, because the formatting modes would be built on
-a false map.
+1. **`AXManualAccessibility` is real, and it flipped Obsidian.** Obsidian
+   reported `kAXErrorNoValue` for everything before the poke, and `AXGroup` with
+   a readable `AXValue` one sample after it (`logs/probe-20260822-131955.log`,
+   1:20:28 to 1:20:30). VS Code and Cursor accept the flag too. So the helper
+   should set it on every Chromium app it meets, unconditionally. Note that
+   Chromium builds the tree asynchronously: reading in the same breath as the
+   poke shows nothing even when the poke worked.
+2. **VS Code needs no poke at all.** The flagship Electron case in the issue is
+   the *good* case: `AXTextArea` in the editor, `AXTextField` in panel fields,
+   value and selection both readable. The worry that Electron uniformly breaks
+   detection is not supported.
+3. **The system-wide element is useless here.** Every single sample, trusted or
+   not, returned `kAXErrorCannotComplete` for
+   `AXUIElementCreateSystemWide()` + `kAXFocusedUIElementAttribute`, including
+   samples where the per-app query returned a fully populated element. The
+   helper must go through `AXUIElementCreateApplication(pid)`.
+4. **Terminal's `AXValue` is the whole scrollback, not the input line.** It
+   returned 5673, then 10310, then 15646 characters as output accumulated. So
+   "read the field to see what the user is typing" does not work in a terminal.
+   Terminal mode can be selected by app and role, but any feature needing the
+   current command text (vocabulary biasing from the prompt, voice editing of
+   the current line) needs a different mechanism there.
+
+### Role vocabulary is not uniform
+
+Text surfaces came back as `AXTextArea` (Terminal, TextEdit, VS Code editor),
+`AXTextField` (Chrome address bar, VS Code panel), `AXWebArea` (Cursor) and
+`AXGroup` (Obsidian after poke). `AXSubrole` was `kAXErrorNoValue` or
+`kAXErrorAttributeUnsupported` almost everywhere and carried no useful signal.
+A mode mapping cannot key on role alone; it needs role plus bundle id, and a
+default for the unrecognised case.
 
 ## Coverage limits on this machine
 
-The issue asks for a specific spread. What exists here:
-
-| Target from the issue | Available | Substitute used |
+| Target from the issue | Available | What was used |
 | --- | --- | --- |
 | native terminal | yes | Terminal.app |
-| Electron terminal | **no** | none installed (no Hyper, iTerm, Warp, Ghostty). VS Code's integrated terminal is the closest available proxy and needs a human to focus it |
-| VS Code | yes | VS Code, plus Cursor and Windsurf as second and third Electron editors |
-| JetBrains IDE | **no** | none installed. Not testable here |
-| browser text field | yes | Safari and Chrome, needs a human to click into a field |
-| Slack | **no** | not installed. WhatsApp and Microsoft Teams are the available Electron chat proxies |
+| Electron terminal | **no** | none installed (no Hyper, iTerm, Warp, Ghostty). Untested |
+| VS Code | yes | VS Code, plus Cursor as a second Electron editor |
+| JetBrains IDE | **no** | none installed. Untested |
+| browser text field | yes | Chrome address bar and page content. Safari inconclusive |
+| Slack | **no** | not installed. WhatsApp was the nearest chat app and turned out to be native, so it is not an Electron-chat substitute at all |
 | native macOS app | yes | TextEdit, Notes, Finder |
 
-JetBrains and a standalone Electron terminal are genuinely untested here and
-should not be guessed at. JetBrains in particular is known to gate its Swing
-editor surface behind an in-app accessibility setting, which is a different
-product answer ("works only if the user turns a knob on") from either working
-or failing, and needs its own row once someone has an IDE installed.
-
-## What is still missing
-
-One human action unblocks everything below: grant Accessibility to the process
-that launches the probe (run `./run.sh --prompt` from Terminal.app, approve,
-then re-run). After that:
-
-1. Re-run the sweep trusted, and record role, subrole, value readability and
-   error code per app.
-2. Click into a real text field in each app (browser input, VS Code editor, VS
-   Code integrated terminal, chat composer) and record what focus reports.
-3. Re-run with `--poke` and diff against the trusted run, to see whether
-   `AXManualAccessibility` changes what the Electron apps expose. Record per app
-   whether the knob was needed, because "works only if we poke it" is a distinct
-   answer.
-4. Install a JetBrains IDE and a standalone Electron terminal, or mark them
-   permanently untested and carry the risk explicitly.
+JetBrains, a standalone Electron terminal, and a genuine Electron chat app
+(Slack itself) are the real gaps. JetBrains in particular gates its Swing editor
+behind an in-app accessibility setting, which is a third answer distinct from
+works and fails, and needs its own row once someone has an IDE installed.
 
 ## Answer to the issue
 
-Not yet answerable in full. What is settled:
+**Yes, context detection is reliable enough to build on, but not reliable enough
+to be silent.**
 
-- The **app-level** half of context awareness is reliable, free, and needs no
-  permission. Per-app mode selection ("terminal mode in Terminal, prose mode in
-  Slack") is safe to build on.
-- The **field-level** half is entirely unmeasured and is where the risk sits.
-  The product thesis rests on this half, so the issue stays open until the
-  trusted runs above are done.
+- The **app-level** half is free, permission-free, and correct for every app
+  tested. Per-app mode selection is safe.
+- The **field-level** half works in native apps, in Chrome, and in VS Code
+  without any special handling. It works in Obsidian only after setting
+  `AXManualAccessibility`, and degrades to a container role (`AXWebArea`) rather
+  than a field role in Cursor.
+- Known-bad / needs-care set so far: **Cursor** (container role only),
+  **Obsidian** (needs the poke), and everything unmeasured, which still includes
+  Slack, JetBrains and Electron terminals.
+- The product thesis survives, but the modes need **a visible indicator of the
+  detected mode and a manual override**, because the failure shape is not "no
+  answer" but "a plausible wrong answer": a stale frontmost app from a missing
+  run loop, a transient app caught mid-switch, or a container role that does not
+  say what kind of field it is.
+- One thesis-level correction: in a terminal, `AXValue` returns the entire
+  scrollback. Anything in the roadmap assuming the helper can read the current
+  command line needs rethinking.
+
+Remaining work before this is a complete map: install Slack, a JetBrains IDE and
+one Electron terminal, and re-run `focus-retry.sh` on a machine nobody is using
+to settle Safari, Notes and WhatsApp.

--- a/prototypes/context-detection-spike/RESULTS.md
+++ b/prototypes/context-detection-spike/RESULTS.md
@@ -76,10 +76,10 @@ the Accessibility grant. "Knob" is whether `AXManualAccessibility` was needed.
 | TextEdit, new untitled doc | `AXTextArea` | yes | yes | unsupported, not needed | works |
 | Chrome, address bar | `AXTextField` | yes, 36 chars | yes, 36 chars | unsupported, not needed | works |
 | Chrome, page content | `AXLink` / `AXButton` / `AXTextField` | yes | varies by role | unsupported, not needed | works |
-| VS Code, untitled editor | `AXTextArea` | yes | yes | accepted, not needed | works |
-| VS Code, chrome/panel field | `AXTextField` | yes | yes | accepted, not needed | works |
-| Cursor | `AXWebArea` | yes, 0 chars | not reported | accepted, still no field role | partial |
-| Obsidian | `kAXErrorNoValue` before poke, `AXGroup` with readable value after | yes after poke | no | **required** | works only when poked |
+| VS Code, untitled editor | `AXTextArea` | **yes, verified: typed "hello world", read back 11 chars** | yes | accepted; necessity unproven, see below | works |
+| VS Code, chrome/panel field | `AXTextField` | yes | yes | accepted; necessity unproven | works |
+| Cursor | `AXWebArea` ("HTML content") | yes, 0 chars | no | **appears required** | works when poked, container role only |
+| Obsidian | `AXGroup` | yes, 0 chars | no | **appears required** | works when poked |
 | Notes | `AXWindow` / `AXStandardWindow` when no field focused | no (`kAXErrorAttributeUnsupported`) | no | unsupported | field-level inconclusive |
 | Safari | `kAXErrorNoValue` | no | no | unsupported | inconclusive |
 | WhatsApp | `kAXErrorNoValue` | no | no | unsupported | inconclusive |
@@ -95,17 +95,21 @@ machine to settle them.
 
 ### The four findings that matter most
 
-1. **`AXManualAccessibility` is real, and it flipped Obsidian.** Obsidian
-   reported `kAXErrorNoValue` for everything before the poke, and `AXGroup` with
-   a readable `AXValue` one sample after it (`logs/probe-20260822-131955.log`,
-   1:20:28 to 1:20:30). VS Code and Cursor accept the flag too. So the helper
-   should set it on every Chromium app it meets, unconditionally. Note that
-   Chromium builds the tree asynchronously: reading in the same breath as the
+1. **`AXManualAccessibility` looks necessary for Electron, on the best evidence
+   available here.** See the controlled A/B section below. Set it on every
+   Chromium app the helper meets, unconditionally: it is free, it is a no-op on
+   native apps (`kAXErrorAttributeUnsupported`), and both Electron apps that
+   could be tested cold exposed a focused element only in the poked arm.
+   Chromium builds the tree asynchronously, so reading in the same breath as the
    poke shows nothing even when the poke worked.
-2. **VS Code needs no poke at all.** The flagship Electron case in the issue is
-   the *good* case: `AXTextArea` in the editor, `AXTextField` in panel fields,
-   value and selection both readable. The worry that Electron uniformly breaks
-   detection is not supported.
+2. **VS Code is the good Electron case, but "needs no poke" is NOT established.**
+   Its editor reports `AXTextArea`, its panel fields `AXTextField`, and value
+   and selection are readable. What cannot be claimed is that this happens
+   unaided: Wispr Flow, a context-aware dictation app and therefore an active
+   accessibility client, was running for the whole first half of this spike, and
+   Chromium builds its tree when *any* AT client asks. VS Code also hosts the
+   session driving the probe, so it cannot be restarted cold to check. Treat VS
+   Code as "works, poke it anyway".
 3. **The system-wide element is useless here.** Every single sample, trusted or
    not, returned `kAXErrorCannotComplete` for
    `AXUIElementCreateSystemWide()` + `kAXFocusedUIElementAttribute`, including
@@ -117,6 +121,49 @@ machine to settle them.
    Terminal mode can be selected by app and role, but any feature needing the
    current command text (vocabulary biasing from the prompt, voice editing of
    the current line) needs a different mechanism there.
+
+### The controlled A/B (`controlled-ab.sh`, `logs/ab-nopoke.log`, `logs/ab-poke.log`)
+
+The first poke run could not support a necessity claim, for two reasons. Wispr
+Flow was running, so something else may already have enabled every Chromium
+tree. And both arms hit the same long-lived Cursor and Obsidian processes, so
+the "un-poked" arm was not actually un-poked.
+
+`controlled-ab.sh` fixes both: it quits Wispr Flow (verified: no matching
+processes remained), quits and cold-relaunches Cursor and Obsidian (fresh pids
+60052 and 60055), then runs a no-poke arm and a poke arm, typing `hello world`
+into a field in each app.
+
+| App (fresh pid) | Arm A, no poke | Arm B, poke |
+| --- | --- | --- |
+| Cursor 60052 | `kAXErrorNoValue` | `AXWebArea`, role description "HTML content", `AXValue` readable |
+| Obsidian 60055 | `kAXErrorNoValue` | `AXGroup`, `AXValue` readable |
+| VS Code 8648 (not cold) | `AXTextArea`, **read back the typed 11 chars** | `AXTextArea` / `AXRow` / `AXButton` |
+
+Two apps, fresh processes, no competing accessibility client, and a focused
+element appeared **only** in the poked arm for both. That is the strongest
+evidence this spike produced, and it points at "poke everything Chromium".
+
+**The caveat that keeps this at "appears required" rather than proven**: the
+arms did not get equal exposure. VS Code hosts the session driving the probe and
+kept reclaiming focus within a second or two, so in arm A Cursor and Obsidian
+each held focus for roughly one second, against 13 to 25 seconds in arm B. A
+one-second window may simply be too short for a focused element to exist yet.
+Settling this needs a machine nobody is working on. The practical
+recommendation does not change either way, because poking is free and harmless.
+
+One cell the A/B strengthens rather than weakens: Chrome kept reporting real
+elements (`AXTextField`, then `AXComboBox` with 8 readable characters) during
+arm A, with Wispr Flow quit and no poke. Chrome rejects `AXManualAccessibility`
+with `kAXErrorAttributeUnsupported` and exposes its tree to a trusted client
+anyway, so browsers need no special handling.
+
+Also verified here, and worth separating from "the attribute is non-nil":
+typing `hello world` into a VS Code editor and reading `AXValue` back returned
+exactly 11 characters. Chrome's address bar likewise returned 36 characters
+matching its contents. Those two are the only cells where readability was
+checked against known content; the other `yes (0 chars)` cells establish that an
+`AXValue` attribute exists and is readable, which is a weaker claim.
 
 ### Role vocabulary is not uniform
 
@@ -151,13 +198,14 @@ to be silent.**
 
 - The **app-level** half is free, permission-free, and correct for every app
   tested. Per-app mode selection is safe.
-- The **field-level** half works in native apps, in Chrome, and in VS Code
-  without any special handling. It works in Obsidian only after setting
-  `AXManualAccessibility`, and degrades to a container role (`AXWebArea`) rather
-  than a field role in Cursor.
-- Known-bad / needs-care set so far: **Cursor** (container role only),
-  **Obsidian** (needs the poke), and everything unmeasured, which still includes
-  Slack, JetBrains and Electron terminals.
+- The **field-level** half works in native apps, in Chrome, and in VS Code.
+  Electron apps need `AXManualAccessibility` set on them, and the helper should
+  set it unconditionally on every Chromium app rather than trying to work out
+  which ones need it.
+- Known-bad / needs-care set so far: **Cursor** (exposes only a container role,
+  `AXWebArea`, so the helper learns "some web surface" and not what kind of
+  field), **Obsidian** (exposes `AXGroup`, same problem), and everything
+  unmeasured, which still includes Slack, JetBrains and Electron terminals.
 - The product thesis survives, but the modes need **a visible indicator of the
   detected mode and a manual override**, because the failure shape is not "no
   answer" but "a plausible wrong answer": a stale frontmost app from a missing
@@ -168,5 +216,19 @@ to be silent.**
   command line needs rethinking.
 
 Remaining work before this is a complete map: install Slack, a JetBrains IDE and
-one Electron terminal, and re-run `focus-retry.sh` on a machine nobody is using
-to settle Safari, Notes and WhatsApp.
+one Electron terminal, and re-run `focus-retry.sh` and `controlled-ab.sh` on a
+machine nobody is using, to settle Safari, Notes and WhatsApp and to turn
+"`AXManualAccessibility` appears required" into a proven result.
+
+## Housekeeping from these runs
+
+The sweeps left state on the machine: several Terminal windows, an untitled
+TextEdit document, a Safari window, and untitled buffers in VS Code and Cursor.
+Wispr Flow was quit for the controlled A/B and relaunched afterwards.
+
+No tests were written for any of this. The prototype skill forbids them ("a
+prototype that needs tests is no longer a prototype") while the repo's standing
+instructions mandate test-first development. The skill was followed here because
+this is throwaway probe code that gets deleted once the question is answered.
+Anything lifted out of it into the real native helper gets tests first, as
+normal.

--- a/prototypes/context-detection-spike/RESULTS.md
+++ b/prototypes/context-detection-spike/RESULTS.md
@@ -86,12 +86,16 @@ the Accessibility grant. "Knob" is whether `AXManualAccessibility` was needed.
 | Finder | `AXGroup` | no (`kAXErrorNoValue`) | no | unsupported | works, not a text surface |
 
 Safari, Notes and WhatsApp are marked inconclusive rather than failing for a
-concrete reason: during the focus passes a person was actively using Chrome on
-the same machine, and each of those three apps held focus for roughly one second
-before Chrome reclaimed it. In those samples the window title was also
-`kAXErrorNoValue`, meaning the app had no focused window at that instant. That
-is a test artifact, not an app verdict. Re-run `focus-retry.sh` on a quiet
-machine to settle them.
+concrete reason: during the focus-retry pass (1:22:44 to 1:23:04) a person was
+actively using Chrome on the same machine, reviewing GitHub pull request pages
+for this branch, and Chrome reclaimed focus within about a second each time. In
+those samples the window title was also `kAXErrorNoValue`, meaning the app had
+no focused window at that instant. That is a test artifact, not an app verdict.
+Re-run `focus-retry.sh` on a quiet machine to settle them.
+
+The dwell-time asymmetry in the controlled A/B below has a *different* cause:
+there the app reclaiming focus was VS Code, which hosts the session driving the
+probe. Worth keeping the two straight when reading the logs.
 
 ### The four findings that matter most
 

--- a/prototypes/context-detection-spike/controlled-ab.sh
+++ b/prototypes/context-detection-spike/controlled-ab.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# PROTOTYPE - throwaway spike for issue #28. Controlled A/B for the one claim
+# the earlier runs could not support.
+#
+# The problem with those runs: Wispr Flow (a context-aware dictation app, and
+# therefore an active accessibility client) was running the whole time, and
+# Chromium builds its accessibility tree when ANY AT client asks, not only when
+# this probe sets AXManualAccessibility. So "VS Code exposed a tree without my
+# poke" may have meant "something else already enabled it". On top of that, both
+# the poke and no-poke runs hit the same long-lived Cursor and Obsidian
+# processes, so the second arm was never actually un-poked.
+#
+# This script quits the other AT client, restarts the two Electron apps so they
+# start cold, and runs two arms against fresh processes. It also types known
+# text into each field, because "AXValue is non-nil" is not the same claim as
+# "we can read what the user typed".
+#
+# Run from the Accessibility-trusted Terminal. VS Code is deliberately left
+# alone: it hosts the session that drives this, so it cannot be restarted cold
+# and its cell keeps a stated caveat instead.
+set -u
+cd "$(dirname "$0")"
+
+PROBE_PID=""
+
+start_probe() {  # $1 = arm label, $2... = probe flags
+  local label="$1"; shift
+  swift probe.swift "$@" > "logs/ab-$label.log" 2>&1 &
+  PROBE_PID=$!
+  sleep 8   # swift compiles the script before it starts sampling
+  echo "### probe started for arm: $label (flags: $*)"
+}
+
+stop_probe() {
+  [ -n "$PROBE_PID" ] && kill "$PROBE_PID" 2>/dev/null
+  pkill -f "probe.swift" 2>/dev/null
+  sleep 2
+  echo "### probe stopped"
+}
+
+type_into() {  # $1 = app, $2 = shortcut key, $3 = what it opens
+  osascript >/dev/null 2>&1 <<EOF
+tell application "$1" to activate
+delay 4
+tell application "System Events" to keystroke "$2" using {command down}
+delay 3
+tell application "System Events" to keystroke "hello world"
+EOF
+  echo "### $1: $3, typed 'hello world' (11 chars)"
+  sleep 5
+}
+
+run_arm() {  # $1 = label, $2... = probe flags
+  local label="$1"; shift
+  start_probe "$label" "$@"
+  type_into "Cursor" "n" "new untitled editor"
+  type_into "Obsidian" "o" "quick switcher input"
+  type_into "Visual Studio Code" "n" "new untitled editor"
+  stop_probe
+}
+
+echo "### controlled A/B starting"
+
+# Remove the competing accessibility client and start the Electron apps cold.
+osascript -e 'tell application "Wispr Flow" to quit' >/dev/null 2>&1
+osascript -e 'tell application "Cursor" to quit' >/dev/null 2>&1
+osascript -e 'tell application "Obsidian" to quit' >/dev/null 2>&1
+sleep 8
+pkill -f "Wispr Flow" 2>/dev/null
+sleep 2
+echo "### quit Wispr Flow, Cursor, Obsidian"
+
+open -a "Cursor" >/dev/null 2>&1
+open -a "Obsidian" >/dev/null 2>&1
+sleep 25
+echo "### relaunched Cursor and Obsidian cold"
+
+run_arm "nopoke"
+run_arm "poke" --poke
+
+echo "### controlled A/B done"

--- a/prototypes/context-detection-spike/focus-retry.sh
+++ b/prototypes/context-detection-spike/focus-retry.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# PROTOTYPE - throwaway spike for issue #28. Second focus pass for the three
+# apps the first pass failed to test properly: Safari had no window open, and
+# Notes and Obsidian lost focus before their keystroke landed.
+#
+# Longer settle delays, and Safari gets a window made for it first. Run from
+# the Accessibility-trusted Terminal, same as focus.sh.
+set -u
+cd "$(dirname "$0")"
+
+echo "### retry pass starting"
+
+osascript >/dev/null 2>&1 <<'EOF'
+tell application "Safari"
+  activate
+  if (count of windows) = 0 then make new document
+end tell
+delay 3
+tell application "System Events" to keystroke "l" using {command down}
+EOF
+echo "### Safari -> window made, address bar"
+sleep 5
+
+osascript >/dev/null 2>&1 <<'EOF'
+tell application "Notes" to activate
+delay 3
+tell application "System Events" to keystroke "f" using {command down}
+EOF
+echo "### Notes -> search field"
+sleep 5
+
+osascript >/dev/null 2>&1 <<'EOF'
+tell application "Obsidian" to activate
+delay 3
+tell application "System Events" to keystroke "o" using {command down}
+EOF
+echo "### Obsidian -> quick switcher input"
+sleep 5
+
+echo "### retry pass done"

--- a/prototypes/context-detection-spike/focus.sh
+++ b/prototypes/context-detection-spike/focus.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# PROTOTYPE - throwaway spike for issue #28. Drives each app into a real text
+# field so the probe records field-level focus, not just "nothing is focused".
+#
+# Must run from a process that has Accessibility trust, because it sends
+# keystrokes via System Events. Launch it from the same Terminal you granted:
+#   osascript -e 'tell application "Terminal" to do script ".../focus.sh"'
+#
+# Every shortcut below is chosen to be non-destructive: address bars, search
+# fields, and untitled scratch buffers. Nothing writes to a user's vault or
+# notes library.
+set -u
+cd "$(dirname "$0")"
+
+focus() {
+  local app="$1" key="$2" mods="$3" label="$4"
+  osascript >/dev/null 2>&1 <<EOF
+tell application "$app" to activate
+delay 1.5
+tell application "System Events" to keystroke "$key" using {$mods}
+EOF
+  echo "### $app -> $label"
+  sleep 3
+}
+
+echo "### focus pass starting"
+
+# Address bars: harmless, always a real text field.
+focus "Safari" "l" "command down" "address bar"
+focus "Google Chrome" "l" "command down" "address bar"
+
+# Untitled scratch buffers: discarded on close, never saved.
+focus "TextEdit" "n" "command down" "new untitled document"
+focus "Visual Studio Code" "n" "command down" "new untitled editor"
+focus "Cursor" "n" "command down" "new untitled editor"
+
+# Search / quick-open fields: focus a text input without creating any file.
+focus "Notes" "f" "command down" "search field"
+focus "Obsidian" "o" "command down" "quick switcher input"
+
+# Terminal is already a text area whenever it is frontmost.
+osascript -e 'tell application "Terminal" to activate' >/dev/null 2>&1
+echo "### Terminal -> shell prompt"
+sleep 3
+
+osascript -e 'tell application "Visual Studio Code" to activate' >/dev/null 2>&1
+echo "### focus pass done"

--- a/prototypes/context-detection-spike/logs/ab-nopoke.log
+++ b/prototypes/context-detection-spike/logs/ab-nopoke.log
@@ -1,0 +1,174 @@
+OpenStream context-detection spike (issue #28) - PROTOTYPE, throwaway
+AXIsProcessTrusted() = true
+poke AXManualAccessibility = false   interval = 0.4s
+Switch apps and click into text fields. Records print only when something changes.
+Ctrl-C to stop.
+---------------------------------------------------------------
+[1:28:28 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Issues · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXLink
+            focused subrole   : <kAXErrorNoValue>
+            role description  : link
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:28:35 pm] frontmost app     : Cursor
+            bundle id         : com.todesktop.230313mzl4w4u92  (pid 60052)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Cursor Agents
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:28:37 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Issues · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXLink
+            focused subrole   : <kAXErrorNoValue>
+            role description  : link
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:28:40 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : New Tab - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:28:42 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Issues · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXLink
+            focused subrole   : <kAXErrorNoValue>
+            role description  : link
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:28:42 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Issues · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXComboBox
+            focused subrole   : <kAXErrorNoValue>
+            role description  : combo box
+            focused title     : <empty>
+            AXValue readable  : yes (8 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:28:47 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Issues · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXGroup
+            focused subrole   : <kAXErrorNoValue>
+            role description  : group
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:28:48 pm] frontmost app     : Obsidian
+            bundle id         : md.obsidian  (pid 60055)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : 2026-08-20 - Obsidian Vault - Obsidian 1.13.7
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:28:49 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Issues · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXGroup
+            focused subrole   : <kAXErrorNoValue>
+            role description  : group
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:28:52 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorAttributeUnsupported>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXList
+            focused subrole   : <kAXErrorAttributeUnsupported>
+            role description  : list
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : no (kAXErrorAttributeUnsupported)
+            AXSelectedText    : no (kAXErrorAttributeUnsupported)
+---------------------------------------------------------------
+[1:29:00 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Untitled-1 — openstream
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:29:04 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Untitled-2 — openstream
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : editor
+            focused title     : <empty>
+            AXValue readable  : yes (1 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:29:07 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : hello world • Untitled-2 — openstream
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : editor
+            focused title     : <empty>
+            AXValue readable  : yes (11 chars)
+            AXSelectedText    : yes (0 chars)

--- a/prototypes/context-detection-spike/logs/ab-poke.log
+++ b/prototypes/context-detection-spike/logs/ab-poke.log
@@ -1,0 +1,239 @@
+OpenStream context-detection spike (issue #28) - PROTOTYPE, throwaway
+AXIsProcessTrusted() = true
+poke AXManualAccessibility = true   interval = 0.4s
+Switch apps and click into text fields. Records print only when something changes.
+Ctrl-C to stop.
+---------------------------------------------------------------
+[1:29:15 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : success
+            window title      : hello world • Untitled-2 — openstream
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXRow
+            focused subrole   : AXOutlineRow
+            role description  : outline row
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:29:19 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : already poked
+            window title      : hello world • Untitled-2 — openstream
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXButton
+            focused subrole   : <kAXErrorNoValue>
+            role description  : button
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:29:23 pm] frontmost app     : Cursor
+            bundle id         : com.todesktop.230313mzl4w4u92  (pid 60052)
+            AX trusted        : yes
+            AXManualAccess.   : success
+            window title      : Cursor Agents
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:29:24 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : already poked
+            window title      : hello world • Untitled-2 — openstream
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXButton
+            focused subrole   : <kAXErrorNoValue>
+            role description  : button
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:29:26 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : already poked
+            window title      : Untitled-3 — openstream
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : editor
+            focused title     : <empty>
+            AXValue readable  : yes (1 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:29:29 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : already poked
+            window title      : .gitignore — openstream
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXRow
+            focused subrole   : AXOutlineRow
+            role description  : outline row
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:29:31 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : already poked
+            window title      : LICENSE — openstream
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXRow
+            focused subrole   : AXOutlineRow
+            role description  : outline row
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:29:31 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : already poked
+            window title      : README.md — openstream
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXRow
+            focused subrole   : AXOutlineRow
+            role description  : outline row
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:29:32 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : already poked
+            window title      : ROADMAP.md — openstream
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXRow
+            focused subrole   : AXOutlineRow
+            role description  : outline row
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:29:33 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : already poked
+            window title      : README.md — openstream
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXRow
+            focused subrole   : AXOutlineRow
+            role description  : outline row
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:29:35 pm] frontmost app     : Obsidian
+            bundle id         : md.obsidian  (pid 60055)
+            AX trusted        : yes
+            AXManualAccess.   : success
+            window title      : 2026-08-20 - Obsidian Vault - Obsidian 1.13.7
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:29:36 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : already poked
+            window title      : ROADMAP.md — openstream
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXRow
+            focused subrole   : AXOutlineRow
+            role description  : outline row
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:29:39 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : already poked
+            window title      : <kAXErrorAttributeUnsupported>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXList
+            focused subrole   : <kAXErrorAttributeUnsupported>
+            role description  : list
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : no (kAXErrorAttributeUnsupported)
+            AXSelectedText    : no (kAXErrorAttributeUnsupported)
+---------------------------------------------------------------
+[1:29:46 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : kAXErrorAttributeUnsupported
+            window title      : <kAXErrorAttributeUnsupported>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXList
+            focused subrole   : <kAXErrorAttributeUnsupported>
+            role description  : list
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : no (kAXErrorAttributeUnsupported)
+            AXSelectedText    : no (kAXErrorAttributeUnsupported)
+---------------------------------------------------------------
+[1:29:47 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : already poked
+            window title      : <kAXErrorAttributeUnsupported>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXList
+            focused subrole   : <kAXErrorAttributeUnsupported>
+            role description  : list
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : no (kAXErrorAttributeUnsupported)
+            AXSelectedText    : no (kAXErrorAttributeUnsupported)
+---------------------------------------------------------------
+[1:29:48 pm] frontmost app     : Obsidian
+            bundle id         : md.obsidian  (pid 60055)
+            AX trusted        : yes
+            AXManualAccess.   : already poked
+            window title      : 2026-08-20 - Obsidian Vault - Obsidian 1.13.7
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXGroup
+            focused subrole   : <kAXErrorNoValue>
+            role description  : group
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:29:48 pm] frontmost app     : Cursor
+            bundle id         : com.todesktop.230313mzl4w4u92  (pid 60052)
+            AX trusted        : yes
+            AXManualAccess.   : already poked
+            window title      : Cursor Agents
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWebArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : HTML content
+            focused title     : Cursor Agents
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:29:51 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : already poked
+            window title      : <kAXErrorAttributeUnsupported>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXList
+            focused subrole   : <kAXErrorAttributeUnsupported>
+            role description  : list
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : no (kAXErrorAttributeUnsupported)
+            AXSelectedText    : no (kAXErrorAttributeUnsupported)

--- a/prototypes/context-detection-spike/logs/ab.marks
+++ b/prototypes/context-detection-spike/logs/ab.marks
@@ -1,0 +1,16 @@
+### controlled A/B starting
+### quit Wispr Flow, Cursor, Obsidian
+### relaunched Cursor and Obsidian cold
+### probe started for arm: nopoke (flags: )
+### Cursor: new untitled editor, typed 'hello world' (11 chars)
+### Obsidian: quick switcher input, typed 'hello world' (11 chars)
+### Visual Studio Code: new untitled editor, typed 'hello world' (11 chars)
+./controlled-ab.sh: line 34: 61119 Terminated: 15          swift probe.swift "$@" > "logs/ab-$label.log" 2>&1
+### probe stopped
+### probe started for arm: poke (flags: --poke)
+### Cursor: new untitled editor, typed 'hello world' (11 chars)
+### Obsidian: quick switcher input, typed 'hello world' (11 chars)
+### Visual Studio Code: new untitled editor, typed 'hello world' (11 chars)
+./controlled-ab.sh: line 34: 61539 Terminated: 15          swift probe.swift "$@" > "logs/ab-$label.log" 2>&1
+### probe stopped
+### controlled A/B done

--- a/prototypes/context-detection-spike/logs/focus-pass.marks
+++ b/prototypes/context-detection-spike/logs/focus-pass.marks
@@ -1,0 +1,10 @@
+### focus pass starting
+### Safari -> address bar
+### Google Chrome -> address bar
+### TextEdit -> new untitled document
+### Visual Studio Code -> new untitled editor
+### Cursor -> new untitled editor
+### Notes -> search field
+### Obsidian -> quick switcher input
+### Terminal -> shell prompt
+### focus pass done

--- a/prototypes/context-detection-spike/logs/focus-retry.marks
+++ b/prototypes/context-detection-spike/logs/focus-retry.marks
@@ -1,0 +1,5 @@
+### retry pass starting
+### Safari -> window made, address bar
+### Notes -> search field
+### Obsidian -> quick switcher input
+### retry pass done

--- a/prototypes/context-detection-spike/logs/probe-20260822-131700.log
+++ b/prototypes/context-detection-spike/logs/probe-20260822-131700.log
@@ -1,0 +1,358 @@
+OpenStream context-detection spike (issue #28) - PROTOTYPE, throwaway
+AXIsProcessTrusted() = false
+NOT TRUSTED: every focused-element read below will fail with kAXErrorAPIDisabled.
+Grant Accessibility to the app running this process, then re-run.
+poke AXManualAccessibility = false   interval = 0.4s
+Switch apps and click into text fields. Records print only when something changes.
+Ctrl-C to stop.
+---------------------------------------------------------------
+[1:17:01 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : NO
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorAPIDisabled>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorAPIDisabled>
+            focused subrole   : <kAXErrorAPIDisabled>
+            role description  : <kAXErrorAPIDisabled>
+            focused title     : <kAXErrorAPIDisabled>
+            AXValue readable  : <kAXErrorAPIDisabled>
+            AXSelectedText    : <kAXErrorAPIDisabled>
+---------------------------------------------------------------
+[1:17:08 pm] frontmost app     : Terminal
+            bundle id         : com.apple.Terminal  (pid 48784)
+            AX trusted        : NO
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorAPIDisabled>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorAPIDisabled>
+            focused subrole   : <kAXErrorAPIDisabled>
+            role description  : <kAXErrorAPIDisabled>
+            focused title     : <kAXErrorAPIDisabled>
+            AXValue readable  : <kAXErrorAPIDisabled>
+            AXSelectedText    : <kAXErrorAPIDisabled>
+---------------------------------------------------------------
+[1:17:20 pm] frontmost app     : universalAccessAuthWarn
+            bundle id         : com.apple.accessibility.universalAccessAuthWarn  (pid 43570)
+            AX trusted        : NO
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorAPIDisabled>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorAPIDisabled>
+            focused subrole   : <kAXErrorAPIDisabled>
+            role description  : <kAXErrorAPIDisabled>
+            focused title     : <kAXErrorAPIDisabled>
+            AXValue readable  : <kAXErrorAPIDisabled>
+            AXSelectedText    : <kAXErrorAPIDisabled>
+---------------------------------------------------------------
+[1:17:21 pm] frontmost app     : System Settings
+            bundle id         : com.apple.systempreferences  (pid 51729)
+            AX trusted        : NO
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorCannotComplete>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorCannotComplete>
+            focused subrole   : <kAXErrorCannotComplete>
+            role description  : <kAXErrorCannotComplete>
+            focused title     : <kAXErrorCannotComplete>
+            AXValue readable  : <kAXErrorCannotComplete>
+            AXSelectedText    : <kAXErrorCannotComplete>
+---------------------------------------------------------------
+[1:17:22 pm] frontmost app     : System Settings
+            bundle id         : com.apple.systempreferences  (pid 51729)
+            AX trusted        : NO
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorAPIDisabled>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorAPIDisabled>
+            focused subrole   : <kAXErrorAPIDisabled>
+            role description  : <kAXErrorAPIDisabled>
+            focused title     : <kAXErrorAPIDisabled>
+            AXValue readable  : <kAXErrorAPIDisabled>
+            AXSelectedText    : <kAXErrorAPIDisabled>
+---------------------------------------------------------------
+[1:17:30 pm] frontmost app     : System Settings
+            bundle id         : com.apple.systempreferences  (pid 51729)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Accessibility
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXOutline
+            focused subrole   : <kAXErrorAttributeUnsupported>
+            role description  : list
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : no (kAXErrorAttributeUnsupported)
+            AXSelectedText    : no (kAXErrorAttributeUnsupported)
+---------------------------------------------------------------
+[1:17:31 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : domain.md — openstream — Untracked
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:18:35 pm] frontmost app     : Terminal
+            bundle id         : com.apple.Terminal  (pid 48784)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : zazai — swift-frontend ◂ run.sh --prompt — 80×24
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextArea
+            focused subrole   : <kAXErrorAttributeUnsupported>
+            role description  : text entry area
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : yes (5673 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:18:40 pm] frontmost app     : TextEdit
+            bundle id         : com.apple.TextEdit  (pid 52341)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Open
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXList
+            focused subrole   : <kAXErrorAttributeUnsupported>
+            role description  : list
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : no (kAXErrorAttributeUnsupported)
+            AXSelectedText    : no (kAXErrorAttributeUnsupported)
+---------------------------------------------------------------
+[1:18:43 pm] frontmost app     : Notes
+            bundle id         : com.apple.Notes  (pid 52376)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Notes
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWindow
+            focused subrole   : AXStandardWindow
+            role description  : standard window
+            focused title     : Notes
+            AXValue readable  : no (kAXErrorAttributeUnsupported)
+            AXSelectedText    : no (kAXErrorAttributeUnsupported)
+---------------------------------------------------------------
+[1:18:46 pm] frontmost app     : Safari
+            bundle id         : com.apple.Safari  (pid 44573)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:18:50 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : New chat - Claude - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXButton
+            focused subrole   : <kAXErrorNoValue>
+            role description  : button
+            focused title     : Usage
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:18:52 pm] frontmost app     : TextEdit
+            bundle id         : com.apple.TextEdit  (pid 52341)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Open
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXList
+            focused subrole   : <kAXErrorAttributeUnsupported>
+            role description  : list
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : no (kAXErrorAttributeUnsupported)
+            AXSelectedText    : no (kAXErrorAttributeUnsupported)
+---------------------------------------------------------------
+[1:18:53 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : domain.md — openstream — Untracked
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:18:54 pm] frontmost app     : Terminal
+            bundle id         : com.apple.Terminal  (pid 48784)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : zazai — swift-frontend ◂ run.sh --prompt — 80×24
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextArea
+            focused subrole   : <kAXErrorAttributeUnsupported>
+            role description  : text entry area
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : yes (10310 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:19:02 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : domain.md — openstream — Untracked
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:19:08 pm] frontmost app     : Cursor
+            bundle id         : com.todesktop.230313mzl4w4u92  (pid 52484)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:19:09 pm] frontmost app     : Cursor
+            bundle id         : com.todesktop.230313mzl4w4u92  (pid 52484)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Cursor Agents
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:19:10 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : domain.md — openstream — Untracked
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:19:12 pm] frontmost app     : Obsidian
+            bundle id         : md.obsidian  (pid 52865)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:19:13 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : domain.md — openstream — Untracked
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:19:16 pm] frontmost app     : ‎WhatsApp
+            bundle id         : net.whatsapp.WhatsApp  (pid 670)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:19:17 pm] frontmost app     : UserNotificationCenter
+            bundle id         : com.apple.UserNotificationCenter  (pid 8495)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <empty>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWindow
+            focused subrole   : AXSystemDialog
+            role description  : system dialogue
+            focused title     : <empty>
+            AXValue readable  : no (kAXErrorAttributeUnsupported)
+            AXSelectedText    : no (kAXErrorAttributeUnsupported)
+---------------------------------------------------------------
+[1:19:17 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : domain.md — openstream — Untracked
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:19:20 pm] frontmost app     : Finder
+            bundle id         : com.apple.finder  (pid 681)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXGroup
+            focused subrole   : <kAXErrorNoValue>
+            role description  : group
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : no (kAXErrorNoValue)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:19:23 pm] frontmost app     : Cursor
+            bundle id         : com.todesktop.230313mzl4w4u92  (pid 52484)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Cursor Agents
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:19:24 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : domain.md — openstream — Untracked
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)

--- a/prototypes/context-detection-spike/logs/probe-20260822-131955.log
+++ b/prototypes/context-detection-spike/logs/probe-20260822-131955.log
@@ -1,0 +1,213 @@
+OpenStream context-detection spike (issue #28) - PROTOTYPE, throwaway
+AXIsProcessTrusted() = true
+poke AXManualAccessibility = true   interval = 0.4s
+Switch apps and click into text fields. Records print only when something changes.
+Ctrl-C to stop.
+---------------------------------------------------------------
+[1:19:58 pm] frontmost app     : Cursor
+            bundle id         : com.todesktop.230313mzl4w4u92  (pid 52484)
+            AX trusted        : yes
+            AXManualAccess.   : success
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:20:00 pm] frontmost app     : Terminal
+            bundle id         : com.apple.Terminal  (pid 48784)
+            AX trusted        : yes
+            AXManualAccess.   : kAXErrorAttributeUnsupported
+            window title      : zazai — swift-frontend ◂ run.sh --poke — 80×24
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextArea
+            focused subrole   : <kAXErrorAttributeUnsupported>
+            role description  : text entry area
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : yes (1335 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:20:09 pm] frontmost app     : TextEdit
+            bundle id         : com.apple.TextEdit  (pid 52341)
+            AX trusted        : yes
+            AXManualAccess.   : kAXErrorAttributeUnsupported
+            window title      : Open
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXList
+            focused subrole   : <kAXErrorAttributeUnsupported>
+            role description  : list
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : no (kAXErrorAttributeUnsupported)
+            AXSelectedText    : no (kAXErrorAttributeUnsupported)
+---------------------------------------------------------------
+[1:20:11 pm] frontmost app     : TextEdit
+            bundle id         : com.apple.TextEdit  (pid 52341)
+            AX trusted        : yes
+            AXManualAccess.   : already poked
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:20:13 pm] frontmost app     : Notes
+            bundle id         : com.apple.Notes  (pid 52376)
+            AX trusted        : yes
+            AXManualAccess.   : kAXErrorAttributeUnsupported
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:20:16 pm] frontmost app     : Safari
+            bundle id         : com.apple.Safari  (pid 44573)
+            AX trusted        : yes
+            AXManualAccess.   : kAXErrorAttributeUnsupported
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:20:19 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : kAXErrorAttributeUnsupported
+            window title      : New chat - Claude - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXButton
+            focused subrole   : <kAXErrorNoValue>
+            role description  : button
+            focused title     : Usage
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:20:22 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : success
+            window title      : domain.md — openstream
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:20:22 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : already poked
+            window title      : New chat - Claude - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXButton
+            focused subrole   : <kAXErrorNoValue>
+            role description  : button
+            focused title     : Usage
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:20:24 pm] frontmost app     : Cursor
+            bundle id         : com.todesktop.230313mzl4w4u92  (pid 52484)
+            AX trusted        : yes
+            AXManualAccess.   : already poked
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:20:26 pm] frontmost app     : Terminal
+            bundle id         : com.apple.Terminal  (pid 48784)
+            AX trusted        : yes
+            AXManualAccess.   : already poked
+            window title      : zazai — swift-frontend ◂ run.sh --poke — 80×24
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextArea
+            focused subrole   : <kAXErrorAttributeUnsupported>
+            role description  : text entry area
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : yes (7363 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:20:28 pm] frontmost app     : Obsidian
+            bundle id         : md.obsidian  (pid 52865)
+            AX trusted        : yes
+            AXManualAccess.   : success
+            window title      : 2026-08-20 - Obsidian Vault - Obsidian 1.13.7
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:20:30 pm] frontmost app     : Obsidian
+            bundle id         : md.obsidian  (pid 52865)
+            AX trusted        : yes
+            AXManualAccess.   : already poked
+            window title      : 2026-08-20 - Obsidian Vault - Obsidian 1.13.7
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXGroup
+            focused subrole   : <kAXErrorNoValue>
+            role description  : group
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:20:31 pm] frontmost app     : ‎WhatsApp
+            bundle id         : net.whatsapp.WhatsApp  (pid 670)
+            AX trusted        : yes
+            AXManualAccess.   : kAXErrorAttributeUnsupported
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:20:35 pm] frontmost app     : Finder
+            bundle id         : com.apple.finder  (pid 681)
+            AX trusted        : yes
+            AXManualAccess.   : kAXErrorAttributeUnsupported
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXGroup
+            focused subrole   : <kAXErrorNoValue>
+            role description  : group
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : no (kAXErrorNoValue)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:20:37 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : already poked
+            window title      : domain.md — openstream — Deleted
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)

--- a/prototypes/context-detection-spike/logs/probe-20260822-132125.log
+++ b/prototypes/context-detection-spike/logs/probe-20260822-132125.log
@@ -1,0 +1,954 @@
+OpenStream context-detection spike (issue #28) - PROTOTYPE, throwaway
+AXIsProcessTrusted() = true
+poke AXManualAccessibility = false   interval = 0.4s
+Switch apps and click into text fields. Records print only when something changes.
+Ctrl-C to stop.
+---------------------------------------------------------------
+[1:21:25 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : domain.md — openstream — Deleted
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:21:38 pm] frontmost app     : Safari
+            bundle id         : com.apple.Safari  (pid 44573)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:21:40 pm] frontmost app     : UserNotificationCenter
+            bundle id         : com.apple.UserNotificationCenter  (pid 8495)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <empty>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWindow
+            focused subrole   : AXSystemDialog
+            role description  : system dialogue
+            focused title     : <empty>
+            AXValue readable  : no (kAXErrorAttributeUnsupported)
+            AXSelectedText    : no (kAXErrorAttributeUnsupported)
+---------------------------------------------------------------
+[1:21:41 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : domain.md — openstream — Deleted
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:21:46 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : New chat - Claude - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXButton
+            focused subrole   : <kAXErrorNoValue>
+            role description  : button
+            focused title     : Usage
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:21:48 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : New chat - Claude - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (36 chars)
+            AXSelectedText    : yes (36 chars)
+---------------------------------------------------------------
+[1:21:48 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : domain.md — openstream — Deleted
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:21:51 pm] frontmost app     : TextEdit
+            bundle id         : com.apple.TextEdit  (pid 52341)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:21:52 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : domain.md — openstream — Deleted
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:21:57 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Untitled-1 — openstream
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : editor
+            focused title     : <empty>
+            AXValue readable  : yes (1 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:21:59 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Untitled-1 — openstream
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:22:00 pm] frontmost app     : Cursor
+            bundle id         : com.todesktop.230313mzl4w4u92  (pid 52484)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:22:01 pm] frontmost app     : Cursor
+            bundle id         : com.todesktop.230313mzl4w4u92  (pid 52484)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Cursor Agents
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:22:02 pm] frontmost app     : Cursor
+            bundle id         : com.todesktop.230313mzl4w4u92  (pid 52484)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Cursor Agents
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWebArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : HTML content
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:22:03 pm] frontmost app     : Cursor
+            bundle id         : com.todesktop.230313mzl4w4u92  (pid 52484)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Cursor Agents
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWebArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : HTML content
+            focused title     : Cursor Agents
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:22:05 pm] frontmost app     : Notes
+            bundle id         : com.apple.Notes  (pid 52376)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:22:05 pm] frontmost app     : TextEdit
+            bundle id         : com.apple.TextEdit  (pid 52341)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Untitled
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextArea
+            focused subrole   : <kAXErrorAttributeUnsupported>
+            role description  : text entry area
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:22:06 pm] frontmost app     : TextEdit
+            bundle id         : com.apple.TextEdit  (pid 52341)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Untitled
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : AXSearchField
+            role description  : search text field
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:22:07 pm] frontmost app     : TextEdit
+            bundle id         : com.apple.TextEdit  (pid 52341)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:22:08 pm] frontmost app     : Terminal
+            bundle id         : com.apple.Terminal  (pid 48784)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : zazai — sleep ◂ focus.sh — 80×24
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextArea
+            focused subrole   : <kAXErrorAttributeUnsupported>
+            role description  : text entry area
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : yes (446 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:22:10 pm] frontmost app     : Obsidian
+            bundle id         : md.obsidian  (pid 52865)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:22:10 pm] frontmost app     : Terminal
+            bundle id         : com.apple.Terminal  (pid 48784)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : zazai — swift-frontend ◂ run.sh — 80×24
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextArea
+            focused subrole   : <kAXErrorAttributeUnsupported>
+            role description  : text entry area
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : yes (14280 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:22:12 pm] frontmost app     : Terminal
+            bundle id         : com.apple.Terminal  (pid 48784)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Open
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXList
+            focused subrole   : <kAXErrorAttributeUnsupported>
+            role description  : list
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : no (kAXErrorAttributeUnsupported)
+            AXSelectedText    : no (kAXErrorAttributeUnsupported)
+---------------------------------------------------------------
+[1:22:15 pm] frontmost app     : Terminal
+            bundle id         : com.apple.Terminal  (pid 48784)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : zazai — swift-frontend ◂ run.sh — 80×24
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextArea
+            focused subrole   : <kAXErrorAttributeUnsupported>
+            role description  : text entry area
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : yes (15646 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:22:17 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Untitled-1 — openstream
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:22:26 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : New chat - Claude - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (28 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:22:28 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <empty>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:22:31 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <empty>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWebArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : HTML content
+            focused title     : New Tab
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:22:31 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <empty>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:22:32 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : GitHub - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:22:32 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : GitHub - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWebArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : HTML content
+            focused title     : GitHub
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:22:36 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : GitHub - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXLink
+            focused subrole   : <kAXErrorNoValue>
+            role description  : link
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:22:37 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Nabzx/openstream: A free, fully local, zero-setup voice dictation app for macOS - built specifically for developers. - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:22:37 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Nabzx/openstream: A free, fully local, zero-setup voice dictation app for macOS - built specifically for developers. - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWebArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : HTML content
+            focused title     : Nabzx/openstream: A free, fully local, zero-setup voice dictation app for macOS - built specifically for developers.
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:22:44 pm] frontmost app     : Safari
+            bundle id         : com.apple.Safari  (pid 44573)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:22:45 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Nabzx/openstream: A free, fully local, zero-setup voice dictation app for macOS - built specifically for developers. - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWebArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : HTML content
+            focused title     : Nabzx/openstream: A free, fully local, zero-setup voice dictation app for macOS - built specifically for developers.
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:22:48 pm] frontmost app     : Terminal
+            bundle id         : com.apple.Terminal  (pid 48784)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : zazai — osascript ◂ focus-retry.sh — 80×24
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextArea
+            focused subrole   : <kAXErrorAttributeUnsupported>
+            role description  : text entry area
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : yes (460 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:22:49 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Nabzx/openstream: A free, fully local, zero-setup voice dictation app for macOS - built specifically for developers. - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWebArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : HTML content
+            focused title     : Nabzx/openstream: A free, fully local, zero-setup voice dictation app for macOS - built specifically for developers.
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:22:50 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Nabzx/openstream: A free, fully local, zero-setup voice dictation app for macOS - built specifically for developers. - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (35 chars)
+            AXSelectedText    : yes (35 chars)
+---------------------------------------------------------------
+[1:22:51 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Nabzx/openstream: A free, fully local, zero-setup voice dictation app for macOS - built specifically for developers. - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXLink
+            focused subrole   : <kAXErrorNoValue>
+            role description  : link
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:22:52 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Issues · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXLink
+            focused subrole   : <kAXErrorNoValue>
+            role description  : link
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:22:56 pm] frontmost app     : Notes
+            bundle id         : com.apple.Notes  (pid 52376)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:22:58 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Issues · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXLink
+            focused subrole   : <kAXErrorNoValue>
+            role description  : link
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:22:58 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Issues · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:23:00 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Issues · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXLink
+            focused subrole   : <kAXErrorNoValue>
+            role description  : link
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:23:00 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Pull requests · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXLink
+            focused subrole   : <kAXErrorNoValue>
+            role description  : link
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:23:04 pm] frontmost app     : Obsidian
+            bundle id         : md.obsidian  (pid 52865)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:23:05 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Pull requests · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXLink
+            focused subrole   : <kAXErrorNoValue>
+            role description  : link
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:23:07 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorAttributeUnsupported>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXList
+            focused subrole   : <kAXErrorAttributeUnsupported>
+            role description  : list
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : no (kAXErrorAttributeUnsupported)
+            AXSelectedText    : no (kAXErrorAttributeUnsupported)
+---------------------------------------------------------------
+[1:23:09 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Pull requests · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXLink
+            focused subrole   : <kAXErrorNoValue>
+            role description  : link
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:23:15 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Comparing Nabzx:main...Zazai840:chore/agent-skills-config · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : Add a title *
+            AXValue readable  : yes (37 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:23:24 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Comparing Nabzx:main...Zazai840:chore/agent-skills-config · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWebArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : HTML content
+            focused title     : Comparing Nabzx:main...Zazai840:chore/agent-skills-config · Nabzx/openstream
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:23:26 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Comparing Nabzx:main...Zazai840:chore/agent-skills-config · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:23:26 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : chore: add agent skills configuration by Zazai840 · Pull Request #35 · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWebArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : HTML content
+            focused title     : chore: add agent skills configuration by Zazai840 · Pull Request #35 · Nabzx/openstream
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:23:32 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : chore: add agent skills configuration by Zazai840 · Pull Request #35 · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : Commit message
+            AXValue readable  : yes (62 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:23:34 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : chore: add agent skills configuration by Zazai840 · Pull Request #35 · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXButton
+            focused subrole   : <kAXErrorNoValue>
+            role description  : button
+            focused title     : Confirm merge
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:23:36 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : chore: add agent skills configuration by Zazai840 · Pull Request #35 · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWebArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : HTML content
+            focused title     : chore: add agent skills configuration by Zazai840 · Pull Request #35 · Nabzx/openstream
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:23:43 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Comparing Nabzx:main...Zazai840:chore/agent-skills-config · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWebArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : HTML content
+            focused title     : Comparing Nabzx:main...Zazai840:chore/agent-skills-config · Nabzx/openstream
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:23:45 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : chore: add agent skills configuration by Zazai840 · Pull Request #35 · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWebArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : HTML content
+            focused title     : chore: add agent skills configuration by Zazai840 · Pull Request #35 · Nabzx/openstream
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:23:45 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Comparing Nabzx:main...Zazai840:chore/agent-skills-config · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWebArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : HTML content
+            focused title     : Comparing Nabzx:main...Zazai840:chore/agent-skills-config · Nabzx/openstream
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:23:46 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Pull requests · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWebArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : HTML content
+            focused title     : Comparing Nabzx:main...Zazai840:chore/agent-skills-config · Nabzx/openstream
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:23:46 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Pull requests · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWebArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : HTML content
+            focused title     : Pull requests · Nabzx/openstream
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:23:48 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Pull requests · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXLink
+            focused subrole   : <kAXErrorNoValue>
+            role description  : link
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:23:49 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Comparing Nabzx:main...Zazai840:prototype/context-detection-28 · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : Add a title *
+            AXValue readable  : yes (56 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:24:16 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Comparing Nabzx:main...Zazai840:prototype/context-detection-28 · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWebArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : HTML content
+            focused title     : Comparing Nabzx:main...Zazai840:prototype/context-detection-28 · Nabzx/openstream
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:24:18 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : spike: probe macOS Accessibility context detection (#28) by Zazai840 · Pull Request #36 · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:24:19 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : spike: probe macOS Accessibility context detection (#28) by Zazai840 · Pull Request #36 · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWebArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : HTML content
+            focused title     : spike: probe macOS Accessibility context detection (#28) by Zazai840 · Pull Request #36 · Nabzx/openstream
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:24:23 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : spike: probe macOS Accessibility context detection (#28) by Zazai840 · Pull Request #36 · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : Commit message
+            AXValue readable  : yes (67 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:24:24 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : spike: probe macOS Accessibility context detection (#28) by Zazai840 · Pull Request #36 · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXButton
+            focused subrole   : <kAXErrorNoValue>
+            role description  : button
+            focused title     : Confirm merge
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:24:26 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : spike: probe macOS Accessibility context detection (#28) by Zazai840 · Pull Request #36 · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWebArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : HTML content
+            focused title     : spike: probe macOS Accessibility context detection (#28) by Zazai840 · Pull Request #36 · Nabzx/openstream
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:24:37 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : spike: probe macOS Accessibility context detection (#28) by Zazai840 · Pull Request #36 · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXLink
+            focused subrole   : <kAXErrorNoValue>
+            role description  : link
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:24:38 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Nabzx/openstream: A free, fully local, zero-setup voice dictation app for macOS - built specifically for developers. - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXLink
+            focused subrole   : <kAXErrorNoValue>
+            role description  : link
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:24:41 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Comparing Nabzx:main...Zazai840:research/model-licensing · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : Add a title *
+            AXValue readable  : yes (61 chars)
+            AXSelectedText    : yes (0 chars)

--- a/prototypes/context-detection-spike/probe.swift
+++ b/prototypes/context-detection-spike/probe.swift
@@ -114,6 +114,10 @@ struct Sample {
     }
 }
 
+/// Apps already poked this run, so the one-second settle wait is paid once per
+/// app rather than on every sample.
+var pokedPIDs = Set<pid_t>()
+
 func sampleNow() -> Sample {
     let trusted = AXIsProcessTrusted()
     var s = Sample(frontApp: "<none>", bundleID: "<none>", pid: "<none>",
@@ -135,7 +139,16 @@ func sampleNow() -> Sample {
     // actually publish a tree.
     let appElement = AXUIElementCreateApplication(app.processIdentifier)
     if wantPoke {
-        s.pokeResult = pokeManualAccessibility(appElement)
+        if pokedPIDs.contains(app.processIdentifier) {
+            s.pokeResult = "already poked"
+        } else {
+            s.pokeResult = pokeManualAccessibility(appElement)
+            pokedPIDs.insert(app.processIdentifier)
+            // Chromium builds its accessibility tree asynchronously after the
+            // flag is set. Reading in the same breath as the poke shows nothing
+            // even when the poke worked, so give it a beat before the first read.
+            Thread.sleep(forTimeInterval: 1.0)
+        }
     }
 
     let systemWide = AXUIElementCreateSystemWide()


### PR DESCRIPTION
Completes the merge of the context-detection spike for #28.

PR #36 landed only the first commit of `prototype/context-detection-28` - the
partial run made *before* the Accessibility grant, where Layer 2 was still
blocked behind `kAXErrorAPIDisabled`. The three commits that actually answer the
question stayed on the branch, so `RESULTS.md` on `main` still reads
"Layer 2 blocked pending an Accessibility grant" while the resolution comment on
#28 cites tables and logs that do not exist on `main`.

This cherry-picks those three onto current `main`:

- `spike: complete the context-detection map after Accessibility grant (#28)` -
  the trusted sweep, the focus pass and retry, and the full Layer 2 table.
- `spike: controlled A/B for AXManualAccessibility, correct confounded claims (#28)` -
  quits the competing accessibility client, cold-relaunches the Electron apps,
  and withdraws the earlier confounded "VS Code needs no poke" claim.
- `spike: separate the two focus-contamination causes in the results map (#28)` -
  distinguishes the Chrome focus-stealing artifact from the dwell-time asymmetry.

No production code. Throwaway probe under `prototypes/context-detection-spike/`,
plus its raw logs as the evidence behind the issue's answer. No tests, per the
prototype skill; anything lifted into the real native helper gets tests first.

Closes #28.
