### PR TITLE
docs: correct README and ROADMAP for the model distribution decision (#30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ What's still missing: **dictation that knows what you're looking at.** Every exi
 1. **Context-aware formatting** — detects the frontmost app/field via the macOS Accessibility API and adapts: no auto-capitalization or punctuation in a terminal, proper comment/docstring formatting in an editor, normal prose everywhere else.
 2. **Codebase-aware vocabulary** — reads identifiers, library names, and project-specific terms from the current git repo / open buffer and biases transcription toward them, so technical jargon and your own function/variable names actually transcribe correctly.
 3. **Voice-driven editing, not just dictation** — select existing text anywhere and speak an edit command ("make this a bullet list", "snake_case that", "shorter") to rewrite it in place.
-4. **Actually zero setup** — STT model and a small local LLM cleanup model ship bundled with the installer. No Ollama, no LM Studio, no manual model downloads, no config screens.
+4. **Build it once, then nothing to set up** — there is no installer and no bundled model. You build from source, and the build compiles whisper.cpp and fetches its model for you. After that: no Ollama, no LM Studio, no manual model downloads, no first-run downloader, no config screens.
 
 ## Status
 
@@ -24,8 +24,9 @@ Early development — pre-alpha, no working build yet. Architecture below is the
 ## Planned architecture
 
 - **App shell**: Electron + React + TypeScript (Vite), menu bar tray app
-- **Speech-to-text**: [whisper.cpp](https://github.com/ggml-org/whisper.cpp), prebuilt binary downloaded at build/first-run (not committed), run as a subprocess
-- **Local LLM cleanup pass**: [llama.cpp](https://github.com/ggml-org/llama.cpp) (`llama-server`) running **Llama 3.2 3B Instruct** (quantized GGUF, ~2GB), downloaded at build/first-run and called over local HTTP for formatting/editing/command-following. Meta built this size specifically for on-device rewriting/summarization, and it matches or beats Llama 3.1 8B on those tasks despite being under half the size. **Llama 3.2 1B** is offered as a lighter fallback for lower-RAM Macs via the model-size setting.
+- **Speech-to-text**: [whisper.cpp](https://github.com/ggml-org/whisper.cpp), **compiled from source at a pinned tag during the build** - upstream publishes no macOS arm64 CLI binary, and a compiler is already required for the native helpers. One model, `ggml-base.en.bin` (141 MiB), fetched during the build from a **pinned Hugging Face revision** and verified against a known SHA-256; the build fails loudly if it does not match. Neither the binary nor the model is committed. Run as a resident `whisper-server` supervised for the life of the app.
+- **Text cleanup**: a **deterministic rules engine**, not a model. Filler removal, punctuation and per-mode formatting cost 0.1-1.0 ms. **There is no LLM in the dictation path** - measurement showed whisper already self-cleans short clips, so a model only earned its keep on exactly the long inputs where it cost seconds.
+- **Local rewrite model (Phase 3 only)**: [llama.cpp](https://github.com/ggml-org/llama.cpp) (`llama-server`), used solely for voice-driven editing, where the user explicitly asks for a rewrite and expects to wait. It starts lazily on first use and is released after 5 minutes idle. The model must be **Apache 2.0 or MIT and ungated** (no account, no terms acceptance): **SmolLM2-1.7B-Instruct** provisionally, Qwen3-1.7B the alternate. How it is acquired is still open.
 - **macOS native helpers**: small Swift/Objective-C binaries (compiled via native build scripts) for Accessibility API context detection, text injection, and mic access
 - **Vocabulary biasing**: lightweight scan of open editor buffer / git repo for identifiers and terms, fed into whisper.cpp as an initial prompt / bias list
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,7 +17,7 @@ Pick who owns which track in Phase 2 based on interest, not this doc — the spl
 Get to "clone and build" for both of you before splitting up.
 
 - [ ] Electron + React + TypeScript (Vite) scaffold, menu bar tray app shell (no functionality yet)
-- [ ] whisper.cpp integrated: download script for the prebuilt binary + a model, **resident `whisper-server` started at app launch and supervised for the life of the app** (not a per-dictation subprocess - see #29), one hardcoded hotkey triggers record → transcribe → print to console
+- [ ] whisper.cpp integrated: build script **compiles whisper.cpp from source at a pinned tag** and fetches `ggml-base.en.bin` from a **pinned Hugging Face revision**, SHA-256 verified (no prebuilt macOS arm64 binary is published - see #30), **resident `whisper-server` started at app launch and supervised for the life of the app** (not a per-dictation subprocess - see #29), one hardcoded hotkey triggers record → transcribe → print to console
 - [ ] GitHub Actions workflow: build check on every PR
 - [ ] Branch protection on `main`: PRs required, one review required
 
@@ -40,18 +40,17 @@ Get to "clone and build" for both of you before splitting up.
 ### Track A — Input & Delivery
 Owns: audio capture, STT, text delivery, packaging.
 
-- [ ] Download pipeline for whisper.cpp binary + models, run at build/first-launch with progress UI
-- [ ] Support multiple whisper.cpp model sizes; settings toggle for speed vs. accuracy
+- [ ] Harden the build-time compile + model fetch: cached artifacts, re-verification on rebuild, loud failure messages. **No first-launch download and no progress UI** - #30 moved model acquisition entirely into the build
+- [ ] ~~Support multiple whisper.cpp model sizes; settings toggle for speed vs. accuracy~~ - **removed by #30.** One model, `ggml-base.en.bin`. The setting existed so low-RAM Macs could dodge the 2 GB LLM, and that LLM left the dictation path in #24; `small.en` is ~3x the work and would put long dictations past the sub-1s budget
 - [ ] Harden text injection across app types — this breaks in Electron apps, terminals, and some Java/Swing apps; needs real cross-app testing
 - [ ] Code signing + notarization, Homebrew cask, `electron-updater` auto-update
 
 ### Track B — Intelligence
-Owns: context awareness, local LLM cleanup.
+Owns: context awareness, per-mode formatting rules.
 
 - [ ] Accessibility API: native helper detects frontmost app + focused field type, define discrete "modes" (terminal / code editor / prose)
 - [ ] Formatting rules engine per mode (no auto-caps/punctuation in terminal, proper comment formatting in editors)
-- [ ] llama.cpp integration: download `llama-server` + Llama 3.2 3B Instruct (quantized GGUF), get a basic cleanup pass running (filler removal, punctuation) over local HTTP. Offer Llama 3.2 1B as a lighter fallback for lower-RAM Macs
-- [ ] Prompt design + a small eval set to judge cleanup quality before/after changes
+- [ ] Prompt design + a small eval set to judge rewrite quality before/after changes
 
 **Definition of done:** Track A ships more reliable, faster, easier-to-install dictation. Track B ships visibly smarter output. Tag `v0.2`.
 
@@ -62,6 +61,7 @@ Owns: context awareness, local LLM cleanup.
 Same tracks, harder problems — this is where it gets genuinely complex.
 
 - **Track A:** codebase vocabulary scanner — extract identifiers/terms from the open git repo or editor buffer, feed them into whisper.cpp as an initial prompt / bias list
+- **Track B:** `llama-server` plumbing - fetch the binary and an **Apache 2.0 / MIT, ungated** GGUF (SmolLM2-1.7B-Instruct provisionally; acquisition policy open in #52), start it, confirm a local HTTP round trip (moved here from Phase 2 by #24 and #32)
 - **Track B:** voice-driven editing — select existing text anywhere, speak a command ("make this a bullet list", "snake_case that"), send it to the **rewrite model server** to rewrite the selection in place. That server starts lazily on the first voice-edit command and is released after 5 minutes idle (see #29); it is never resident during ordinary dictation
 
 **Definition of done:** dictation that's measurably more accurate on your own codebase's vocabulary, plus voice-editing of existing text. Tag `v0.3`.
@@ -71,7 +71,7 @@ Same tracks, harder problems — this is where it gets genuinely complex.
 ## Phase 4 — v1.0: Polish & launch (both, target: 1-2 weeks)
 
 - [ ] Permission state check - build script warns when a helper hash changes, app tests all three grants at launch and blocks on Accessibility / Input Monitoring (#47)
-- [ ] Settings UI complete (hotkey remapping, model choice, mode rules)
+- [ ] Settings UI complete (hotkey remapping, mode rules) - **no model choice**, see #30
 - [ ] Release automation (GitHub Releases + Homebrew formula bump on tag, `electron-builder` pipeline)
 - [ ] README demo GIF, short landing page
 - [ ] Public launch (Show HN, r/macapps, etc.)


### PR DESCRIPTION
Applies the repo fallout from [Bundle the models in the installer, or download on first run?](https://github.com/Nabzx/openstream/issues/30), part of [Map: lock the decisions the roadmap assumes](https://github.com/Nabzx/openstream/issues/23).

The decision was recorded on the ticket and the ticket closed, but `README.md` and `ROADMAP.md` still carried the claims it invalidated.

**Settled by #30:** whisper.cpp is **compiled from source at a pinned tag during the build** (upstream publishes no macOS arm64 CLI binary, and a compiler is already required for the two native helpers), and `ggml-base.en.bin` (141 MiB) is fetched at a **pinned Hugging Face revision** verified against a SHA-256. No installer, no first-run downloader, one model.

### README
- **"Actually zero setup ... ship bundled with the installer"** was false three ways: there is no installer ([#27](https://github.com/Nabzx/openstream/issues/27)), models are fetched rather than bundled, and source-only is the *maximum*-setup option. Repositioned to "build it once, then nothing to set up".
- The speech-to-text line described a **prebuilt binary that does not exist** for our target.
- The **local LLM cleanup pass** line still presented Llama 3.2 3B as in the dictation path. Split into a rules-engine cleanup line ([#24](https://github.com/Nabzx/openstream/issues/24)) and a Phase 3 rewrite-model line that requires an Apache 2.0 / MIT, ungated model ([#32](https://github.com/Nabzx/openstream/issues/32)), with acquisition left open to [#52](https://github.com/Nabzx/openstream/issues/52).
- The **model-size setting** is gone.

### ROADMAP
- Phase 0 and Phase 2 Track A describe the build-time compile plus verified fetch; **no first-launch download, no progress UI**.
- The multiple-model-sizes item is struck: it existed so low-RAM Macs could dodge the 2 GB LLM that left the dictation path, and `small.en` would risk the sub-1s budget.
- `llama-server` plumbing moved from Phase 2 Track B to Phase 3 Track B (following #24 and #32) and no longer names Llama 3.2.
- Phase 4 settings UI loses "model choice".

### Deliberately untouched
- The **native-helpers** architecture line in README - open PR #34 owns it.
- ROADMAP's **code signing / Homebrew cask / release automation** lines. Those are outstanding fallout from [#27](https://github.com/Nabzx/openstream/issues/27) and [#37](https://github.com/Nabzx/openstream/issues/37), not from #30.