### PR TITLE
prototype: TCC attribution probe for two native helpers (#46)

### DIFF
--- a/prototypes/tcc-attribution-46/.gitignore
+++ b/prototypes/tcc-attribution-46/.gitignore
@@ -1,0 +1,4 @@
+# PROTOTYPE - throwaway spike for issue #46.
+# The built bundle and the Electron runtime are both reproducible from build.sh.
+build/
+vendor/

--- a/prototypes/tcc-attribution-46/README.md
+++ b/prototypes/tcc-attribution-46/README.md
@@ -1,0 +1,133 @@
+# TCC attribution probe (issue #46)
+
+PROTOTYPE. Throwaway code that answers one question. Not a native helper, not
+production, no tests, do not build on this.
+
+## The question
+
+Does each native helper hold its own Accessibility and Input Monitoring grant,
+or does the Electron host hold them on the helpers' behalf?
+
+Issue #26 settled on **two** helpers split on the permission boundary: a hotkey
+helper (Input Monitoring) and an accessibility helper (Accessibility), both
+spawned by the Electron main process over stdio. Two macOS mechanisms point
+opposite ways about who the resulting TCC entry belongs to:
+
+- The **responsible process** mechanism attributes a spawned child's TCC
+  requests to the parent GUI app, which would put all the grants on the
+  Electron bundle.
+- **Accessibility and Input Monitoring** appear to be checked against the
+  *calling* binary's code requirement, which would give each helper its own
+  entry keyed to its own CDHash.
+
+This cannot be settled by reading: sources conflict, and the TCC databases are
+SIP-protected. So the artifact is an experiment, not a demo.
+
+This is neither of the prototype skill's two standard shapes (a clickable state
+model, or UI variants), for the same reason as
+`prototypes/context-detection-spike`: the question is empirical and about real
+OS behaviour, so the artifact is an instrumented build you drive by hand.
+
+## Why the answer matters
+
+- **Blast radius per rebuild.** If the helpers hold their own grants, a rebuild
+  touching only the Electron JavaScript breaks nothing, because issue #40 makes
+  helper builds deterministic. If the Electron host holds them, every
+  JavaScript change drops every grant and the deterministic helper build buys
+  nothing.
+- **Whether `tccutil reset` is usable at all.** It needs a bundle identifier
+  known to LaunchServices. A bare helper binary has none.
+- **What the grant check actually probes.** The build-script warning and the
+  app start gate have to test the right binary.
+
+## What gets built
+
+`./build.sh` produces `build/TCCProbe.app`: a real, ad-hoc-signed Electron
+bundle with its own bundle id (`dev.openstream.prototype.tccprobe`), containing
+two stub Swift helpers at `Contents/Resources/helpers/`. The Electron main
+process spawns them over stdio, exactly like the planned architecture.
+
+Three subjects, each reporting its own grant state:
+
+| Subject | Grant probed | Reported via | Functionally probed via |
+| --- | --- | --- | --- |
+| `TCCProbe.app` (Electron host) | Accessibility, Microphone | `systemPreferences` | - |
+| `axhelper` | Accessibility | `AXIsProcessTrusted()` | a real `AXUIElementCopyAttributeValue` on the frontmost app |
+| `hotkeyhelper` | Input Monitoring | `IOHIDCheckAccess(kIOHIDRequestTypeListenEvent)` | a real listen-only `CGEvent` tap |
+
+Reported and functional are recorded separately because they can disagree, and
+when they do the functional one is the truth.
+
+Each helper also prints the three fields the question turns on:
+
+- **`cdhash`** - the code identity a per-helper TCC entry would be keyed to.
+- **`bundleIdentifier`** - `null` for a bare Mach-O. If it is null, `tccutil
+  reset` has no target for that binary.
+- **`responsiblePid` / `responsibleExecutable`** - the process macOS holds
+  responsible for this process's TCC requests, read through
+  `responsibility_get_pid_responsible_for_pid`. This is the responsible-process
+  mechanism itself, read directly rather than inferred.
+
+## Running it
+
+```sh
+./build.sh                 # full build; fetches Electron once into vendor/
+open build/TCCProbe.app    # the window: buttons, prompts, full state per click
+./readstate.sh <label>     # no UI: dump all three subjects to logs/ as JSON
+```
+
+The window reads all three subjects on launch and after every button click, and
+"Copy report to clipboard" dumps every reading as JSON for pasting into
+RESULTS.md. `readstate.sh` captures the same readings without a human clicking,
+which is what you want immediately after a rebuild.
+
+**Always launch through `open` or `readstate.sh`, never by running the binary
+from a shell.** Starting it from a terminal makes that terminal's GUI app
+(Terminal, iTerm, VS Code) the *responsible process*, and responsible-process
+attribution is the exact mechanism under test. Measured, both ways:
+
+```
+launched from a VS Code terminal   responsible = /Applications/Visual Studio Code.app/...
+launched via `open`                responsible = .../TCCProbe.app/Contents/MacOS/TCCProbe
+```
+
+`logs/state.log` accumulates the CDHash of the app and both helpers after every
+build, so the two rebuild arms are auditable after the fact.
+
+## The experiment
+
+Steps 3 and 5 need a human at the machine: the grant has to be given in System
+Settings, and the System Settings list itself is a large part of the evidence.
+
+1. `./build.sh`
+2. `./readstate.sh baseline`. Expect everything denied. This is the pre-grant
+   baseline and needs no clicking.
+3. **(human)** `open build/TCCProbe.app`, click **Spawn axhelper (--prompt)**,
+   then **Spawn hotkeyhelper (--prompt)**. Grant both in System Settings >
+   Privacy & Security.
+   **Record what the list names**: an entry called `TCCProbe`, or entries called
+   `axhelper` / `hotkeyhelper`. That single observation answers most of the
+   question on its own.
+4. `./readstate.sh granted`. Confirm everything now passes, so the baseline is
+   a real grant and not a stale prompt.
+5. `./rebuild-js.sh` then `./readstate.sh arm1-js` - **arm 1**, JavaScript
+   changes, helpers untouched. The script asserts the helper CDHashes did not
+   move.
+   - Helpers still pass, host drops → grants are **per-helper**.
+   - All three drop → the **Electron bundle** holds them.
+6. `./rebuild-helpers.sh` then `./readstate.sh arm2-helpers` - **arm 2**,
+   helpers recompiled with a new build tag so their CDHash really moves,
+   JavaScript untouched. The script asserts the CDHash moved.
+   - Helpers now fail → the entry is keyed to the helper's own code identity.
+   - Helpers still pass → it is not.
+7. Try `tccutil reset Accessibility dev.openstream.prototype.tccprobe` and note
+   whether it clears the helper's state, the host's, or nothing.
+
+Record each step in `RESULTS.md` as it happens. Every cell there must be a real
+observation; anything not measured says so.
+
+## Cleaning up
+
+The prototype grants are real TCC entries. When finished, remove `TCCProbe`,
+`axhelper` and `hotkeyhelper` from System Settings > Privacy & Security >
+Accessibility and > Input Monitoring, and delete `build/`.

--- a/prototypes/tcc-attribution-46/RESULTS.md
+++ b/prototypes/tcc-attribution-46/RESULTS.md
@@ -1,0 +1,105 @@
+# Results (issue #46)
+
+Status: **harness verified, experiment not yet run.** The build, both helpers,
+the Electron host, the headless capture and both rebuild arms have been run and
+checked. The experiment itself needs a human at the machine, because the grant
+must be given in System Settings and the System Settings list is itself the
+main evidence.
+
+Every cell below must be a real observation from a run. Cells that were not
+measured say so. Nothing here is inferred.
+
+Machine: macOS 15.6.1 (Darwin 24.6.0), Apple Silicon, Swift 6.1.2,
+Electron (see `app/package.json`).
+
+## What is already measured
+
+These came from running the helpers directly, before any grant existed. They
+are real, but they are the setup, not the answer.
+
+| Observation | Value | Reading |
+| --- | --- | --- |
+| `axhelper` `bundleIdentifier` | `null` | A bare Mach-O helper has no bundle identifier, so `tccutil reset <id>` has **no target** for it. If grants attach per-helper, there is no supported way to clear a stale entry; the user must remove it by hand in System Settings. |
+| `hotkeyhelper` `bundleIdentifier` | `null` | Same. |
+| `responsibleExecutable`, both helpers, app launched via `open` | `.../TCCProbe.app/Contents/MacOS/TCCProbe` | **The responsible-process mechanism does attribute both spawned helpers to the Electron host.** Each helper's immediate parent is also TCCProbe, and macOS names TCCProbe responsible for its TCC requests. So the mechanism from the issue is real and active here. It does *not* yet follow that Accessibility and Input Monitoring key on it - that is what steps 3-6 decide. |
+| `responsibleExecutable`, same binaries, launched from a VS Code terminal | `/Applications/Visual Studio Code.app/Contents/MacOS/Code` | Responsibility walks up to the ancestor **GUI app**, not the immediate parent shell. This is a methodology hazard, not a finding: launching the probe from a terminal silently substitutes the terminal for the app under test. `readstate.sh` launches via `open` for this reason. |
+| `adhocSigned` | `true` for both helpers | Ad-hoc signing works and each helper carries a distinct `signingIdentifier` and CDHash. |
+| Arm 1 invariant (`rebuild-js.sh`) | helper CDHashes unchanged: `00667d0a…`, `b57a6437…` | The JS-only rebuild is genuinely helper-neutral even though the whole bundle is re-signed `--deep`. Ad-hoc signing is deterministic over identical content, so arm 1 isolates the variable it claims to. |
+| Arm 2 invariant (`rebuild-helpers.sh`) | axhelper CDHash moved `00667d0a…` → `c997c749…`, and its `signingIdentifier` moved too | The helper-only rebuild really does change helper code identity, including the ad-hoc signing identifier and therefore the designated requirement. Arm 2 isolates its variable. |
+
+## Step 2 - baseline, before any grant
+
+Not measured yet.
+
+| Subject | CDHash | Reported | Functional |
+| --- | --- | --- | --- |
+| `TCCProbe.app` | - | - | - |
+| `axhelper` | - | - | - |
+| `hotkeyhelper` | - | - | - |
+
+## Step 3 - what System Settings names
+
+**The single most decisive observation.** Not measured yet.
+
+| Pane | Entry name(s) that appeared | Names the `.app` or the helper binary? |
+| --- | --- | --- |
+| Accessibility | - | - |
+| Input Monitoring | - | - |
+
+## Step 4 - after granting, before any rebuild
+
+Not measured yet.
+
+| Subject | Reported | Functional |
+| --- | --- | --- |
+| `TCCProbe.app` | - | - |
+| `axhelper` | - | - |
+| `hotkeyhelper` | - | - |
+
+## Step 5 - arm 1: JavaScript rebuilt, helpers untouched
+
+Not measured yet. `rebuild-js.sh` asserts the helper CDHashes did not move;
+record whether that assertion held.
+
+| Subject | CDHash moved? | Reported | Functional |
+| --- | --- | --- | --- |
+| `TCCProbe.app` | - | - | - |
+| `axhelper` | - | - | - |
+| `hotkeyhelper` | - | - | - |
+
+Reading: helpers still pass and the host drops → grants are per-helper.
+All three drop → the Electron bundle holds them.
+
+## Step 6 - arm 2: helpers rebuilt, JavaScript untouched
+
+Not measured yet. `rebuild-helpers.sh` asserts the helper CDHash did move;
+record whether that assertion held.
+
+| Subject | CDHash moved? | Reported | Functional |
+| --- | --- | --- | --- |
+| `TCCProbe.app` | - | - | - |
+| `axhelper` | - | - | - |
+| `hotkeyhelper` | - | - | - |
+
+Reading: helpers now fail → the entry is keyed to the helper's own code
+identity. Helpers still pass → it is not.
+
+## Step 7 - `tccutil reset`
+
+Not measured yet.
+
+| Command | Exit status | What it actually cleared |
+| --- | --- | --- |
+| `tccutil reset Accessibility dev.openstream.prototype.tccprobe` | - | - |
+| `tccutil reset ListenEvent dev.openstream.prototype.tccprobe` | - | - |
+
+## Verdict
+
+Not reached. The three answers this ticket owes issue #23:
+
+1. Which binary each grant attaches to - **open**.
+2. Whether `tccutil reset` has a usable target - **partially answered**: the
+   helpers have no bundle identifier, so if grants attach per-helper the answer
+   is no. Confirmed by measurement above, but conditional on step 5/6.
+3. How much of the per-rebuild problem the deterministic helper build removes -
+   **open**, follows from 1.

--- a/prototypes/tcc-attribution-46/app/src/index.html
+++ b/prototypes/tcc-attribution-46/app/src/index.html
@@ -1,0 +1,123 @@
+<!doctype html>
+<!-- PROTOTYPE - throwaway spike for issue #46. -->
+<meta charset="utf-8" />
+<title>TCCProbe</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font: 13px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; margin: 0; padding: 16px 20px; }
+  h1 { font-size: 15px; margin: 0 0 2px; }
+  .sub { opacity: .65; margin: 0 0 14px; }
+  .bar { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 14px; }
+  button { font: inherit; padding: 6px 10px; border-radius: 6px; cursor: pointer; }
+  .row { display: grid; grid-template-columns: 220px 1fr; gap: 10px; padding: 3px 0; border-bottom: 1px solid rgba(128,128,128,.18); }
+  .k { opacity: .6; }
+  .v { overflow-wrap: anywhere; }
+  .yes { color: #1a7f37; font-weight: 600; }
+  .no  { color: #cf222e; font-weight: 600; }
+  .card { border: 1px solid rgba(128,128,128,.3); border-radius: 8px; padding: 12px 14px; margin-bottom: 12px; }
+  .card h2 { font-size: 13px; margin: 0 0 8px; }
+  pre { white-space: pre-wrap; margin: 8px 0 0; opacity: .8; }
+  .hint { opacity: .6; margin: 14px 0 0; }
+</style>
+
+<h1>TCC attribution probe - PROTOTYPE, issue #46</h1>
+<p class="sub">
+  Which binary holds the grant: the Electron bundle, or each spawned helper?
+  JS build tag <b>JS_BUILD_TAG_PLACEHOLDER</b>.
+  Every click re-reads the full state and appends a card below.
+</p>
+
+<div class="bar">
+  <button data-act="host">Read host state</button>
+  <button data-act="ax">Spawn axhelper (check only)</button>
+  <button data-act="ax-prompt">Spawn axhelper (--prompt)</button>
+  <button data-act="hk">Spawn hotkeyhelper (check only)</button>
+  <button data-act="hk-prompt">Spawn hotkeyhelper (--prompt)</button>
+  <button data-act="host-prompt">Host prompts for Accessibility</button>
+  <button data-act="all">Read everything</button>
+  <button data-act="copy">Copy report to clipboard</button>
+  <button data-act="clear">Clear</button>
+</div>
+
+<div id="out"></div>
+<p class="hint">
+  After each rebuild: quit the app fully (Cmd-Q), relaunch it, then click
+  &ldquo;Read everything&rdquo;. Compare the CDHash lines with logs/state.log.
+</p>
+
+<script>
+  const { ipcRenderer, clipboard } = require('electron');
+  const out = document.getElementById('out');
+  const collected = [];
+
+  const BOOLEAN_KEYS = new Set([
+    'reportedTrusted', 'functionallyTrusted', 'promptedTrusted',
+    'reportedGranted', 'functionallyGranted', 'promptedGranted',
+    'adhocSigned', 'prompted',
+  ]);
+
+  function flatten(obj, prefix = '') {
+    const rows = [];
+    for (const [k, v] of Object.entries(obj || {})) {
+      const key = prefix ? `${prefix}.${k}` : k;
+      if (v && typeof v === 'object' && !Array.isArray(v)) rows.push(...flatten(v, key));
+      else rows.push([key, v]);
+    }
+    return rows;
+  }
+
+  function render(payload) {
+    collected.push(payload);
+    const card = document.createElement('div');
+    card.className = 'card';
+    const title = document.createElement('h2');
+    title.textContent = `${payload.subject}  @ ${new Date().toLocaleTimeString()}`;
+    card.appendChild(title);
+    for (const [k, v] of flatten(payload)) {
+      if (k === 'subject') continue;
+      const row = document.createElement('div');
+      row.className = 'row';
+      const kd = document.createElement('div'); kd.className = 'k'; kd.textContent = k;
+      const vd = document.createElement('div'); vd.className = 'v';
+      const leaf = k.split('.').pop();
+      if (typeof v === 'boolean' && BOOLEAN_KEYS.has(leaf)) {
+        vd.innerHTML = `<span class="${v ? 'yes' : 'no'}">${v ? 'YES' : 'NO'}</span>`;
+      } else {
+        vd.textContent = v === null ? 'null' : String(v);
+      }
+      row.append(kd, vd);
+      card.appendChild(row);
+    }
+    out.prepend(card);
+  }
+
+  const actions = {
+    host: () => ipcRenderer.invoke('host-state'),
+    ax: () => ipcRenderer.invoke('run-helper', 'axhelper', []),
+    'ax-prompt': () => ipcRenderer.invoke('run-helper', 'axhelper', ['--prompt']),
+    hk: () => ipcRenderer.invoke('run-helper', 'hotkeyhelper', []),
+    'hk-prompt': () => ipcRenderer.invoke('run-helper', 'hotkeyhelper', ['--prompt']),
+    'host-prompt': () => ipcRenderer.invoke('host-prompt-accessibility'),
+  };
+
+  document.querySelector('.bar').addEventListener('click', async (e) => {
+    const act = e.target.dataset.act;
+    if (!act) return;
+    if (act === 'clear') { out.innerHTML = ''; collected.length = 0; return; }
+    if (act === 'copy') {
+      clipboard.writeText(JSON.stringify(collected, null, 2));
+      e.target.textContent = 'Copied';
+      setTimeout(() => { e.target.textContent = 'Copy report to clipboard'; }, 1200);
+      return;
+    }
+    if (act === 'all') {
+      for (const k of ['host', 'ax', 'hk']) render(await actions[k]());
+      return;
+    }
+    render(await actions[act]());
+  });
+
+  // Surface the state on launch without a click, so a relaunch after a rebuild
+  // is self-documenting.
+  (async () => { for (const k of ['host', 'ax', 'hk']) render(await actions[k]()); })();
+</script>

--- a/prototypes/tcc-attribution-46/app/src/main.js
+++ b/prototypes/tcc-attribution-46/app/src/main.js
@@ -1,0 +1,115 @@
+// PROTOTYPE - throwaway spike for issue #46. No error handling beyond what
+// makes it runnable, no abstractions, no tests. Do not build on this.
+//
+// The Electron host is one of the three subjects of the experiment, so it
+// reports its own grant state alongside whatever the helpers report. If the
+// host says trusted and a helper says not (or the reverse), that difference is
+// the answer.
+//
+// Two ways to run it:
+//   open build/TCCProbe.app            window, buttons, prompts
+//   ./readstate.sh                     --selftest, prints the same JSON, no UI
+const { app, BrowserWindow, ipcMain, systemPreferences } = require('electron');
+const { execFile } = require('node:child_process');
+const path = require('node:path');
+
+const JS_BUILD_TAG = 'JS_BUILD_TAG_PLACEHOLDER';
+const HELPER_DIR = path.join(process.resourcesPath, 'helpers');
+
+function run(cmd, args) {
+  return new Promise((resolve) => {
+    execFile(cmd, args, { timeout: 20000 }, (err, stdout, stderr) => {
+      resolve({ err: err ? String(err.message) : null, stdout, stderr });
+    });
+  });
+}
+
+// codesign is the only readable source of truth for a running binary's CDHash;
+// the TCC databases themselves are SIP-protected.
+async function codeIdentity(target) {
+  const { stdout, stderr } = await run('/usr/bin/codesign', ['-dvvv', target]);
+  const text = `${stdout}\n${stderr}`;
+  const pick = (key) => (text.match(new RegExp(`^${key}=(.*)$`, 'm')) || [])[1] || null;
+  return {
+    path: target,
+    cdhash: pick('CDHash'),
+    signingIdentifier: pick('Identifier'),
+    teamIdentifier: pick('TeamIdentifier'),
+  };
+}
+
+async function hostState() {
+  return {
+    subject: 'electron host (TCCProbe.app)',
+    jsBuildTag: JS_BUILD_TAG,
+    pid: process.pid,
+    execPath: process.execPath,
+    bundleIdentifier: 'dev.openstream.prototype.tccprobe',
+    accessibility: {
+      // Same API the axhelper calls, asked from inside the Electron process.
+      reportedTrusted: systemPreferences.isTrustedAccessibilityClient(false),
+    },
+    microphone: systemPreferences.getMediaAccessStatus('microphone'),
+    code: await codeIdentity(app.getPath('exe').replace(/\/Contents\/MacOS\/.*$/, '')),
+  };
+}
+
+async function runHelper(name, flags) {
+  const bin = path.join(HELPER_DIR, name);
+  const { err, stdout, stderr } = await run(bin, flags || []);
+  let parsed = null;
+  try {
+    parsed = JSON.parse(stdout.trim().split('\n').pop());
+  } catch (_) { /* leave null, raw output is shown instead */ }
+  return {
+    subject: `${name} (spawned by the Electron main process over stdio)`,
+    invokedAs: [bin, ...(flags || [])].join(' '),
+    spawnError: err,
+    raw: parsed ? null : { stdout, stderr },
+    result: parsed,
+    code: await codeIdentity(bin),
+  };
+}
+
+ipcMain.handle('host-state', hostState);
+ipcMain.handle('run-helper', (_e, name, flags) => runHelper(name, flags));
+ipcMain.handle('host-prompt-accessibility', async () => ({
+  subject: 'electron host prompting for Accessibility',
+  prompted: systemPreferences.isTrustedAccessibilityClient(true),
+}));
+
+const SELFTEST = process.argv.includes('--selftest');
+
+app.whenReady().then(async () => {
+  if (SELFTEST) {
+    // No window: read all three subjects and exit. Used by readstate.sh so a
+    // rebuild arm can be recorded without a human clicking anything.
+    //
+    // The report goes to --out=<path> rather than stdout because readstate.sh
+    // has to launch this through `open`, which gives no usable stdout. It
+    // launches through `open` on purpose: starting the app from a shell makes
+    // the *terminal's* GUI app the responsible process, which contaminates the
+    // one mechanism this experiment is measuring.
+    const report = {
+      capturedAt: new Date().toISOString(),
+      host: await hostState(),
+      axhelper: await runHelper('axhelper', []),
+      hotkeyhelper: await runHelper('hotkeyhelper', []),
+    };
+    const text = JSON.stringify(report, null, 2) + '\n';
+    const outArg = process.argv.find((a) => a.startsWith('--out='));
+    if (outArg) require('node:fs').writeFileSync(outArg.slice('--out='.length), text);
+    else process.stdout.write(text);
+    app.exit(0);
+    return;
+  }
+  const win = new BrowserWindow({
+    width: 1040,
+    height: 860,
+    title: `TCCProbe (js ${JS_BUILD_TAG})`,
+    webPreferences: { nodeIntegration: true, contextIsolation: false },
+  });
+  win.loadFile(path.join(__dirname, 'index.html'));
+});
+
+app.on('window-all-closed', () => app.quit());

--- a/prototypes/tcc-attribution-46/app/src/package.json
+++ b/prototypes/tcc-attribution-46/app/src/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "tccprobe",
+  "private": true,
+  "version": "0.0.0",
+  "main": "main.js"
+}

--- a/prototypes/tcc-attribution-46/build.sh
+++ b/prototypes/tcc-attribution-46/build.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# PROTOTYPE - throwaway spike for issue #46.
+#
+# Full build from scratch: compile both stub helpers, assemble a real Electron
+# .app around them, ad-hoc sign everything, record every CDHash.
+#
+#   ./build.sh                 full build (fetches Electron on first run)
+#   ./build.sh --helpers-only  recompile the helpers only, no Electron
+#
+# Run ./rebuild-js.sh and ./rebuild-helpers.sh afterwards; those are the two
+# experiment arms.
+source "$(cd "$(dirname "$0")" && pwd)/lib.sh"
+
+HELPERS_ONLY=0
+[ "${1:-}" = "--helpers-only" ] && HELPERS_ONLY=1
+
+TAG="$(date -u +%Y%m%d-%H%M%S)-initial"
+
+if [ "$HELPERS_ONLY" = 1 ]; then
+  mkdir -p "$HELPER_DIR"
+  compile_helper axhelper "$TAG"
+  compile_helper hotkeyhelper "$TAG"
+  echo "helpers built at $HELPER_DIR"
+  exit 0
+fi
+
+# 1. Electron runtime. Fetched once from the pinned release into vendor/ and
+#    reused. Deliberately not npm: the `electron` package's postinstall does the
+#    same download behind a hook that gives no progress and hangs silently on a
+#    restricted network. A pinned curl is the direct path and is reproducible.
+ELECTRON_VERSION="32.3.3"
+ELECTRON_DIR="$ROOT/vendor/electron-$ELECTRON_VERSION"
+ELECTRON_SRC="$ELECTRON_DIR/Electron.app"
+if [ ! -d "$ELECTRON_SRC" ]; then
+  echo "==> fetching Electron $ELECTRON_VERSION (one time, ~100MB)"
+  zip="$ROOT/vendor/electron-$ELECTRON_VERSION.zip"
+  mkdir -p "$ROOT/vendor"
+  curl -fL --progress-bar -o "$zip" \
+    "https://github.com/electron/electron/releases/download/v$ELECTRON_VERSION/electron-v$ELECTRON_VERSION-darwin-arm64.zip"
+  mkdir -p "$ELECTRON_DIR"
+  ditto -x -k "$zip" "$ELECTRON_DIR"
+  rm -f "$zip"
+fi
+
+# 2. Assemble the bundle from a pristine copy of the Electron runtime.
+echo "==> assembling $APP"
+rm -rf "$APP"
+mkdir -p "$BUILD"
+cp -R "$ELECTRON_SRC" "$APP"
+rm -rf "$APP/Contents/Resources/default_app.asar"
+
+# Give the bundle its own identity. The bundle id is what `tccutil reset` would
+# need if the grants attach to the .app rather than to the helpers.
+/usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier $BUNDLE_ID" "$APP/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleName TCCProbe" "$APP/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleDisplayName TCCProbe" "$APP/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleExecutable TCCProbe" "$APP/Contents/Info.plist"
+mv "$APP/Contents/MacOS/Electron" "$APP/Contents/MacOS/TCCProbe"
+# Usage strings, so a prompt from the host is attributable to this app.
+/usr/libexec/PlistBuddy -c "Add :NSMicrophoneUsageDescription string 'PROTOTYPE: TCC attribution spike (issue #46)'" "$APP/Contents/Info.plist" 2>/dev/null || true
+
+# 3. App JS.
+"$ROOT/sync-js.sh" --no-sign
+
+# 4. Helpers.
+compile_helper axhelper "$TAG"
+compile_helper hotkeyhelper "$TAG"
+
+# 5. Sign. Helpers were signed individually inside compile_helper; --deep
+#    re-signs them as part of the bundle, and record() shows whether that moved
+#    their CDHash.
+echo "==> signing"
+sign_app
+
+record "build.sh (initial full build)"
+echo "built: $APP"
+echo "open it with:  open '$APP'"

--- a/prototypes/tcc-attribution-46/helpers/axhelper.swift
+++ b/prototypes/tcc-attribution-46/helpers/axhelper.swift
@@ -1,0 +1,61 @@
+// PROTOTYPE - throwaway spike for issue #46.
+//
+// Stub for the planned *accessibility* helper. It does nothing the product
+// needs; it only answers "does this binary hold Accessibility trust?" in two
+// ways, because they can disagree:
+//
+//   reported   - AXIsProcessTrusted(), what the API claims.
+//   functional - an actual AXUIElementCopyAttributeValue against the frontmost
+//                app. A grant that reports true but returns kAXErrorAPIDisabled
+//                is not a grant, and only the functional probe catches that.
+//
+// Flags: --prompt  ask for the grant (AXIsProcessTrustedWithOptions).
+import Foundation
+import ApplicationServices
+import AppKit
+
+func axErrorName(_ e: AXError) -> String {
+    switch e {
+    case .success: return "success"
+    case .apiDisabled: return "kAXErrorAPIDisabled (not trusted)"
+    case .noValue: return "kAXErrorNoValue (nothing focused)"
+    case .cannotComplete: return "kAXErrorCannotComplete (app did not answer)"
+    case .attributeUnsupported: return "kAXErrorAttributeUnsupported"
+    case .invalidUIElement: return "kAXErrorInvalidUIElement"
+    case .notImplemented: return "kAXErrorNotImplemented"
+    default: return "AXError(\(e.rawValue))"
+    }
+}
+
+// Bumped by rebuild-helpers.sh so the recompiled binary differs in content and
+// therefore in CDHash. This constant is the whole point of the second rebuild.
+let buildTag = "BUILD_TAG_PLACEHOLDER"
+
+let args = Array(CommandLine.arguments.dropFirst())
+let wantPrompt = args.contains("--prompt")
+
+var out = identityFields(role: "axhelper")
+out["buildTag"] = buildTag
+out["grant"] = "Accessibility"
+
+if wantPrompt {
+    let opts = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true] as CFDictionary
+    out["promptedTrusted"] = AXIsProcessTrustedWithOptions(opts)
+}
+out["reportedTrusted"] = AXIsProcessTrusted()
+
+// Functional probe: read the focused element of whatever is frontmost.
+if let front = NSWorkspace.shared.frontmostApplication {
+    out["frontmostApp"] = front.bundleIdentifier ?? front.localizedName ?? "<unknown>"
+    let app = AXUIElementCreateApplication(front.processIdentifier)
+    var focused: CFTypeRef?
+    let err = AXUIElementCopyAttributeValue(app, kAXFocusedUIElementAttribute as CFString, &focused)
+    out["functionalAXError"] = Int(err.rawValue)
+    out["functionalAXErrorName"] = axErrorName(err)
+    out["functionallyTrusted"] = (err != .apiDisabled && err != .notImplemented)
+} else {
+    out["functionallyTrusted"] = false
+    out["functionalAXErrorName"] = "noFrontmostApp"
+}
+
+emit(out)

--- a/prototypes/tcc-attribution-46/helpers/hotkeyhelper.swift
+++ b/prototypes/tcc-attribution-46/helpers/hotkeyhelper.swift
@@ -1,0 +1,53 @@
+// PROTOTYPE - throwaway spike for issue #46.
+//
+// Stub for the planned *hotkey* helper, the Input Monitoring half of the
+// permission split. Same two-layer check as axhelper:
+//
+//   reported   - IOHIDCheckAccess(kIOHIDRequestTypeListenEvent).
+//   functional - actually creating a listen-only CGEvent tap. Input Monitoring
+//                is what a global hotkey listener really needs, and the tap
+//                either gets created or it does not.
+//
+// Flags: --prompt  ask for the grant (IOHIDRequestAccess).
+import Foundation
+import IOKit.hid
+import CoreGraphics
+
+func accessName(_ t: IOHIDAccessType) -> String {
+    switch t {
+    case kIOHIDAccessTypeGranted: return "granted"
+    case kIOHIDAccessTypeDenied: return "denied"
+    case kIOHIDAccessTypeUnknown: return "unknown (never asked)"
+    default: return "IOHIDAccessType(\(t.rawValue))"
+    }
+}
+
+let buildTag = "BUILD_TAG_PLACEHOLDER"
+
+let args = Array(CommandLine.arguments.dropFirst())
+let wantPrompt = args.contains("--prompt")
+
+var out = identityFields(role: "hotkeyhelper")
+out["buildTag"] = buildTag
+out["grant"] = "Input Monitoring"
+
+if wantPrompt {
+    out["promptedGranted"] = IOHIDRequestAccess(kIOHIDRequestTypeListenEvent)
+}
+
+let access = IOHIDCheckAccess(kIOHIDRequestTypeListenEvent)
+out["reportedAccess"] = accessName(access)
+out["reportedGranted"] = (access == kIOHIDAccessTypeGranted)
+
+// Functional probe: a listen-only tap on keyDown. Returns nil without the grant.
+let mask = (1 << CGEventType.keyDown.rawValue)
+let tap = CGEvent.tapCreate(tap: .cgSessionEventTap,
+                            place: .headInsertEventTap,
+                            options: .listenOnly,
+                            eventsOfInterest: CGEventMask(mask),
+                            callback: { _, _, event, _ in Unmanaged.passUnretained(event) },
+                            userInfo: nil)
+out["functionallyGranted"] = (tap != nil)
+if let tap { CFMachPortInvalidate(tap) }
+
+emit(out)

--- a/prototypes/tcc-attribution-46/helpers/identity.swift
+++ b/prototypes/tcc-attribution-46/helpers/identity.swift
@@ -1,0 +1,81 @@
+// PROTOTYPE - throwaway spike for issue #46. Not a native helper, not production.
+//
+// Shared identity block. Every helper prints this so the run records *which
+// binary* was asking, next to what the OS answered. The three fields that
+// matter to the question:
+//
+//   cdhash      - the code identity TCC would key an entry to, if entries are
+//                 per-helper.
+//   bundleId    - nil for a bare Mach-O. If it is nil, `tccutil reset` has no
+//                 target for this binary, because tccutil takes a bundle id
+//                 known to LaunchServices.
+//   responsible - the pid macOS holds *responsible* for this process's TCC
+//                 requests. If that is the Electron .app rather than the
+//                 helper itself, the responsible-process mechanism is in play.
+import Foundation
+import Security
+
+func selfSigningInfo() -> (cdhash: String, identifier: String, adhoc: Bool) {
+    var code: SecCode?
+    guard SecCodeCopySelf([], &code) == errSecSuccess, let code else {
+        return ("<unavailable>", "<unavailable>", false)
+    }
+    var stat: SecStaticCode?
+    guard SecCodeCopyStaticCode(code, [], &stat) == errSecSuccess, let stat else {
+        return ("<unavailable>", "<unavailable>", false)
+    }
+    var infoRef: CFDictionary?
+    let flags = SecCSFlags(rawValue: kSecCSSigningInformation)
+    guard SecCodeCopySigningInformation(stat, flags, &infoRef) == errSecSuccess,
+          let info = infoRef as? [String: Any] else {
+        return ("<unavailable>", "<unavailable>", false)
+    }
+    let hash = (info[kSecCodeInfoUnique as String] as? Data)
+        .map { $0.map { String(format: "%02x", $0) }.joined() } ?? "<unsigned>"
+    let ident = info[kSecCodeInfoIdentifier as String] as? String ?? "<none>"
+    // kSecCodeSignatureAdhoc == 0x0002 in the code-signing flags word.
+    let cs = info[kSecCodeInfoFlags as String] as? UInt32 ?? 0
+    return (hash, ident, cs & 0x0002 != 0)
+}
+
+// Private libsystem call behind the "responsible process" mechanism. Resolved
+// at runtime because it has no public header.
+func responsiblePid(for pid: pid_t) -> pid_t {
+    typealias Fn = @convention(c) (pid_t) -> pid_t
+    guard let sym = dlsym(UnsafeMutableRawPointer(bitPattern: -2), // RTLD_DEFAULT
+                          "responsibility_get_pid_responsible_for_pid") else { return -1 }
+    return unsafeBitCast(sym, to: Fn.self)(pid)
+}
+
+func processName(_ pid: pid_t) -> String {
+    guard pid > 0 else { return "<none>" }
+    var buf = [CChar](repeating: 0, count: 4096)
+    guard proc_pidpath(pid, &buf, UInt32(buf.count)) > 0 else { return "<unknown>" }
+    return String(cString: buf)
+}
+
+func identityFields(role: String) -> [String: Any] {
+    let sign = selfSigningInfo()
+    let me = getpid()
+    let resp = responsiblePid(for: me)
+    return [
+        "role": role,
+        "pid": Int(me),
+        "executable": ProcessInfo.processInfo.arguments.first ?? "<none>",
+        "resolvedExecutable": processName(me),
+        "cdhash": sign.cdhash,
+        "signingIdentifier": sign.identifier,
+        "adhocSigned": sign.adhoc,
+        "bundleIdentifier": Bundle.main.bundleIdentifier ?? NSNull(),
+        "parentPid": Int(getppid()),
+        "parentExecutable": processName(getppid()),
+        "responsiblePid": Int(resp),
+        "responsibleExecutable": processName(resp),
+    ]
+}
+
+func emit(_ dict: [String: Any]) {
+    let data = try! JSONSerialization.data(withJSONObject: dict, options: [.sortedKeys])
+    FileHandle.standardOutput.write(data)
+    FileHandle.standardOutput.write("\n".data(using: .utf8)!)
+}

--- a/prototypes/tcc-attribution-46/lib.sh
+++ b/prototypes/tcc-attribution-46/lib.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# PROTOTYPE - throwaway spike for issue #46. Shared build/record helpers.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD="$ROOT/build"
+APP="$BUILD/TCCProbe.app"
+HELPER_DIR="$APP/Contents/Resources/helpers"
+LOGS="$ROOT/logs"
+BUNDLE_ID="dev.openstream.prototype.tccprobe"
+
+mkdir -p "$BUILD" "$LOGS"
+
+# Compile one helper. Swift only allows top-level statements in main.swift, so
+# the entry source is copied under that name into a scratch dir.
+#   compile_helper <name> <build-tag>
+compile_helper() {
+  local name="$1" tag="$2"
+  local tmp; tmp="$(mktemp -d)"
+  cp "$ROOT/helpers/identity.swift" "$tmp/identity.swift"
+  sed "s/BUILD_TAG_PLACEHOLDER/$tag/" "$ROOT/helpers/$name.swift" > "$tmp/main.swift"
+  mkdir -p "$HELPER_DIR"
+  swiftc -O -o "$HELPER_DIR/$name" "$tmp/identity.swift" "$tmp/main.swift"
+  rm -rf "$tmp"
+  # Ad-hoc sign the helper on its own. This is the identity the question is
+  # about: if TCC keys entries per-helper, this CDHash is the key.
+  codesign --force --sign - --timestamp=none "$HELPER_DIR/$name"
+}
+
+# Ad-hoc sign the Electron bundle. Inner code first, outer bundle last, which is
+# what --deep does; the helpers are re-signed by it but ad-hoc signing is
+# deterministic over identical content, so their CDHash must not move. record()
+# checks that rather than assuming it.
+sign_app() {
+  codesign --force --deep --sign - --timestamp=none "$APP"
+}
+
+cdhash_of() {
+  codesign -dvvv "$1" 2>&1 | awk -F'=' '/^CDHash=/{print $2}'
+}
+
+ident_of() {
+  codesign -dvvv "$1" 2>&1 | awk -F'=' '/^Identifier=/{print $2}'
+}
+
+# Append one full snapshot of every code identity to logs/state.log and echo it.
+#   record <label>
+record() {
+  local label="$1"
+  local out="$LOGS/state.log"
+  {
+    echo "=== $label  ($(date -u +%Y-%m-%dT%H:%M:%SZ))"
+    printf '%-28s %-46s %s\n' "TARGET" "CDHASH" "SIGNING IDENTIFIER"
+    printf '%-28s %-46s %s\n' "TCCProbe.app" "$(cdhash_of "$APP")" "$(ident_of "$APP")"
+    for h in axhelper hotkeyhelper; do
+      [ -f "$HELPER_DIR/$h" ] || continue
+      printf '%-28s %-46s %s\n' "$h" "$(cdhash_of "$HELPER_DIR/$h")" "$(ident_of "$HELPER_DIR/$h")"
+    done
+    echo
+  } | tee -a "$out"
+}

--- a/prototypes/tcc-attribution-46/logs/state-20260822-152558-launched-from-terminal-CONTAMINATED.json
+++ b/prototypes/tcc-attribution-46/logs/state-20260822-152558-launched-from-terminal-CONTAMINATED.json
@@ -1,0 +1,84 @@
+{
+  "capturedAt": "2026-08-22T15:25:59.663Z",
+  "host": {
+    "subject": "electron host (TCCProbe.app)",
+    "jsBuildTag": "20260822-152553",
+    "pid": 54956,
+    "execPath": "/Users/zazai/workspace/zazai840/openstream/.claude/worktrees/prototype+tcc-attribution-46/prototypes/tcc-attribution-46/build/TCCProbe.app/Contents/MacOS/TCCProbe",
+    "bundleIdentifier": "dev.openstream.prototype.tccprobe",
+    "accessibility": {
+      "reportedTrusted": false
+    },
+    "microphone": "not-determined",
+    "code": {
+      "path": "/Users/zazai/workspace/zazai840/openstream/.claude/worktrees/prototype+tcc-attribution-46/prototypes/tcc-attribution-46/build/TCCProbe.app",
+      "cdhash": "974380b6aa2e1a19d2be2231598d77babc0377cc",
+      "signingIdentifier": "dev.openstream.prototype.tccprobe",
+      "teamIdentifier": "not set"
+    }
+  },
+  "axhelper": {
+    "subject": "axhelper (spawned by the Electron main process over stdio)",
+    "invokedAs": "/Users/zazai/workspace/zazai840/openstream/.claude/worktrees/prototype+tcc-attribution-46/prototypes/tcc-attribution-46/build/TCCProbe.app/Contents/Resources/helpers/axhelper",
+    "spawnError": null,
+    "raw": null,
+    "result": {
+      "adhocSigned": true,
+      "buildTag": "20260822-152358-initial",
+      "bundleIdentifier": null,
+      "cdhash": "00667d0a09a106ae7012df6aca0ebb8a579803ad",
+      "executable": "/Users/zazai/workspace/zazai840/openstream/.claude/worktrees/prototype+tcc-attribution-46/prototypes/tcc-attribution-46/build/TCCProbe.app/Contents/Resources/helpers/axhelper",
+      "frontmostApp": "com.microsoft.VSCode",
+      "functionalAXError": -25211,
+      "functionalAXErrorName": "kAXErrorAPIDisabled (not trusted)",
+      "functionallyTrusted": false,
+      "grant": "Accessibility",
+      "parentExecutable": "/Users/zazai/workspace/zazai840/openstream/.claude/worktrees/prototype+tcc-attribution-46/prototypes/tcc-attribution-46/build/TCCProbe.app/Contents/MacOS/TCCProbe",
+      "parentPid": 54956,
+      "pid": 54976,
+      "reportedTrusted": false,
+      "resolvedExecutable": "/Users/zazai/workspace/zazai840/openstream/.claude/worktrees/prototype+tcc-attribution-46/prototypes/tcc-attribution-46/build/TCCProbe.app/Contents/Resources/helpers/axhelper",
+      "responsibleExecutable": "/Applications/Visual Studio Code.app/Contents/MacOS/Code",
+      "responsiblePid": 68468,
+      "role": "axhelper",
+      "signingIdentifier": "axhelper-55554944fd4586e3319c3331856477854ed358a2"
+    },
+    "code": {
+      "path": "/Users/zazai/workspace/zazai840/openstream/.claude/worktrees/prototype+tcc-attribution-46/prototypes/tcc-attribution-46/build/TCCProbe.app/Contents/Resources/helpers/axhelper",
+      "cdhash": "00667d0a09a106ae7012df6aca0ebb8a579803ad",
+      "signingIdentifier": "axhelper-55554944fd4586e3319c3331856477854ed358a2",
+      "teamIdentifier": "not set"
+    }
+  },
+  "hotkeyhelper": {
+    "subject": "hotkeyhelper (spawned by the Electron main process over stdio)",
+    "invokedAs": "/Users/zazai/workspace/zazai840/openstream/.claude/worktrees/prototype+tcc-attribution-46/prototypes/tcc-attribution-46/build/TCCProbe.app/Contents/Resources/helpers/hotkeyhelper",
+    "spawnError": null,
+    "raw": null,
+    "result": {
+      "adhocSigned": true,
+      "buildTag": "20260822-152358-initial",
+      "bundleIdentifier": null,
+      "cdhash": "b57a6437926900c3c59de0a287b63f6c8f75c397",
+      "executable": "/Users/zazai/workspace/zazai840/openstream/.claude/worktrees/prototype+tcc-attribution-46/prototypes/tcc-attribution-46/build/TCCProbe.app/Contents/Resources/helpers/hotkeyhelper",
+      "functionallyGranted": false,
+      "grant": "Input Monitoring",
+      "parentExecutable": "/Users/zazai/workspace/zazai840/openstream/.claude/worktrees/prototype+tcc-attribution-46/prototypes/tcc-attribution-46/build/TCCProbe.app/Contents/MacOS/TCCProbe",
+      "parentPid": 54956,
+      "pid": 54978,
+      "reportedAccess": "denied",
+      "reportedGranted": false,
+      "resolvedExecutable": "/Users/zazai/workspace/zazai840/openstream/.claude/worktrees/prototype+tcc-attribution-46/prototypes/tcc-attribution-46/build/TCCProbe.app/Contents/Resources/helpers/hotkeyhelper",
+      "responsibleExecutable": "/Applications/Visual Studio Code.app/Contents/MacOS/Code",
+      "responsiblePid": 68468,
+      "role": "hotkeyhelper",
+      "signingIdentifier": "hotkeyhelper-555549444db69eacc18038c4823262770dc2a523"
+    },
+    "code": {
+      "path": "/Users/zazai/workspace/zazai840/openstream/.claude/worktrees/prototype+tcc-attribution-46/prototypes/tcc-attribution-46/build/TCCProbe.app/Contents/Resources/helpers/hotkeyhelper",
+      "cdhash": "b57a6437926900c3c59de0a287b63f6c8f75c397",
+      "signingIdentifier": "hotkeyhelper-555549444db69eacc18038c4823262770dc2a523",
+      "teamIdentifier": "not set"
+    }
+  }
+}

--- a/prototypes/tcc-attribution-46/logs/state-20260822-152632-baseline-viaopen.json
+++ b/prototypes/tcc-attribution-46/logs/state-20260822-152632-baseline-viaopen.json
@@ -1,0 +1,84 @@
+{
+  "capturedAt": "2026-08-22T15:26:33.707Z",
+  "host": {
+    "subject": "electron host (TCCProbe.app)",
+    "jsBuildTag": "20260822-152631",
+    "pid": 55335,
+    "execPath": "/Users/zazai/workspace/zazai840/openstream/.claude/worktrees/prototype+tcc-attribution-46/prototypes/tcc-attribution-46/build/TCCProbe.app/Contents/MacOS/TCCProbe",
+    "bundleIdentifier": "dev.openstream.prototype.tccprobe",
+    "accessibility": {
+      "reportedTrusted": false
+    },
+    "microphone": "not-determined",
+    "code": {
+      "path": "/Users/zazai/workspace/zazai840/openstream/.claude/worktrees/prototype+tcc-attribution-46/prototypes/tcc-attribution-46/build/TCCProbe.app",
+      "cdhash": "d057b8095a6e3a8ec03ada59044123904d424d27",
+      "signingIdentifier": "dev.openstream.prototype.tccprobe",
+      "teamIdentifier": "not set"
+    }
+  },
+  "axhelper": {
+    "subject": "axhelper (spawned by the Electron main process over stdio)",
+    "invokedAs": "/Users/zazai/workspace/zazai840/openstream/.claude/worktrees/prototype+tcc-attribution-46/prototypes/tcc-attribution-46/build/TCCProbe.app/Contents/Resources/helpers/axhelper",
+    "spawnError": null,
+    "raw": null,
+    "result": {
+      "adhocSigned": true,
+      "buildTag": "20260822-152358-initial",
+      "bundleIdentifier": null,
+      "cdhash": "00667d0a09a106ae7012df6aca0ebb8a579803ad",
+      "executable": "/Users/zazai/workspace/zazai840/openstream/.claude/worktrees/prototype+tcc-attribution-46/prototypes/tcc-attribution-46/build/TCCProbe.app/Contents/Resources/helpers/axhelper",
+      "frontmostApp": "dev.openstream.prototype.tccprobe",
+      "functionalAXError": -25211,
+      "functionalAXErrorName": "kAXErrorAPIDisabled (not trusted)",
+      "functionallyTrusted": false,
+      "grant": "Accessibility",
+      "parentExecutable": "/Users/zazai/workspace/zazai840/openstream/.claude/worktrees/prototype+tcc-attribution-46/prototypes/tcc-attribution-46/build/TCCProbe.app/Contents/MacOS/TCCProbe",
+      "parentPid": 55335,
+      "pid": 55366,
+      "reportedTrusted": false,
+      "resolvedExecutable": "/Users/zazai/workspace/zazai840/openstream/.claude/worktrees/prototype+tcc-attribution-46/prototypes/tcc-attribution-46/build/TCCProbe.app/Contents/Resources/helpers/axhelper",
+      "responsibleExecutable": "/Users/zazai/workspace/zazai840/openstream/.claude/worktrees/prototype+tcc-attribution-46/prototypes/tcc-attribution-46/build/TCCProbe.app/Contents/MacOS/TCCProbe",
+      "responsiblePid": 55335,
+      "role": "axhelper",
+      "signingIdentifier": "axhelper-55554944fd4586e3319c3331856477854ed358a2"
+    },
+    "code": {
+      "path": "/Users/zazai/workspace/zazai840/openstream/.claude/worktrees/prototype+tcc-attribution-46/prototypes/tcc-attribution-46/build/TCCProbe.app/Contents/Resources/helpers/axhelper",
+      "cdhash": "00667d0a09a106ae7012df6aca0ebb8a579803ad",
+      "signingIdentifier": "axhelper-55554944fd4586e3319c3331856477854ed358a2",
+      "teamIdentifier": "not set"
+    }
+  },
+  "hotkeyhelper": {
+    "subject": "hotkeyhelper (spawned by the Electron main process over stdio)",
+    "invokedAs": "/Users/zazai/workspace/zazai840/openstream/.claude/worktrees/prototype+tcc-attribution-46/prototypes/tcc-attribution-46/build/TCCProbe.app/Contents/Resources/helpers/hotkeyhelper",
+    "spawnError": null,
+    "raw": null,
+    "result": {
+      "adhocSigned": true,
+      "buildTag": "20260822-152358-initial",
+      "bundleIdentifier": null,
+      "cdhash": "b57a6437926900c3c59de0a287b63f6c8f75c397",
+      "executable": "/Users/zazai/workspace/zazai840/openstream/.claude/worktrees/prototype+tcc-attribution-46/prototypes/tcc-attribution-46/build/TCCProbe.app/Contents/Resources/helpers/hotkeyhelper",
+      "functionallyGranted": false,
+      "grant": "Input Monitoring",
+      "parentExecutable": "/Users/zazai/workspace/zazai840/openstream/.claude/worktrees/prototype+tcc-attribution-46/prototypes/tcc-attribution-46/build/TCCProbe.app/Contents/MacOS/TCCProbe",
+      "parentPid": 55335,
+      "pid": 55368,
+      "reportedAccess": "denied",
+      "reportedGranted": false,
+      "resolvedExecutable": "/Users/zazai/workspace/zazai840/openstream/.claude/worktrees/prototype+tcc-attribution-46/prototypes/tcc-attribution-46/build/TCCProbe.app/Contents/Resources/helpers/hotkeyhelper",
+      "responsibleExecutable": "/Users/zazai/workspace/zazai840/openstream/.claude/worktrees/prototype+tcc-attribution-46/prototypes/tcc-attribution-46/build/TCCProbe.app/Contents/MacOS/TCCProbe",
+      "responsiblePid": 55335,
+      "role": "hotkeyhelper",
+      "signingIdentifier": "hotkeyhelper-555549444db69eacc18038c4823262770dc2a523"
+    },
+    "code": {
+      "path": "/Users/zazai/workspace/zazai840/openstream/.claude/worktrees/prototype+tcc-attribution-46/prototypes/tcc-attribution-46/build/TCCProbe.app/Contents/Resources/helpers/hotkeyhelper",
+      "cdhash": "b57a6437926900c3c59de0a287b63f6c8f75c397",
+      "signingIdentifier": "hotkeyhelper-555549444db69eacc18038c4823262770dc2a523",
+      "teamIdentifier": "not set"
+    }
+  }
+}

--- a/prototypes/tcc-attribution-46/logs/state-20260822-152843-baseline.json
+++ b/prototypes/tcc-attribution-46/logs/state-20260822-152843-baseline.json
@@ -1,0 +1,84 @@
+{
+  "capturedAt": "2026-08-22T15:28:45.033Z",
+  "host": {
+    "subject": "electron host (TCCProbe.app)",
+    "jsBuildTag": "20260822-152834",
+    "pid": 57506,
+    "execPath": "/Users/zazai/workspace/zazai840/openstream/.claude/worktrees/prototype+tcc-attribution-46/prototypes/tcc-attribution-46/build/TCCProbe.app/Contents/MacOS/TCCProbe",
+    "bundleIdentifier": "dev.openstream.prototype.tccprobe",
+    "accessibility": {
+      "reportedTrusted": false
+    },
+    "microphone": "not-determined",
+    "code": {
+      "path": "/Users/zazai/workspace/zazai840/openstream/.claude/worktrees/prototype+tcc-attribution-46/prototypes/tcc-attribution-46/build/TCCProbe.app",
+      "cdhash": "f1fd7593920fcc0abc84509e945c56e29b348ee9",
+      "signingIdentifier": "dev.openstream.prototype.tccprobe",
+      "teamIdentifier": "not set"
+    }
+  },
+  "axhelper": {
+    "subject": "axhelper (spawned by the Electron main process over stdio)",
+    "invokedAs": "/Users/zazai/workspace/zazai840/openstream/.claude/worktrees/prototype+tcc-attribution-46/prototypes/tcc-attribution-46/build/TCCProbe.app/Contents/Resources/helpers/axhelper",
+    "spawnError": null,
+    "raw": null,
+    "result": {
+      "adhocSigned": true,
+      "buildTag": "20260822-152834-initial",
+      "bundleIdentifier": null,
+      "cdhash": "3a378bfa8cdc98b5522a4bb5b953c915cbc7987d",
+      "executable": "/Users/zazai/workspace/zazai840/openstream/.claude/worktrees/prototype+tcc-attribution-46/prototypes/tcc-attribution-46/build/TCCProbe.app/Contents/Resources/helpers/axhelper",
+      "frontmostApp": "dev.openstream.prototype.tccprobe",
+      "functionalAXError": -25211,
+      "functionalAXErrorName": "kAXErrorAPIDisabled (not trusted)",
+      "functionallyTrusted": false,
+      "grant": "Accessibility",
+      "parentExecutable": "/Users/zazai/workspace/zazai840/openstream/.claude/worktrees/prototype+tcc-attribution-46/prototypes/tcc-attribution-46/build/TCCProbe.app/Contents/MacOS/TCCProbe",
+      "parentPid": 57506,
+      "pid": 57534,
+      "reportedTrusted": false,
+      "resolvedExecutable": "/Users/zazai/workspace/zazai840/openstream/.claude/worktrees/prototype+tcc-attribution-46/prototypes/tcc-attribution-46/build/TCCProbe.app/Contents/Resources/helpers/axhelper",
+      "responsibleExecutable": "/Users/zazai/workspace/zazai840/openstream/.claude/worktrees/prototype+tcc-attribution-46/prototypes/tcc-attribution-46/build/TCCProbe.app/Contents/MacOS/TCCProbe",
+      "responsiblePid": 57506,
+      "role": "axhelper",
+      "signingIdentifier": "axhelper-55554944adf51a2421453116b4cb0083719ffb31"
+    },
+    "code": {
+      "path": "/Users/zazai/workspace/zazai840/openstream/.claude/worktrees/prototype+tcc-attribution-46/prototypes/tcc-attribution-46/build/TCCProbe.app/Contents/Resources/helpers/axhelper",
+      "cdhash": "3a378bfa8cdc98b5522a4bb5b953c915cbc7987d",
+      "signingIdentifier": "axhelper-55554944adf51a2421453116b4cb0083719ffb31",
+      "teamIdentifier": "not set"
+    }
+  },
+  "hotkeyhelper": {
+    "subject": "hotkeyhelper (spawned by the Electron main process over stdio)",
+    "invokedAs": "/Users/zazai/workspace/zazai840/openstream/.claude/worktrees/prototype+tcc-attribution-46/prototypes/tcc-attribution-46/build/TCCProbe.app/Contents/Resources/helpers/hotkeyhelper",
+    "spawnError": null,
+    "raw": null,
+    "result": {
+      "adhocSigned": true,
+      "buildTag": "20260822-152834-initial",
+      "bundleIdentifier": null,
+      "cdhash": "b5bf42dcba8b48b09d349454b4ebc7f64fda47dc",
+      "executable": "/Users/zazai/workspace/zazai840/openstream/.claude/worktrees/prototype+tcc-attribution-46/prototypes/tcc-attribution-46/build/TCCProbe.app/Contents/Resources/helpers/hotkeyhelper",
+      "functionallyGranted": false,
+      "grant": "Input Monitoring",
+      "parentExecutable": "/Users/zazai/workspace/zazai840/openstream/.claude/worktrees/prototype+tcc-attribution-46/prototypes/tcc-attribution-46/build/TCCProbe.app/Contents/MacOS/TCCProbe",
+      "parentPid": 57506,
+      "pid": 57538,
+      "reportedAccess": "denied",
+      "reportedGranted": false,
+      "resolvedExecutable": "/Users/zazai/workspace/zazai840/openstream/.claude/worktrees/prototype+tcc-attribution-46/prototypes/tcc-attribution-46/build/TCCProbe.app/Contents/Resources/helpers/hotkeyhelper",
+      "responsibleExecutable": "/Users/zazai/workspace/zazai840/openstream/.claude/worktrees/prototype+tcc-attribution-46/prototypes/tcc-attribution-46/build/TCCProbe.app/Contents/MacOS/TCCProbe",
+      "responsiblePid": 57506,
+      "role": "hotkeyhelper",
+      "signingIdentifier": "hotkeyhelper-55554944f47d07216fbc3dc3b9a47c0d4e8ae352"
+    },
+    "code": {
+      "path": "/Users/zazai/workspace/zazai840/openstream/.claude/worktrees/prototype+tcc-attribution-46/prototypes/tcc-attribution-46/build/TCCProbe.app/Contents/Resources/helpers/hotkeyhelper",
+      "cdhash": "b5bf42dcba8b48b09d349454b4ebc7f64fda47dc",
+      "signingIdentifier": "hotkeyhelper-55554944f47d07216fbc3dc3b9a47c0d4e8ae352",
+      "teamIdentifier": "not set"
+    }
+  }
+}

--- a/prototypes/tcc-attribution-46/logs/state.log
+++ b/prototypes/tcc-attribution-46/logs/state.log
@@ -1,0 +1,30 @@
+=== build.sh (initial full build)  (2026-08-22T15:23:31Z)
+TARGET                       CDHASH                                         SIGNING IDENTIFIER
+TCCProbe.app                 e67924c8258c7c33b419f92e8c55b33f21d2850b       dev.openstream.prototype.tccprobe
+axhelper                     9e7527d6d5e10f4ab840133098242f6d3937bd58       axhelper-55554944a2b0d6b484153e96b8befc629ba63e6a
+hotkeyhelper                 b6747e7f3aff262eae143b7843d6a43f7d9d90d9       hotkeyhelper-5555494442c8eb9f0c933455bc41762c5ee979d4
+
+=== build.sh (initial full build)  (2026-08-22T15:25:07Z)
+TARGET                       CDHASH                                         SIGNING IDENTIFIER
+TCCProbe.app                 6f995504ade4e1351f764023ec0e102eb41be262       dev.openstream.prototype.tccprobe
+axhelper                     00667d0a09a106ae7012df6aca0ebb8a579803ad       axhelper-55554944fd4586e3319c3331856477854ed358a2
+hotkeyhelper                 b57a6437926900c3c59de0a287b63f6c8f75c397       hotkeyhelper-555549444db69eacc18038c4823262770dc2a523
+
+=== rebuild-js.sh (JavaScript changed, helpers untouched)  (2026-08-22T15:26:42Z)
+TARGET                       CDHASH                                         SIGNING IDENTIFIER
+TCCProbe.app                 5b9eeeb02f3b5debbcb22673e733feb9a96ccf94       dev.openstream.prototype.tccprobe
+axhelper                     00667d0a09a106ae7012df6aca0ebb8a579803ad       axhelper-55554944fd4586e3319c3331856477854ed358a2
+hotkeyhelper                 b57a6437926900c3c59de0a287b63f6c8f75c397       hotkeyhelper-555549444db69eacc18038c4823262770dc2a523
+
+=== rebuild-helpers.sh (helpers recompiled, JavaScript untouched)  (2026-08-22T15:26:49Z)
+TARGET                       CDHASH                                         SIGNING IDENTIFIER
+TCCProbe.app                 423220d98157d41c1ea39d3a93917fa10c26574b       dev.openstream.prototype.tccprobe
+axhelper                     c997c749b4c6b0f539bf926f41349f98d1f77e3b       axhelper-555549446464d3c073203e68af6679a1ee784ae1
+hotkeyhelper                 27f382076b71740cb5c9a47a08a65cb2ed69a4dc       hotkeyhelper-55554944294063a0842a38de8b69b53dab852ad1
+
+=== build.sh (initial full build)  (2026-08-22T15:28:37Z)
+TARGET                       CDHASH                                         SIGNING IDENTIFIER
+TCCProbe.app                 f1fd7593920fcc0abc84509e945c56e29b348ee9       dev.openstream.prototype.tccprobe
+axhelper                     3a378bfa8cdc98b5522a4bb5b953c915cbc7987d       axhelper-55554944adf51a2421453116b4cb0083719ffb31
+hotkeyhelper                 b5bf42dcba8b48b09d349454b4ebc7f64fda47dc       hotkeyhelper-55554944f47d07216fbc3dc3b9a47c0d4e8ae352
+

--- a/prototypes/tcc-attribution-46/readstate.sh
+++ b/prototypes/tcc-attribution-46/readstate.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# PROTOTYPE - throwaway spike for issue #46.
+#
+# Reads all three subjects with no UI and no clicking, and appends the JSON to
+# logs/. Use it right after each rebuild arm to capture that arm's state.
+#
+#   ./readstate.sh <label>
+#
+# It launches through `open`, not by running the binary directly. That matters:
+# starting the app from a shell makes the terminal's GUI app (Terminal, iTerm,
+# VS Code) the *responsible process*, and responsible-process attribution is
+# exactly what the experiment is trying to measure. Launched via `open`, the app
+# is its own responsible process, which is what a real user's launch looks like.
+#
+# It cannot replace the human steps: prompting for a grant, and reading what
+# System Settings names. Those are steps 3 and 7 in README.md.
+source "$(cd "$(dirname "$0")" && pwd)/lib.sh"
+
+LABEL="${1:-unlabelled}"
+STAMP="$(date -u +%Y%m%d-%H%M%S)"
+OUT="$LOGS/state-$STAMP-$LABEL.json"
+
+open -W -n "$APP" --args --selftest "--out=$OUT"
+
+if [ ! -s "$OUT" ]; then
+  echo "no report written - the app may have failed to start" >&2
+  exit 1
+fi
+echo "wrote $OUT"
+
+# The lines that matter, pulled out of the JSON.
+/usr/bin/python3 - "$OUT" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1]))
+h, ax, hk = d["host"], d["axhelper"]["result"], d["hotkeyhelper"]["result"]
+print(f'host          reported={h["accessibility"]["reportedTrusted"]!s:<5} '
+      f'mic={h["microphone"]:<16} cdhash={h["code"]["cdhash"]}')
+print(f'axhelper      reported={ax["reportedTrusted"]!s:<5} '
+      f'functional={ax["functionallyTrusted"]!s:<5} cdhash={ax["cdhash"]}')
+print(f'              responsible={ax["responsibleExecutable"]}')
+print(f'hotkeyhelper  reported={hk["reportedGranted"]!s:<5} '
+      f'functional={hk["functionallyGranted"]!s:<5} cdhash={hk["cdhash"]}')
+print(f'              responsible={hk["responsibleExecutable"]}')
+PY

--- a/prototypes/tcc-attribution-46/rebuild-helpers.sh
+++ b/prototypes/tcc-attribution-46/rebuild-helpers.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# PROTOTYPE - throwaway spike for issue #46.
+#
+# EXPERIMENT ARM 2: recompile the helpers with a changed build tag, so their
+# content and therefore their CDHash really moves. The JavaScript is untouched.
+#
+# What to watch: if the helpers now fail their grant check while the app still
+# passes, TCC keys the entry to the helper's own code identity. If they keep
+# passing, the entry is not keyed to them.
+source "$(cd "$(dirname "$0")" && pwd)/lib.sh"
+
+if [ ! -d "$APP" ]; then echo "no build yet - run ./build.sh first" >&2; exit 1; fi
+
+before_ax="$(cdhash_of "$HELPER_DIR/axhelper")"
+TAG="$(date -u +%Y%m%d-%H%M%S)-helperrebuild"
+
+compile_helper axhelper "$TAG"
+compile_helper hotkeyhelper "$TAG"
+sign_app
+
+record "rebuild-helpers.sh (helpers recompiled, JavaScript untouched)"
+
+after_ax="$(cdhash_of "$HELPER_DIR/axhelper")"
+if [ "$before_ax" = "$after_ax" ]; then
+  echo "WARN axhelper CDHash did NOT move - the arm is void, the rebuild changed nothing"
+else
+  echo "OK   axhelper CDHash moved ($before_ax -> $after_ax)"
+fi
+echo
+echo "Now: quit and relaunch the app, click each helper button, record the result."

--- a/prototypes/tcc-attribution-46/rebuild-js.sh
+++ b/prototypes/tcc-attribution-46/rebuild-js.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# PROTOTYPE - throwaway spike for issue #46.
+#
+# EXPERIMENT ARM 1: change only the Electron JavaScript, then re-sign the app.
+# The helper binaries are not recompiled and not touched.
+#
+# What to watch: the app's CDHash moves, the helpers' CDHashes must not. Then
+# relaunch the app and click the helper buttons. If the helpers still pass and
+# the app does not, grants attach per-helper; if all three drop, the Electron
+# bundle holds them.
+source "$(cd "$(dirname "$0")" && pwd)/lib.sh"
+
+if [ ! -d "$APP" ]; then echo "no build yet - run ./build.sh first" >&2; exit 1; fi
+
+before_ax="$(cdhash_of "$HELPER_DIR/axhelper")"
+before_hk="$(cdhash_of "$HELPER_DIR/hotkeyhelper")"
+
+JS_TAG="$(date -u +%Y%m%d-%H%M%S)-jsrebuild" "$ROOT/sync-js.sh"
+
+after_ax="$(cdhash_of "$HELPER_DIR/axhelper")"
+after_hk="$(cdhash_of "$HELPER_DIR/hotkeyhelper")"
+
+record "rebuild-js.sh (JavaScript changed, helpers untouched)"
+
+for pair in "axhelper:$before_ax:$after_ax" "hotkeyhelper:$before_hk:$after_hk"; do
+  IFS=: read -r n b a <<< "$pair"
+  if [ "$b" = "$a" ]; then
+    echo "OK   $n CDHash unchanged across the JS rebuild ($a)"
+  else
+    echo "WARN $n CDHash MOVED ($b -> $a) - the JS-only rebuild was not helper-neutral"
+  fi
+done
+echo
+echo "Now: quit and relaunch the app, click each helper button, record the result."

--- a/prototypes/tcc-attribution-46/sync-js.sh
+++ b/prototypes/tcc-attribution-46/sync-js.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# PROTOTYPE - throwaway spike for issue #46.
+# Copies app/src into the bundle and stamps it with a JS build tag. Used by
+# build.sh (with --no-sign) and by rebuild-js.sh (which signs).
+source "$(cd "$(dirname "$0")" && pwd)/lib.sh"
+
+TAG="${JS_TAG:-$(date -u +%Y%m%d-%H%M%S)}"
+DEST="$APP/Contents/Resources/app"
+
+rm -rf "$DEST"
+mkdir -p "$DEST"
+cp "$ROOT/app/src/"* "$DEST/"
+sed -i '' "s/JS_BUILD_TAG_PLACEHOLDER/$TAG/g" "$DEST/main.js" "$DEST/index.html"
+
+[ "${1:-}" = "--no-sign" ] || sign_app
+echo "js synced (tag $TAG)"


### PR DESCRIPTION
Throwaway experiment for issue #46: does each native helper hold its own Accessibility / Input Monitoring grant, or does the Electron host hold them on the helpers' behalf? Sources conflict and the TCC databases are SIP-protected, so the question needs a real signed build, not more reading.

build.sh produces an ad-hoc-signed Electron bundle (TCCProbe.app) with its own bundle id, containing two stub Swift helpers spawned over stdio exactly like the planned architecture. Each subject reports its grant state twice, reported and functionally probed, plus its CDHash, its bundle identifier and its responsible process.

Two rebuild arms isolate one variable each: rebuild-js.sh changes only the JavaScript and asserts the helper CDHashes did not move; rebuild-helpers.sh recompiles the helpers and asserts their CDHash did. readstate.sh captures all three subjects headlessly via `open`, so an arm can be recorded without clicking.

Harness verified end to end: both helpers compile and sign, the bundle passes --verify --deep --strict, the window renders, the headless capture works, and both arm invariants hold. Already measured, before any grant exists:

- Both helpers' responsible process resolves to TCCProbe.app, so the responsible-process mechanism is real and active here.
- Both helpers report bundleIdentifier null, so `tccutil reset <id>` has no target for a bare helper binary.
- Launching from a terminal makes the terminal's GUI app responsible instead, which would silently contaminate the result; readstate.sh launches via `open` to avoid it.

RESULTS.md holds the verdict table. The remaining steps need a human: the grant has to be given in System Settings, and what that list names is itself the main evidence.