### PR TITLE
docs: correct README model distribution and LLM claims (#30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ What's still missing: **dictation that knows what you're looking at.** Every exi
 1. **Context-aware formatting** — detects the frontmost app/field via the macOS Accessibility API and adapts: no auto-capitalization or punctuation in a terminal, proper comment/docstring formatting in an editor, normal prose everywhere else.
 2. **Codebase-aware vocabulary** — reads identifiers, library names, and project-specific terms from the current git repo / open buffer and biases transcription toward them, so technical jargon and your own function/variable names actually transcribe correctly.
 3. **Voice-driven editing, not just dictation** — select existing text anywhere and speak an edit command ("make this a bullet list", "snake_case that", "shorter") to rewrite it in place.
-4. **Actually zero setup** — STT model and a small local LLM cleanup model ship bundled with the installer. No Ollama, no LM Studio, no manual model downloads, no config screens.
+4. **No model wrangling** - the build fetches the speech-to-text model for you, at a pinned version, checksum-verified. No Ollama, no LM Studio, no account, no model picker, no config screens. Setup is a `git clone` and a build: v0.x is source-only, so you build it yourself.
 
 ## Status
 
@@ -24,8 +24,9 @@ Early development — pre-alpha, no working build yet. Architecture below is the
 ## Planned architecture
 
 - **App shell**: Electron + React + TypeScript (Vite), menu bar tray app
-- **Speech-to-text**: [whisper.cpp](https://github.com/ggml-org/whisper.cpp), prebuilt binary downloaded at build/first-run (not committed), run as a subprocess
-- **Local LLM cleanup pass**: [llama.cpp](https://github.com/ggml-org/llama.cpp) (`llama-server`) running **Llama 3.2 3B Instruct** (quantized GGUF, ~2GB), downloaded at build/first-run and called over local HTTP for formatting/editing/command-following. Meta built this size specifically for on-device rewriting/summarization, and it matches or beats Llama 3.1 8B on those tasks despite being under half the size. **Llama 3.2 1B** is offered as a lighter fallback for lower-RAM Macs via the model-size setting.
+- **Speech-to-text**: [whisper.cpp](https://github.com/ggml-org/whisper.cpp), compiled from source at a pinned version during the build (not committed), run as a subprocess. There is no prebuilt macOS binary upstream, and the published `xcframework` is a static library that would require a native Node add-on in the Electron main process, which the helper-process design rules out. The `ggml-base.en.bin` model (141 MiB) is fetched by the build from a pinned Hugging Face revision and checked against a recorded SHA-256. One model, no size setting: it is the only model measured against the sub-1s latency budget.
+- **Text cleanup**: deterministic rules, not a model. A local LLM was measured out of the dictation path: it cost seconds where rules cost well under a millisecond, and whisper.cpp already self-cleans the short clips where a model would be cheap.
+- **Local LLM (Phase 3 only)**: [llama.cpp](https://github.com/ggml-org/llama.cpp) (`llama-server`) is used only for **voice-driven editing**, where you explicitly ask for a rewrite and expect to wait. The model is **SmolLM2-1.7B-Instruct** (Apache 2.0, ungated, quantized GGUF, ~1 GB), chosen for a permissive licence and no gated download; the exact model is provisional pending an eval set. Nothing in v0.1 or v0.2 depends on it.
 - **macOS native helpers**: small Swift/Objective-C binaries (compiled via native build scripts) for Accessibility API context detection, text injection, and mic access
 - **Vocabulary biasing**: lightweight scan of open editor buffer / git repo for identifiers and terms, fed into whisper.cpp as an initial prompt / bias list
 
@@ -33,6 +34,8 @@ Early development — pre-alpha, no working build yet. Architecture below is the
 
 - Apple Silicon Mac (M1 or later)
 - macOS 13+ (tentative, may adjust)
+- Xcode Command Line Tools, to compile whisper.cpp and the native helpers
+- A network connection for the build, which fetches the speech-to-text model
 
 ## Roadmap
 


### PR DESCRIPTION
Resolves [Bundle the models in the installer, or download on first run?](https://github.com/Nabzx/openstream/issues/30) at the file level.

This fixes **contradiction 1** on [Map: lock the decisions the roadmap assumes](https://github.com/Nabzx/openstream/issues/23): the pitch promised models "ship bundled with the installer" while the architecture section directly below claimed they were downloaded at build/first-run. It also applies the line 27 edit that [Accept Llama 3.2's terms, or switch to a permissively licensed model?](https://github.com/Nabzx/openstream/issues/32) deliberately deferred to #30, so the README lands correct in one pass rather than two.

Changes:
- **Pitch point 4** drops the zero-setup claim. Source-only per #27 means the user builds it, and there is no installer to bundle into.
- **whisper.cpp** is compiled from source at a pinned version. The old "prebuilt binary downloaded" described an artifact upstream does not publish for macOS; the released `xcframework` is a static library needing a native Node add-on in the Electron main process, which #26 rules out.
- **The speech model** is named, sized (141 MiB), and stated as build-time fetched from a pinned Hugging Face revision with a SHA-256 check. No model-size setting - `base.en` is the only model measured against the sub-1s budget from #24.
- **In-path LLM cleanup** becomes deterministic rules, per #24.
- **Phase 3 model** is SmolLM2-1.7B-Instruct, per #32.
- **Requirements** gains Xcode Command Line Tools and a build-time network connection.

Docs only, no code. Per the map's planning-only rule, this changes claims to match decisions already made and settles nothing new.