### PR TITLE
docs: settle model process lifecycle (#29)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,49 @@
+# openstream
+
+A local-first voice dictation app for macOS. The user holds a key, speaks, and the spoken words are placed into whatever application is frontmost. Nothing leaves the machine.
+
+## Language
+
+### The dictation act
+
+**Dictation**:
+One complete act of speaking and having the resulting text placed at the cursor. Begins when the user presses the push-to-talk key and ends when the text lands.
+_Avoid_: Utterance, recording, session
+
+**Dictation latency budget**:
+The time from the end of speech to text being ready, which the product commits to keeping under one second.
+_Avoid_: Response time, turnaround
+
+**Voice edit**:
+A rewrite of text the user has already selected, requested by speaking a command such as "make this a bullet list". Distinct from dictation: the user asks for it explicitly and expects to wait.
+_Avoid_: Cleanup, correction, LLM pass
+
+### Model processes
+
+Named by the role they fill, never by the model that currently fills it. Which model occupies a role is a separate, still-open question.
+
+**Transcription model server**:
+The process that turns captured audio into text. Fills the role currently held by `whisper-server`.
+_Avoid_: whisper, STT engine, the transcriber
+
+**Rewrite model server**:
+The process that rewrites existing text on request, serving voice edits only. Fills the role currently held by `llama-server`, though the model in that role is not settled.
+_Avoid_: llama-server, the LLM, cleanup model
+
+**Model supervisor**:
+The single component that owns the lifecycle of every model server: starting it, restarting it after a crash or a settings change, and releasing it.
+_Avoid_: Process manager, runner, daemon
+
+**Resident**:
+A model server that is already loaded and waiting, so a request pays inference cost only and never model-load cost.
+_Avoid_: Warm, preloaded, cached
+
+**Idle release**:
+Shutting a model server down after a period without requests, so it holds no memory between bursts of use.
+_Avoid_: Eviction, unloading, timeout kill
+
+### Cleanup
+
+**Rules cleanup**:
+Deterministic, non-model text tidying applied to every dictation. Costs under a millisecond, and is the only cleanup on the dictation path.
+_Avoid_: Post-processing, formatting pass

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,7 +17,7 @@ Pick who owns which track in Phase 2 based on interest, not this doc — the spl
 Get to "clone and build" for both of you before splitting up.
 
 - [ ] Electron + React + TypeScript (Vite) scaffold, menu bar tray app shell (no functionality yet)
-- [ ] whisper.cpp integrated: download script for the prebuilt binary + a model, subprocess wrapper, one hardcoded hotkey triggers record → transcribe → print to console
+- [ ] whisper.cpp integrated: download script for the prebuilt binary + a model, **resident `whisper-server` started at app launch and supervised for the life of the app** (not a per-dictation subprocess - see #29), one hardcoded hotkey triggers record → transcribe → print to console
 - [ ] GitHub Actions workflow: build check on every PR
 - [ ] Branch protection on `main`: PRs required, one review required
 
@@ -62,7 +62,7 @@ Owns: context awareness, local LLM cleanup.
 Same tracks, harder problems — this is where it gets genuinely complex.
 
 - **Track A:** codebase vocabulary scanner — extract identifiers/terms from the open git repo or editor buffer, feed them into whisper.cpp as an initial prompt / bias list
-- **Track B:** voice-driven editing — select existing text anywhere, speak a command ("make this a bullet list", "snake_case that"), send it to `llama-server` to rewrite the selection in place
+- **Track B:** voice-driven editing — select existing text anywhere, speak a command ("make this a bullet list", "snake_case that"), send it to the **rewrite model server** to rewrite the selection in place. That server starts lazily on the first voice-edit command and is released after 5 minutes idle (see #29); it is never resident during ordinary dictation
 
 **Definition of done:** dictation that's measurably more accurate on your own codebase's vocabulary, plus voice-editing of existing text. Tag `v0.3`.
 


### PR DESCRIPTION
Resolves the wayfinder ticket [Model process lifecycle: resident or on demand?](https://github.com/Nabzx/openstream/issues/29), on the map [Map: lock the decisions the roadmap assumes](https://github.com/Nabzx/openstream/issues/23).

## The decision

Two model roles, two different lifecycles:

- **Transcription model server** (currently `whisper-server`): **resident**, started at app launch, kept for the life of the app.
- **Rewrite model server** (currently `llama-server`, but see #32): **lazy start** on the first voice-edit command, **released after 5 minutes idle**. Never resident during ordinary dictation.

Stated by role rather than by model, because which model fills the rewrite role is still open.

## Why

`ROADMAP.md` Phase 0 said "subprocess wrapper", which silently assumed a model load on every dictation. Measured, that load is **0.38s** for `base.en` against a **1s** dictation latency budget - over a third of the budget, spent on work that produces nothing new. With `small.en` (the speed-vs-accuracy setting the roadmap promises) it is 0.81s load + 0.51s transcribe = **1.32s**, which exceeds the budget outright. The assumption would have removed a promised feature.

Residency is cheap on the transcription side: `whisper-server` with `small.en` measures **597 MB** RSS, and `base.en` is around 270 MB. Against an Electron shell already holding 200-400 MB, that does not change the size class of the app, and it is ~3% of an 8 GB machine.

The rewrite model is the opposite case: ~2 GB for a 3B model is a quarter of an 8 GB machine, held for a feature that may never be invoked in a given session. Idle release earns its complexity there, and only there.

## Changes

- `ROADMAP.md` Phase 0: per-dictation subprocess corrected to a supervised resident `whisper-server`.
- `ROADMAP.md` Phase 3 Track B: names the rewrite model server and its lazy/idle-release policy.
- `CONTEXT.md` (new): the vocabulary this decision fixed - dictation, dictation latency budget, voice edit, transcription model server, rewrite model server, model supervisor, resident, idle release, rules cleanup.

Numbers from `spike/llm-cleanup-latency/FINDINGS.md`, except the RSS figure, which was measured directly during the ticket.
