### PR TITLE
docs: correct Phase 4 permission item to a recurring state check (#40)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -70,7 +70,7 @@ Same tracks, harder problems — this is where it gets genuinely complex.
 
 ## Phase 4 — v1.0: Polish & launch (both, target: 1-2 weeks)
 
-- [ ] Onboarding flow — mic + Accessibility permission walkthrough
+- [ ] Permission state check - build script warns when a helper hash changes, app tests all three grants at launch and blocks on Accessibility / Input Monitoring (#47)
 - [ ] Settings UI complete (hotkey remapping, model choice, mode rules)
 - [ ] Release automation (GitHub Releases + Homebrew formula bump on tag, `electron-builder` pipeline)
 - [ ] README demo GIF, short landing page


### PR DESCRIPTION
Fallout from [How is the per-rebuild permission re-grant presented to the user?](https://github.com/Nabzx/openstream/issues/40) on the wayfinder map.

`ROADMAP.md` Phase 4 still listed "Onboarding flow - mic + Accessibility permission walkthrough". That describes a one-time first-run walkthrough, which has no referent under source-only distribution: updating is rebuilding, so permission state has to be checked continuously.

Issue #18 is closed as obsolete and #47 replaces it. This corrects the roadmap line to match.

One line, docs only.