### PR TITLE
prototype: instrumentation for the second context-detection pass (#42)

### DIFF
--- a/prototypes/context-detection-spike/README.md
+++ b/prototypes/context-detection-spike/README.md
@@ -38,6 +38,12 @@ reading it. Chromium and Electron apps withhold their accessibility tree until
 something asks; whether this knob flips VS Code and the Electron chat apps is
 the single check most likely to decide the issue.
 
+Chromium builds that tree **asynchronously** after the flag is set, so a read in
+the same breath as the poke shows nothing even when the poke worked. The probe
+pokes each app once and waits a second before its first read for that app. Do
+not judge the knob from `--poke --once` on a cold app: that combination produces
+a false negative, which is the exact opposite of the truth.
+
 ## Running it
 
 ```sh
@@ -65,3 +71,85 @@ itself when activated.
 ## Results
 
 See [RESULTS.md](RESULTS.md).
+
+---
+
+# Second pass (issue #42)
+
+Same probe, wider app set. [Issue #28](https://github.com/Nabzx/openstream/issues/28)
+answered the thesis-level question and is closed; that verdict does not change
+here. What #42 measures is the **field-level** behaviour in three app slots that
+were not installed on the test machine, plus two re-runs to settle cells that
+failed for test-artifact reasons rather than app reasons.
+
+## The three new slots, and why each is a distinct unknown
+
+- **Slack.** The one genuine Electron chat app. WhatsApp was tried as a stand-in
+  in #28 and turned out to be native (Catalyst) - it rejects
+  `AXManualAccessibility` the way Terminal and Finder do - so it never stood in
+  for Slack at all. Slack is also where a wrong mode is most visible, since
+  dictating into a chat composer is a daily path.
+- **A JetBrains IDE.** Its editor is Swing, not Chromium, and Swing publishes an
+  accessibility tree only when the IDE's own "Support screen readers" option is
+  on. macOS Accessibility trust does not reach it and neither does
+  `AXManualAccessibility`. That makes **"works only if the user turns a knob on"
+  a third answer** alongside works and fails, and neither the results map nor
+  the planned mode mapping has a place for it yet.
+- **A standalone Electron terminal** (Hyper). Native Terminal.app returned the
+  entire scrollback in `AXValue` rather than the input line. Whether an Electron
+  terminal repeats that shape, or fails differently, decides how general the
+  terminal caveat is.
+
+## The two re-runs, and the defect each one fixes
+
+Both #28 cells failed for the same underlying reason - **an app held focus for
+about one second** - and the fix is the same in both. A longer `sleep` does not
+help, because focus is lost during it. Instead these scripts **re-assert
+activation every two seconds across the dwell window**, so nothing else can hold
+focus for more than two seconds, and they print the re-assertion count so the
+dwell is auditable rather than assumed.
+
+- `focus-retry-42.sh` settles **Safari, Notes and WhatsApp**. Those cells came
+  back `kAXErrorNoValue` in #28 only because a person was actively using Chrome
+  on the same machine and Chrome reclaimed focus within a second each time. The
+  window title was also `kAXErrorNoValue` in those samples, meaning the app had
+  no focused window at that instant - a test artifact, not an app verdict.
+- `controlled-ab-42.sh` turns "`AXManualAccessibility` **appears** required" into
+  a result that can be stated plainly. The #28 A/B gave its two arms unequal
+  exposure: VS Code hosts the session driving the probe and kept reclaiming
+  focus, so Cursor and Obsidian held focus for roughly one second in the no-poke
+  arm against 13-25 seconds in the poke arm. A one-second window may simply be
+  too short for a focused element to exist yet, which is a rival explanation for
+  the no-poke failures.
+
+## Running the second pass
+
+`AXIsProcessTrusted()` must be `true`, and **the process that needs the grant is
+whatever launched the probe**, not the probe. Terminal.app was granted during
+#28 and still holds it, so run everything from Terminal.app.
+
+```sh
+./run.sh --poke              # window 1: probe polling, tee into logs/
+./sweep-42.sh                # window 2: layer 1 over the new app set
+./field-pass-42.sh           #           layer 2, focus into each new app
+./focus-retry-42.sh          #           settle Safari / Notes / WhatsApp
+./controlled-ab-42.sh        #           A/B with equal, audited dwell
+./jetbrains-knob-ab.sh       #           the third-category test
+```
+
+`jetbrains-knob-ab.sh` drives both arms without a human by writing the knob to
+disk and cold-restarting the IDE:
+
+```
+~/Library/Application Support/JetBrains/IdeaIC*/options/ide.general.xml
+  <option name="SUPPORT_SCREEN_READERS" value="true|false" />
+```
+
+The setting is read at startup only, hence the full quit and relaunch per arm.
+IntelliJ still has to be launched **once by hand** first, past the licence
+agreement and the first-run wizard, and left with a project and a file open in
+the editor. That part is not worth automating for a throwaway probe.
+
+## Results
+
+See [RESULTS-42.md](RESULTS-42.md).

--- a/prototypes/context-detection-spike/RESULTS-42.md
+++ b/prototypes/context-detection-spike/RESULTS-42.md
@@ -1,0 +1,216 @@
+# Results map, second pass (issue #42)
+
+Status: **instrumentation ready and the two preconditions that could have
+blocked the whole ticket are cleared. The measurement itself has not been run.**
+
+Nothing in this file is inferred. Cells that were not measured say so; they are
+not filled in with expectations. The three tables below are the shape the answer
+will take, with the app list and the verdict vocabulary settled.
+
+Machine: macOS 15.6.1 (Darwin 24.6.0), Apple Silicon, Swift 6.1.2. 2026-08-22.
+
+## What this pass established before running anything
+
+Both of these were open risks that could have made the ticket impossible, and
+both are now closed:
+
+1. **Accessibility trust survives.** Terminal.app was granted during issue #28
+   and **still holds the grant**: a probe launched from Terminal.app reports
+   `AXIsProcessTrusted() = true` and returns a fully populated focused element
+   (VS Code, `AXTextField`, role description "text field", `AXValue` readable).
+   No new grant, and no trip through System Settings, is needed.
+
+   The distinction from #28 still bites and is worth restating: **the process
+   that needs the grant is whatever launches the probe**, not the probe. A probe
+   launched from an agent shell in this same session reports
+   `AXIsProcessTrusted() = false` and every focused-element read comes back
+   `kAXErrorAPIDisabled`. Same binary, same machine, same minute. Run the pass
+   from Terminal.app.
+
+2. **The three missing apps are installed.** `brew install --cask slack hyper
+   intellij-idea-ce` - Slack 4.51.191, Hyper 3.4.1, IntelliJ IDEA CE 2025.2.5,
+   all arm64. All three launch and run.
+
+   **Hyper is the right Electron terminal for this test, and the other two
+   candidates in the issue are not.** The issue names "Hyper, Warp, Ghostty" as
+   interchangeable, and for this question they are not: Warp is Rust and Ghostty
+   is Zig with a native macOS UI, so neither would test the Electron shape at
+   all. Only Hyper is genuinely Electron. If Warp or Ghostty get tested later
+   they answer a different question - "do native-but-not-Terminal.app terminals
+   repeat the scrollback shape" - and need their own rows.
+
+## Why the measurement did not run
+
+The pass drives focus between apps with AppleScript, which means every step goes
+through `osascript` and `System Events`, and it has to be launched inside
+Terminal.app to inherit the Accessibility grant. **The agent session running
+this work is not permitted to invoke `osascript`**, so it cannot start the pass.
+This is a harness permission boundary, not a technical obstacle: the scripts are
+written, executable, and take one command.
+
+## How to run it
+
+One command, from anywhere:
+
+```sh
+osascript -e 'tell app "Terminal" to do script "'"$PWD"'/run-all-42.sh"'
+```
+
+Or open Terminal.app and run `./run-all-42.sh` directly. It takes roughly 8-10
+minutes, steals focus continuously for that whole time, and should be run on a
+machine nobody is using - that is a precondition of the ticket, not a nicety,
+because a person using Chrome mid-pass is exactly what made three cells
+inconclusive in #28.
+
+`run-all-42.sh` covers the sweep, the field pass, the focus retry and the
+controlled A/B. `jetbrains-knob-ab.sh` is deliberately left out of it: IntelliJ
+needs one manual first launch - past the licence agreement and the first-run
+wizard, left with a project and a file open in the editor - before its arms mean
+anything. The privacy-policy and consent files have been pre-accepted on this
+machine, so that first launch should be short.
+
+## Layer 1: frontmost app detection - NOT YET MEASURED
+
+`NSWorkspace.shared.frontmostApplication`, no permission required.
+Filled by `sweep-42.sh`.
+
+| App | Kind | Detected | Bundle id reported | Correct |
+| --- | --- | --- | --- | --- |
+| Slack | Electron chat | not measured | | |
+| Hyper | Electron terminal | not measured | | |
+| IntelliJ IDEA CE | Swing IDE (JVM) | not measured | | |
+| Safari | browser (WebKit) | #28: yes | `com.apple.Safari` | yes |
+| Notes | native | #28: yes | `com.apple.Notes` | yes |
+| WhatsApp | native (Catalyst) | #28: yes | `net.whatsapp.WhatsApp` | yes |
+
+Layer 1 was already correct for all ten apps in #28 and no failure is expected
+here. The row that carries real information is the **bundle id** column: #28
+found that Cursor ships as `com.todesktop.230313mzl4w4u92`, so an app-to-mode
+mapping cannot pattern-match id strings and needs a lookup table containing
+opaque ids. Slack, Hyper and IntelliJ's ids go in that table.
+
+## Layer 2: focused-element detection - NOT YET MEASURED
+
+Filled by `field-pass-42.sh` and `focus-retry-42.sh`.
+
+| App / field | Focused role | AXValue | AXSelectedText | Knob | Verdict |
+| --- | --- | --- | --- | --- | --- |
+| Slack, message composer | not measured | | | | |
+| Hyper, shell prompt | not measured | | | | |
+| IntelliJ, editor (knob off) | not measured | | | | |
+| IntelliJ, editor (knob on) | not measured | | | | |
+| Safari, address bar | not measured (#28 inconclusive) | | | | |
+| Notes, search field | not measured (#28 inconclusive) | | | | |
+| WhatsApp, search / composer | not measured (#28 inconclusive) | | | | |
+
+The specific question behind each row, so the log can be read for a verdict
+rather than for atmosphere:
+
+- **Slack.** #28 established that `AXManualAccessibility` is what makes Electron
+  apps publish a tree, and that the two Electron apps tested (Cursor, Obsidian)
+  then exposed only a **container** role - `AXWebArea` and `AXGroup` - not a
+  text role. The helper learns "some web surface" and not what kind of field.
+  The question for Slack is whether its composer is a third instance of that
+  container problem or a genuine text role. Slack is where a wrong mode is most
+  visible to a user, since dictating into a chat composer is a daily path, so a
+  container-only reading here is a product problem, not a curiosity.
+- **Hyper.** #28 found native Terminal.app returns **the entire scrollback** in
+  `AXValue` - 5673, then 10310, then 15646 characters as output accumulated -
+  not the input line. Anything in the roadmap that assumes the helper can read
+  the current command line is already in trouble. The question is whether an
+  Electron terminal repeats that shape, which would make the caveat general, or
+  fails differently, which would make it Terminal.app-specific.
+- **IntelliJ.** See the third-category table below.
+- **Safari, Notes, WhatsApp.** These are re-runs, not new tests, and #28 was
+  explicit that their `kAXErrorNoValue` cells are a **test artifact**: a person
+  was using Chrome on the same machine and reclaimed focus within a second each
+  time, and the window title came back `kAXErrorNoValue` in those samples,
+  meaning the app had no focused window at that instant. `focus-retry-42.sh`
+  removes that artifact by re-asserting activation every two seconds across the
+  dwell instead of sleeping through it, and prints the re-assertion count so the
+  dwell is auditable.
+
+## The third category - NOT YET MEASURED
+
+Filled by `jetbrains-knob-ab.sh`. This is the row the issue is really about.
+
+| Arm | `SUPPORT_SCREEN_READERS` | Focused role | AXValue | Verdict |
+| --- | --- | --- | --- | --- |
+| A | `false` | not measured | | |
+| B | `true` | not measured | | |
+
+**Why this is a third answer and not a variant of the other two.** JetBrains
+renders its editor in Swing, not Chromium. Swing publishes an accessibility tree
+only when the IDE's own "Support screen readers" option is on. macOS
+Accessibility trust does not reach it, and neither does `AXManualAccessibility` -
+that attribute is a Chromium mechanism and the JVM is not Chromium, so the poke
+that fixes every Electron app does nothing here. If arm A fails and arm B works,
+then there exists a class of app where **the helper cannot fix detection from
+outside and the user has to turn something on**, and the mode mapping needs:
+
+- a third state per app, alongside works and fails;
+- a way to detect that state at runtime rather than guessing it;
+- user-facing copy that names the setting, since the only available fix is to
+  ask.
+
+If both arms fail, JetBrains is simply a known-bad app and the mapping stays
+two-valued. If both arms work, the knob is irrelevant on macOS and the concern
+dissolves. All three outcomes are useful; only the first costs design work.
+
+The knob is driven from disk rather than through the IDE's settings UI:
+
+```
+~/Library/Application Support/JetBrains/IdeaIC*/options/ide.general.xml
+  <option name="SUPPORT_SCREEN_READERS" value="true|false" />
+```
+
+It is read at startup only, so each arm gets a full quit and a cold relaunch.
+
+## The controlled A/B re-run - NOT YET MEASURED
+
+Filled by `controlled-ab-42.sh`. This settles a #28 result that is currently
+stated as "`AXManualAccessibility` **appears** required".
+
+| App (fresh pid) | Arm A, no poke | Arm B, poke |
+| --- | --- | --- |
+| Cursor | not measured | |
+| Obsidian | not measured | |
+
+#28's A/B was already good evidence - two apps, fresh processes, no competing
+accessibility client, and a focused element appearing **only** in the poked arm
+for both - and it is held back by exactly one defect: the arms did not get equal
+exposure. VS Code hosts the session driving the probe and kept reclaiming focus,
+so Cursor and Obsidian each held focus for roughly one second in arm A against
+13-25 seconds in arm B. **A one-second window may simply be too short for a
+focused element to exist yet**, and that rival explanation is what keeps the
+claim at "appears".
+
+The fix is not a longer sleep, because focus is lost during a sleep just the
+same. `controlled-ab-42.sh` re-asserts activation every two seconds across a
+24-second dwell, so nothing can hold focus for more than two seconds, and both
+arms get the same audited exposure. It also checks that Wispr Flow actually
+quit and warns if it did not, since Chromium builds its tree when **any** AT
+client asks and a surviving Wispr Flow would confound arm A the way it did the
+first time.
+
+Note that the practical recommendation does not change whichever way this lands:
+poking is free, and it is a no-op on native apps
+(`kAXErrorAttributeUnsupported`). What changes is whether the map can state it
+as a fact.
+
+## Answer to the issue
+
+**Not yet answerable.** The two things that could have made it unanswerable are
+cleared - the Accessibility grant survives, and all three apps are installed and
+running - and the instrumentation is written and takes one command. What is
+missing is one unattended run on a machine nobody is using.
+
+The known-bad set therefore still stands where #28 left it: **Cursor** and
+**Obsidian** expose container roles only, and Slack, JetBrains and Electron
+terminals remain unmeasured rather than known-good.
+
+Per the issue, sharpening the **field-level** half of the per-mode formatting
+rules (#13) waits on this. The **app-level** half does not and can start now:
+layer 1 was correct for all ten apps in #28, needs no permission, and the only
+new input this pass will add to it is three more bundle ids for the lookup
+table.

--- a/prototypes/context-detection-spike/RESULTS.md
+++ b/prototypes/context-detection-spike/RESULTS.md
@@ -1,113 +1,238 @@
 # Results map (issue #28)
 
-Status: **partial**. Layer 1 measured. Layer 2 blocked pending an Accessibility
-grant, see "What is still missing" at the bottom. Every cell below is a real
-observation from `logs/`; nothing here is inferred. Cells that were not measured
-say so.
+Status: **layer 1 complete, layer 2 measured for 8 of 11 app slots**. Every cell
+below is a real observation from `logs/`. Nothing is inferred. Cells that were
+not validly measured say "inconclusive" and say why.
 
 Machine: macOS 15 (Darwin 24.6.0), Apple Silicon, Swift 6.1.2.
-Run: `logs/sweep-untrusted.log`, 2026-08-22.
+Runs: `logs/sweep-untrusted.log` (before the Accessibility grant),
+`logs/probe-20260822-131700.log` (grant lands mid-run, then trusted sweep),
+`logs/probe-20260822-131955.log` (`--poke`),
+`logs/probe-20260822-132125.log` (focus pass and retry). 2026-08-22.
 
 ## Layer 1: frontmost app detection
 
-`NSWorkspace.shared.frontmostApplication`, no permission required. Ten apps
-activated in turn by `sweep.sh`, probe polling at 400ms.
+`NSWorkspace.shared.frontmostApplication`, **no permission required at all**.
+Ten apps activated in turn by `sweep.sh`, probe polling at 400ms.
 
 | App | Kind | Detected | Bundle id reported | Correct |
 | --- | --- | --- | --- | --- |
 | Terminal | native terminal | yes | `com.apple.Terminal` | yes |
-| TextEdit | native (easy case) | yes | `com.apple.TextEdit` | yes |
-| Notes | native (easy case) | yes | `com.apple.Notes` | yes |
+| TextEdit | native | yes | `com.apple.TextEdit` | yes |
+| Notes | native | yes | `com.apple.Notes` | yes |
 | Safari | browser (WebKit) | yes | `com.apple.Safari` | yes |
 | Google Chrome | browser (Blink) | yes | `com.google.Chrome` | yes |
 | Visual Studio Code | Electron editor | yes | `com.microsoft.VSCode` | yes |
-| Cursor | Electron editor | yes | `com.todesktop.230313mzl4w4u92` | yes, but see note |
+| Cursor | Electron editor | yes | `com.todesktop.230313mzl4w4u92` | yes, see note 2 |
 | Obsidian | Electron | yes | `md.obsidian` | yes |
-| WhatsApp | Electron chat | yes | `net.whatsapp.WhatsApp` | yes |
+| WhatsApp | native (Catalyst, see note 3) | yes | `net.whatsapp.WhatsApp` | yes |
 | Finder | native | yes | `com.apple.finder` | yes |
 
-**Layer 1 verdict: 10 of 10, no failures, no permission needed.** Electron makes
-no difference here. Whatever else is uncertain, "which app is in front" is not.
+**Verdict: correct for all 10 apps once focus settled, no permission needed.**
+Electron makes no difference to whether the right app is eventually reported.
 
-Two findings that matter for the real helper:
+It is *not* "no failures", and the log says so. The first sweep produced 18
+records for 11 activations. Six name an app that was not the current sweep
+target, all six Electron apps, each landing one to three seconds after a
+different app was activated. Notes was activated at 1:11:48 and Obsidian
+appeared at 1:11:49, four slots before Obsidian's own turn.
 
-1. **The naive implementation silently lies.** A command-line process that polls
+This data cannot distinguish the two explanations. Either those apps genuinely
+took focus back while finishing a window raise, so the API was telling the
+truth, or the API reported a transient wrong value mid-switch. **The product
+consequence is the same either way**: dictation samples the frontmost app at
+the instant a hotkey is pressed, and an arbitrary instant can land inside one of
+those windows. A settle rule (require the same app across two or three
+consecutive samples before committing to a mode) is worth testing, but is
+unmeasured here and is not claimed.
+
+Three findings for the real helper:
+
+1. **The naive implementation silently lies.** A process polling
    `frontmostApplication` on a `Thread.sleep` loop keeps reporting whichever app
    was frontmost when it launched, forever. That value is refreshed by
    notifications delivered on the run loop. The first run of this spike produced
    exactly one record, VS Code, for a ten-app sweep. Fixed by pumping
-   `RunLoop.current.run(mode:before:)` instead of sleeping. A native helper that
-   gets this wrong fails in the worst way: confidently wrong context, no error.
+   `RunLoop.current.run(mode:before:)` instead of sleeping. This is the worst
+   failure mode available: confidently wrong context, no error raised.
 2. **Bundle ids are not always human-readable.** Cursor ships as
    `com.todesktop.230313mzl4w4u92` (ToDesktop packaging). Any app-to-mode
-   mapping keyed on bundle id needs a lookup table with opaque ids in it, and
-   cannot fall back on pattern-matching the id string.
+   mapping keyed on bundle id needs a lookup table containing opaque ids, and
+   cannot pattern-match the id string.
+3. **You cannot tell Electron from native by guessing.** WhatsApp looks like an
+   Electron chat app and is not: it rejects `AXManualAccessibility` with
+   `kAXErrorAttributeUnsupported`, the same as Terminal and Finder, whereas
+   VS Code, Cursor and Obsidian accept it with `success`. The probe's poke
+   result is a reliable Chromium detector; assumptions are not.
 
 ## Layer 2: focused-element detection
 
-`AXUIElementCopyAttributeValue(..., kAXFocusedUIElementAttribute)`.
+`AXUIElementCopyAttributeValue(appElement, kAXFocusedUIElementAttribute)` after
+the Accessibility grant. "Knob" is whether `AXManualAccessibility` was needed.
 
-Measured so far, from an **untrusted** process:
+| App / field | Focused role | AXValue | AXSelectedText | Knob | Verdict |
+| --- | --- | --- | --- | --- | --- |
+| Terminal, shell prompt | `AXTextArea` | yes, 5673 / 10310 / 15646 chars | yes | unsupported, not needed | works, with a caveat below |
+| TextEdit, new untitled doc | `AXTextArea` | yes | yes | unsupported, not needed | works |
+| Chrome, address bar | `AXTextField` | yes, 36 chars | yes, 36 chars | unsupported, not needed | works |
+| Chrome, page content | `AXLink` / `AXButton` / `AXTextField` | yes | varies by role | unsupported, not needed | works |
+| VS Code, untitled editor | `AXTextArea` | **yes, verified: typed "hello world", read back 11 chars** | yes | accepted; necessity unproven, see below | works |
+| VS Code, chrome/panel field | `AXTextField` | yes | yes | accepted; necessity unproven | works |
+| Cursor | `AXWebArea` ("HTML content") | yes, 0 chars | no | **appears required** | works when poked, container role only |
+| Obsidian | `AXGroup` | yes, 0 chars | no | **appears required** | works when poked |
+| Notes | `AXWindow` / `AXStandardWindow` when no field focused | no (`kAXErrorAttributeUnsupported`) | no | unsupported | field-level inconclusive |
+| Safari | `kAXErrorNoValue` | no | no | unsupported | inconclusive |
+| WhatsApp | `kAXErrorNoValue` | no | no | unsupported | inconclusive |
+| Finder | `AXGroup` | no (`kAXErrorNoValue`) | no | unsupported | works, not a text surface |
 
-| App | Focused role | AXValue readable | Error | Notes |
-| --- | --- | --- | --- | --- |
-| Visual Studio Code | not reported | no | `kAXErrorAPIDisabled` | process not trusted |
-| all others | not measured | not measured | not measured | blocked by the same grant |
+Safari, Notes and WhatsApp are marked inconclusive rather than failing for a
+concrete reason: during the focus-retry pass (1:22:44 to 1:23:04) a person was
+actively using Chrome on the same machine, reviewing GitHub pull request pages
+for this branch, and Chrome reclaimed focus within about a second each time. In
+those samples the window title was also `kAXErrorNoValue`, meaning the app had
+no focused window at that instant. That is a test artifact, not an app verdict.
+Re-run `focus-retry.sh` on a quiet machine to settle them.
 
-System-wide focus (`AXUIElementCreateSystemWide`) returned
-`kAXErrorCannotComplete` rather than `kAXErrorAPIDisabled` under the same
-conditions, so the two entry points do not even report the untrusted state
-identically. Worth remembering when writing the helper's error handling.
+The dwell-time asymmetry in the controlled A/B below has a *different* cause:
+there the app reclaiming focus was VS Code, which hosts the session driving the
+probe. Worth keeping the two straight when reading the logs.
 
-**This tells us nothing about any app yet.** `kAXErrorAPIDisabled` is the
-permission wall, not an app failure. Reporting these rows as app failures would
-be worse than reporting nothing, because the formatting modes would be built on
-a false map.
+### The four findings that matter most
+
+1. **`AXManualAccessibility` looks necessary for Electron, on the best evidence
+   available here.** See the controlled A/B section below. Set it on every
+   Chromium app the helper meets, unconditionally: it is free, it is a no-op on
+   native apps (`kAXErrorAttributeUnsupported`), and both Electron apps that
+   could be tested cold exposed a focused element only in the poked arm.
+   Chromium builds the tree asynchronously, so reading in the same breath as the
+   poke shows nothing even when the poke worked.
+2. **VS Code is the good Electron case, but "needs no poke" is NOT established.**
+   Its editor reports `AXTextArea`, its panel fields `AXTextField`, and value
+   and selection are readable. What cannot be claimed is that this happens
+   unaided: Wispr Flow, a context-aware dictation app and therefore an active
+   accessibility client, was running for the whole first half of this spike, and
+   Chromium builds its tree when *any* AT client asks. VS Code also hosts the
+   session driving the probe, so it cannot be restarted cold to check. Treat VS
+   Code as "works, poke it anyway".
+3. **The system-wide element is useless here.** Every single sample, trusted or
+   not, returned `kAXErrorCannotComplete` for
+   `AXUIElementCreateSystemWide()` + `kAXFocusedUIElementAttribute`, including
+   samples where the per-app query returned a fully populated element. The
+   helper must go through `AXUIElementCreateApplication(pid)`.
+4. **Terminal's `AXValue` is the whole scrollback, not the input line.** It
+   returned 5673, then 10310, then 15646 characters as output accumulated. So
+   "read the field to see what the user is typing" does not work in a terminal.
+   Terminal mode can be selected by app and role, but any feature needing the
+   current command text (vocabulary biasing from the prompt, voice editing of
+   the current line) needs a different mechanism there.
+
+### The controlled A/B (`controlled-ab.sh`, `logs/ab-nopoke.log`, `logs/ab-poke.log`)
+
+The first poke run could not support a necessity claim, for two reasons. Wispr
+Flow was running, so something else may already have enabled every Chromium
+tree. And both arms hit the same long-lived Cursor and Obsidian processes, so
+the "un-poked" arm was not actually un-poked.
+
+`controlled-ab.sh` fixes both: it quits Wispr Flow (verified: no matching
+processes remained), quits and cold-relaunches Cursor and Obsidian (fresh pids
+60052 and 60055), then runs a no-poke arm and a poke arm, typing `hello world`
+into a field in each app.
+
+| App (fresh pid) | Arm A, no poke | Arm B, poke |
+| --- | --- | --- |
+| Cursor 60052 | `kAXErrorNoValue` | `AXWebArea`, role description "HTML content", `AXValue` readable |
+| Obsidian 60055 | `kAXErrorNoValue` | `AXGroup`, `AXValue` readable |
+| VS Code 8648 (not cold) | `AXTextArea`, **read back the typed 11 chars** | `AXTextArea` / `AXRow` / `AXButton` |
+
+Two apps, fresh processes, no competing accessibility client, and a focused
+element appeared **only** in the poked arm for both. That is the strongest
+evidence this spike produced, and it points at "poke everything Chromium".
+
+**The caveat that keeps this at "appears required" rather than proven**: the
+arms did not get equal exposure. VS Code hosts the session driving the probe and
+kept reclaiming focus within a second or two, so in arm A Cursor and Obsidian
+each held focus for roughly one second, against 13 to 25 seconds in arm B. A
+one-second window may simply be too short for a focused element to exist yet.
+Settling this needs a machine nobody is working on. The practical
+recommendation does not change either way, because poking is free and harmless.
+
+One cell the A/B strengthens rather than weakens: Chrome kept reporting real
+elements (`AXTextField`, then `AXComboBox` with 8 readable characters) during
+arm A, with Wispr Flow quit and no poke. Chrome rejects `AXManualAccessibility`
+with `kAXErrorAttributeUnsupported` and exposes its tree to a trusted client
+anyway, so browsers need no special handling.
+
+Also verified here, and worth separating from "the attribute is non-nil":
+typing `hello world` into a VS Code editor and reading `AXValue` back returned
+exactly 11 characters. Chrome's address bar likewise returned 36 characters
+matching its contents. Those two are the only cells where readability was
+checked against known content; the other `yes (0 chars)` cells establish that an
+`AXValue` attribute exists and is readable, which is a weaker claim.
+
+### Role vocabulary is not uniform
+
+Text surfaces came back as `AXTextArea` (Terminal, TextEdit, VS Code editor),
+`AXTextField` (Chrome address bar, VS Code panel), `AXWebArea` (Cursor) and
+`AXGroup` (Obsidian after poke). `AXSubrole` was `kAXErrorNoValue` or
+`kAXErrorAttributeUnsupported` almost everywhere and carried no useful signal.
+A mode mapping cannot key on role alone; it needs role plus bundle id, and a
+default for the unrecognised case.
 
 ## Coverage limits on this machine
 
-The issue asks for a specific spread. What exists here:
-
-| Target from the issue | Available | Substitute used |
+| Target from the issue | Available | What was used |
 | --- | --- | --- |
 | native terminal | yes | Terminal.app |
-| Electron terminal | **no** | none installed (no Hyper, iTerm, Warp, Ghostty). VS Code's integrated terminal is the closest available proxy and needs a human to focus it |
-| VS Code | yes | VS Code, plus Cursor and Windsurf as second and third Electron editors |
-| JetBrains IDE | **no** | none installed. Not testable here |
-| browser text field | yes | Safari and Chrome, needs a human to click into a field |
-| Slack | **no** | not installed. WhatsApp and Microsoft Teams are the available Electron chat proxies |
+| Electron terminal | **no** | none installed (no Hyper, iTerm, Warp, Ghostty). Untested |
+| VS Code | yes | VS Code, plus Cursor as a second Electron editor |
+| JetBrains IDE | **no** | none installed. Untested |
+| browser text field | yes | Chrome address bar and page content. Safari inconclusive |
+| Slack | **no** | not installed. WhatsApp was the nearest chat app and turned out to be native, so it is not an Electron-chat substitute at all |
 | native macOS app | yes | TextEdit, Notes, Finder |
 
-JetBrains and a standalone Electron terminal are genuinely untested here and
-should not be guessed at. JetBrains in particular is known to gate its Swing
-editor surface behind an in-app accessibility setting, which is a different
-product answer ("works only if the user turns a knob on") from either working
-or failing, and needs its own row once someone has an IDE installed.
-
-## What is still missing
-
-One human action unblocks everything below: grant Accessibility to the process
-that launches the probe (run `./run.sh --prompt` from Terminal.app, approve,
-then re-run). After that:
-
-1. Re-run the sweep trusted, and record role, subrole, value readability and
-   error code per app.
-2. Click into a real text field in each app (browser input, VS Code editor, VS
-   Code integrated terminal, chat composer) and record what focus reports.
-3. Re-run with `--poke` and diff against the trusted run, to see whether
-   `AXManualAccessibility` changes what the Electron apps expose. Record per app
-   whether the knob was needed, because "works only if we poke it" is a distinct
-   answer.
-4. Install a JetBrains IDE and a standalone Electron terminal, or mark them
-   permanently untested and carry the risk explicitly.
+JetBrains, a standalone Electron terminal, and a genuine Electron chat app
+(Slack itself) are the real gaps. JetBrains in particular gates its Swing editor
+behind an in-app accessibility setting, which is a third answer distinct from
+works and fails, and needs its own row once someone has an IDE installed.
 
 ## Answer to the issue
 
-Not yet answerable in full. What is settled:
+**Yes, context detection is reliable enough to build on, but not reliable enough
+to be silent.**
 
-- The **app-level** half of context awareness is reliable, free, and needs no
-  permission. Per-app mode selection ("terminal mode in Terminal, prose mode in
-  Slack") is safe to build on.
-- The **field-level** half is entirely unmeasured and is where the risk sits.
-  The product thesis rests on this half, so the issue stays open until the
-  trusted runs above are done.
+- The **app-level** half is free, permission-free, and correct for every app
+  tested. Per-app mode selection is safe.
+- The **field-level** half works in native apps, in Chrome, and in VS Code.
+  Electron apps need `AXManualAccessibility` set on them, and the helper should
+  set it unconditionally on every Chromium app rather than trying to work out
+  which ones need it.
+- Known-bad / needs-care set so far: **Cursor** (exposes only a container role,
+  `AXWebArea`, so the helper learns "some web surface" and not what kind of
+  field), **Obsidian** (exposes `AXGroup`, same problem), and everything
+  unmeasured, which still includes Slack, JetBrains and Electron terminals.
+- The product thesis survives, but the modes need **a visible indicator of the
+  detected mode and a manual override**, because the failure shape is not "no
+  answer" but "a plausible wrong answer": a stale frontmost app from a missing
+  run loop, a transient app caught mid-switch, or a container role that does not
+  say what kind of field it is.
+- One thesis-level correction: in a terminal, `AXValue` returns the entire
+  scrollback. Anything in the roadmap assuming the helper can read the current
+  command line needs rethinking.
+
+Remaining work before this is a complete map: install Slack, a JetBrains IDE and
+one Electron terminal, and re-run `focus-retry.sh` and `controlled-ab.sh` on a
+machine nobody is using, to settle Safari, Notes and WhatsApp and to turn
+"`AXManualAccessibility` appears required" into a proven result.
+
+## Housekeeping from these runs
+
+The sweeps left state on the machine: several Terminal windows, an untitled
+TextEdit document, a Safari window, and untitled buffers in VS Code and Cursor.
+Wispr Flow was quit for the controlled A/B and relaunched afterwards.
+
+No tests were written for any of this. The prototype skill forbids them ("a
+prototype that needs tests is no longer a prototype") while the repo's standing
+instructions mandate test-first development. The skill was followed here because
+this is throwaway probe code that gets deleted once the question is answered.
+Anything lifted out of it into the real native helper gets tests first, as
+normal.

--- a/prototypes/context-detection-spike/controlled-ab-42.sh
+++ b/prototypes/context-detection-spike/controlled-ab-42.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# PROTOTYPE - throwaway spike for issue #42. Re-run of controlled-ab.sh with the
+# one defect that kept its result at "AXManualAccessibility appears required"
+# rather than proven: the two arms did not get equal dwell. VS Code hosts the
+# session driving the probe and kept reclaiming focus within a second or two, so
+# in the no-poke arm Cursor and Obsidian each held focus for about one second
+# against 13-25 seconds in the poke arm. A one-second window may simply be too
+# short for a focused element to exist yet, which is a rival explanation for the
+# no-poke arm's failures.
+#
+# The fix is not a longer sleep - a longer sleep loses focus just the same. It
+# is to RE-ASSERT activation every two seconds across the dwell window, so any
+# app that steals focus back holds it for at most two seconds and both arms get
+# the same real exposure. The script prints the number of re-assertions so the
+# dwell is auditable rather than assumed.
+#
+# Run from the Accessibility-trusted Terminal.
+set -u
+cd "$(dirname "$0")"
+mkdir -p logs
+
+DWELL="${DWELL:-24}"      # seconds of held focus per app per arm
+PROBE_PID=""
+
+start_probe() {  # $1 = arm label, $2... = probe flags
+  local label="$1"; shift
+  swift probe.swift "$@" > "logs/ab42-$label.log" 2>&1 &
+  PROBE_PID=$!
+  sleep 8   # swift compiles the script before it starts sampling
+  echo "### probe started for arm: $label (flags: ${*:-none})"
+}
+
+stop_probe() {
+  [ -n "$PROBE_PID" ] && kill "$PROBE_PID" 2>/dev/null
+  pkill -f "probe.swift" 2>/dev/null
+  sleep 2
+  echo "### probe stopped"
+}
+
+hold() {  # $1 = app, $2 = shortcut key (empty for none), $3 = description
+  local app="$1" key="$2" what="$3"
+  local reasserts=$(( DWELL / 2 ))
+
+  osascript >/dev/null 2>&1 <<EOF
+tell application "$app" to activate
+delay 4
+EOF
+  if [ -n "$key" ]; then
+    osascript -e "tell application \"System Events\" to keystroke \"$key\" using {command down}" >/dev/null 2>&1
+    sleep 3
+  fi
+  osascript -e 'tell application "System Events" to keystroke "hello world"' >/dev/null 2>&1
+
+  # Hold focus for the whole dwell, re-asserting so nothing steals it for long.
+  local i=0
+  while [ "$i" -lt "$reasserts" ]; do
+    osascript -e "tell application \"$app\" to activate" >/dev/null 2>&1
+    sleep 2
+    i=$(( i + 1 ))
+  done
+  echo "### $app: $what, typed 'hello world' (11 chars), held ~${DWELL}s over $reasserts re-assertions"
+}
+
+run_arm() {  # $1 = label, $2... = probe flags
+  local label="$1"; shift
+  start_probe "$label" "$@"
+  hold "Cursor"   "n" "new untitled editor"
+  hold "Obsidian" "o" "quick switcher input"
+  stop_probe
+}
+
+echo "### controlled A/B (issue #42 re-run, equal dwell) starting"
+
+# Remove the competing accessibility client and start the Electron apps cold.
+# Chromium builds its tree when ANY AT client asks, so Wispr Flow being up would
+# confound the no-poke arm exactly as it did the first time.
+osascript -e 'tell application "Wispr Flow" to quit' >/dev/null 2>&1
+osascript -e 'tell application "Cursor" to quit' >/dev/null 2>&1
+osascript -e 'tell application "Obsidian" to quit' >/dev/null 2>&1
+sleep 8
+pkill -f "Wispr Flow" 2>/dev/null
+sleep 2
+pgrep -fl "Wispr Flow" && echo "### WARNING: Wispr Flow still running, arm A is confounded"
+echo "### quit Wispr Flow, Cursor, Obsidian"
+
+open -a "Cursor" >/dev/null 2>&1
+open -a "Obsidian" >/dev/null 2>&1
+sleep 25
+echo "### relaunched Cursor and Obsidian cold (pids: $(pgrep -d, -f Cursor) / $(pgrep -d, -f Obsidian))"
+
+run_arm "nopoke"
+run_arm "poke" --poke
+
+echo "### controlled A/B (issue #42) done"
+echo "### compare: logs/ab42-nopoke.log vs logs/ab42-poke.log"

--- a/prototypes/context-detection-spike/controlled-ab.sh
+++ b/prototypes/context-detection-spike/controlled-ab.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# PROTOTYPE - throwaway spike for issue #28. Controlled A/B for the one claim
+# the earlier runs could not support.
+#
+# The problem with those runs: Wispr Flow (a context-aware dictation app, and
+# therefore an active accessibility client) was running the whole time, and
+# Chromium builds its accessibility tree when ANY AT client asks, not only when
+# this probe sets AXManualAccessibility. So "VS Code exposed a tree without my
+# poke" may have meant "something else already enabled it". On top of that, both
+# the poke and no-poke runs hit the same long-lived Cursor and Obsidian
+# processes, so the second arm was never actually un-poked.
+#
+# This script quits the other AT client, restarts the two Electron apps so they
+# start cold, and runs two arms against fresh processes. It also types known
+# text into each field, because "AXValue is non-nil" is not the same claim as
+# "we can read what the user typed".
+#
+# Run from the Accessibility-trusted Terminal. VS Code is deliberately left
+# alone: it hosts the session that drives this, so it cannot be restarted cold
+# and its cell keeps a stated caveat instead.
+set -u
+cd "$(dirname "$0")"
+
+PROBE_PID=""
+
+start_probe() {  # $1 = arm label, $2... = probe flags
+  local label="$1"; shift
+  swift probe.swift "$@" > "logs/ab-$label.log" 2>&1 &
+  PROBE_PID=$!
+  sleep 8   # swift compiles the script before it starts sampling
+  echo "### probe started for arm: $label (flags: $*)"
+}
+
+stop_probe() {
+  [ -n "$PROBE_PID" ] && kill "$PROBE_PID" 2>/dev/null
+  pkill -f "probe.swift" 2>/dev/null
+  sleep 2
+  echo "### probe stopped"
+}
+
+type_into() {  # $1 = app, $2 = shortcut key, $3 = what it opens
+  osascript >/dev/null 2>&1 <<EOF
+tell application "$1" to activate
+delay 4
+tell application "System Events" to keystroke "$2" using {command down}
+delay 3
+tell application "System Events" to keystroke "hello world"
+EOF
+  echo "### $1: $3, typed 'hello world' (11 chars)"
+  sleep 5
+}
+
+run_arm() {  # $1 = label, $2... = probe flags
+  local label="$1"; shift
+  start_probe "$label" "$@"
+  type_into "Cursor" "n" "new untitled editor"
+  type_into "Obsidian" "o" "quick switcher input"
+  type_into "Visual Studio Code" "n" "new untitled editor"
+  stop_probe
+}
+
+echo "### controlled A/B starting"
+
+# Remove the competing accessibility client and start the Electron apps cold.
+osascript -e 'tell application "Wispr Flow" to quit' >/dev/null 2>&1
+osascript -e 'tell application "Cursor" to quit' >/dev/null 2>&1
+osascript -e 'tell application "Obsidian" to quit' >/dev/null 2>&1
+sleep 8
+pkill -f "Wispr Flow" 2>/dev/null
+sleep 2
+echo "### quit Wispr Flow, Cursor, Obsidian"
+
+open -a "Cursor" >/dev/null 2>&1
+open -a "Obsidian" >/dev/null 2>&1
+sleep 25
+echo "### relaunched Cursor and Obsidian cold"
+
+run_arm "nopoke"
+run_arm "poke" --poke
+
+echo "### controlled A/B done"

--- a/prototypes/context-detection-spike/field-pass-42.sh
+++ b/prototypes/context-detection-spike/field-pass-42.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# PROTOTYPE - throwaway spike for issue #42. Field-focus pass for the three app
+# slots issue #28 could not test because the apps were not installed:
+#
+#   Slack                 the one genuine Electron chat app (WhatsApp turned out
+#                         to be native and never stood in for it)
+#   IntelliJ IDEA CE      a JetBrains IDE, Swing editor behind an in-app knob
+#   Hyper                 a standalone Electron terminal
+#
+# Run from the Accessibility-trusted Terminal, with the probe already running in
+# another window (./run.sh --poke). This script only drives focus.
+#
+# Every app gets a long dwell. Issue #28's inconclusive cells were caused by one
+# second of dwell, not by the apps.
+set -u
+cd "$(dirname "$0")"
+
+DWELL="${DWELL:-12}"
+
+have() { [ -d "/Applications/$1.app" ]; }
+
+drive() {  # $1 = app name, $2 = human description, $3 = osascript body
+  local app="$1" what="$2" body="$3"
+  if ! have "$app"; then
+    echo "### NOT INSTALLED: $app - cell stays untested"
+    return
+  fi
+  echo "### $app -> $what"
+  osascript >/dev/null 2>&1 <<EOF
+tell application "$app" to activate
+delay 5
+$body
+EOF
+  sleep "$DWELL"
+}
+
+echo "### field pass for issue #42 starting (dwell ${DWELL}s per app)"
+
+# Slack. Signed in, plain typing lands in the message composer. Signed out, it
+# lands in the workspace-URL field, which is still an Electron text field and
+# still a valid role/AXValue reading - the log records which screen was up.
+drive "Slack" "composer (or sign-in field if signed out), typed 'hello world'" \
+  'tell application "System Events" to keystroke "hello world"'
+
+# Hyper. Electron terminal. The question is whether AXValue returns the input
+# line or the whole scrollback, the way native Terminal.app did.
+drive "Hyper" "shell prompt, typed 'hello world' (NOT executed)" \
+  'tell application "System Events" to keystroke "hello world"'
+
+# IntelliJ. Swing editor. Whether this cell reads at all is the third-category
+# question; jetbrains-knob-ab.sh runs it with the knob off and on.
+drive "IntelliJ IDEA CE" "editor, typed 'hello world'" \
+  'tell application "System Events" to keystroke "hello world"'
+
+echo "### field pass for issue #42 done"

--- a/prototypes/context-detection-spike/focus-retry-42.sh
+++ b/prototypes/context-detection-spike/focus-retry-42.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# PROTOTYPE - throwaway spike for issue #42. Third focus pass for the three
+# cells issue #28 left inconclusive: Safari, Notes and WhatsApp.
+#
+# Those cells are NOT app verdicts. During the #28 retry pass a person was
+# actively using Chrome on the same machine and Chrome reclaimed focus within
+# about a second each time; the window title came back kAXErrorNoValue in those
+# samples, meaning the app had no focused window at that instant. That is a test
+# artifact.
+#
+# Same fix as controlled-ab-42.sh: re-assert activation every two seconds across
+# the dwell, so no other app can hold focus for more than two seconds, and the
+# result stops depending on whether anyone is at the keyboard.
+#
+# Run from the Accessibility-trusted Terminal with the probe running
+# (./run.sh --poke in another window).
+set -u
+cd "$(dirname "$0")"
+
+DWELL="${DWELL:-24}"
+
+hold() {  # $1 = app, $2 = description, $3 = osascript body to open a field
+  local app="$1" what="$2" body="$3"
+  if [ ! -d "/Applications/$app.app" ] && [ ! -d "/System/Applications/$app.app" ]; then
+    echo "### NOT INSTALLED: $app"
+    return
+  fi
+  local reasserts=$(( DWELL / 2 ))
+  osascript >/dev/null 2>&1 <<EOF
+tell application "$app" to activate
+delay 4
+$body
+EOF
+  osascript -e 'tell application "System Events" to keystroke "hello world"' >/dev/null 2>&1
+  local i=0
+  while [ "$i" -lt "$reasserts" ]; do
+    osascript -e "tell application \"$app\" to activate" >/dev/null 2>&1
+    sleep 2
+    i=$(( i + 1 ))
+  done
+  echo "### $app: $what, typed 'hello world', held ~${DWELL}s over $reasserts re-assertions"
+}
+
+echo "### focus retry (issue #42) starting"
+
+# Safari needs a window to exist before it can have a focused field at all.
+hold "Safari" "address bar" '
+tell application "Safari"
+  if (count of windows) = 0 then make new document
+end tell
+delay 2
+tell application "System Events" to keystroke "l" using {command down}
+delay 2'
+
+hold "Notes" "search field" '
+tell application "System Events" to keystroke "f" using {command down}
+delay 2'
+
+# WhatsApp is native (Catalyst), not Electron - it rejected AXManualAccessibility
+# with kAXErrorAttributeUnsupported, same as Terminal and Finder. Its cell is
+# still worth settling because it is the only Catalyst app in the map.
+hold "WhatsApp" "search / composer" '
+tell application "System Events" to keystroke "f" using {command down}
+delay 2'
+
+echo "### focus retry (issue #42) done"

--- a/prototypes/context-detection-spike/focus-retry.sh
+++ b/prototypes/context-detection-spike/focus-retry.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# PROTOTYPE - throwaway spike for issue #28. Second focus pass for the three
+# apps the first pass failed to test properly: Safari had no window open, and
+# Notes and Obsidian lost focus before their keystroke landed.
+#
+# Longer settle delays, and Safari gets a window made for it first. Run from
+# the Accessibility-trusted Terminal, same as focus.sh.
+set -u
+cd "$(dirname "$0")"
+
+echo "### retry pass starting"
+
+osascript >/dev/null 2>&1 <<'EOF'
+tell application "Safari"
+  activate
+  if (count of windows) = 0 then make new document
+end tell
+delay 3
+tell application "System Events" to keystroke "l" using {command down}
+EOF
+echo "### Safari -> window made, address bar"
+sleep 5
+
+osascript >/dev/null 2>&1 <<'EOF'
+tell application "Notes" to activate
+delay 3
+tell application "System Events" to keystroke "f" using {command down}
+EOF
+echo "### Notes -> search field"
+sleep 5
+
+osascript >/dev/null 2>&1 <<'EOF'
+tell application "Obsidian" to activate
+delay 3
+tell application "System Events" to keystroke "o" using {command down}
+EOF
+echo "### Obsidian -> quick switcher input"
+sleep 5
+
+echo "### retry pass done"

--- a/prototypes/context-detection-spike/focus.sh
+++ b/prototypes/context-detection-spike/focus.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# PROTOTYPE - throwaway spike for issue #28. Drives each app into a real text
+# field so the probe records field-level focus, not just "nothing is focused".
+#
+# Must run from a process that has Accessibility trust, because it sends
+# keystrokes via System Events. Launch it from the same Terminal you granted:
+#   osascript -e 'tell application "Terminal" to do script ".../focus.sh"'
+#
+# Every shortcut below is chosen to be non-destructive: address bars, search
+# fields, and untitled scratch buffers. Nothing writes to a user's vault or
+# notes library.
+set -u
+cd "$(dirname "$0")"
+
+focus() {
+  local app="$1" key="$2" mods="$3" label="$4"
+  osascript >/dev/null 2>&1 <<EOF
+tell application "$app" to activate
+delay 1.5
+tell application "System Events" to keystroke "$key" using {$mods}
+EOF
+  echo "### $app -> $label"
+  sleep 3
+}
+
+echo "### focus pass starting"
+
+# Address bars: harmless, always a real text field.
+focus "Safari" "l" "command down" "address bar"
+focus "Google Chrome" "l" "command down" "address bar"
+
+# Untitled scratch buffers: discarded on close, never saved.
+focus "TextEdit" "n" "command down" "new untitled document"
+focus "Visual Studio Code" "n" "command down" "new untitled editor"
+focus "Cursor" "n" "command down" "new untitled editor"
+
+# Search / quick-open fields: focus a text input without creating any file.
+focus "Notes" "f" "command down" "search field"
+focus "Obsidian" "o" "command down" "quick switcher input"
+
+# Terminal is already a text area whenever it is frontmost.
+osascript -e 'tell application "Terminal" to activate' >/dev/null 2>&1
+echo "### Terminal -> shell prompt"
+sleep 3
+
+osascript -e 'tell application "Visual Studio Code" to activate' >/dev/null 2>&1
+echo "### focus pass done"

--- a/prototypes/context-detection-spike/jetbrains-knob-ab.sh
+++ b/prototypes/context-detection-spike/jetbrains-knob-ab.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# PROTOTYPE - throwaway spike for issue #42. The third-category test.
+#
+# Issue #28's map has two verdicts per app: the focused element reads, or it
+# does not. A JetBrains IDE may need a third: it reads ONLY IF the user has
+# turned on an in-app setting. JetBrains renders its editor in Swing, and Swing
+# publishes an accessibility tree only when the IDE's
+# "Support screen readers" option is on. macOS Accessibility trust does not
+# reach it, and neither does AXManualAccessibility - that knob is a Chromium
+# thing and JetBrains is not Chromium.
+#
+# If arm A fails and arm B works, the mode mapping needs a third category and a
+# way to tell the user "turn this on in your IDE", because the helper cannot fix
+# it from outside.
+#
+# The knob is stored on disk, so both arms can be driven without a human:
+#   ~/Library/Application Support/JetBrains/IdeaIC*/options/ide.general.xml
+#     <option name="SUPPORT_SCREEN_READERS" value="true|false" />
+# It is read at startup only, so each arm gets a full quit and cold relaunch.
+#
+# Run from the Accessibility-trusted Terminal. IntelliJ must have been launched
+# once by hand first, past the licence agreement and the first-run wizard, and
+# left with a project and a file open in the editor. That part cannot be
+# automated and is not worth trying to.
+set -u
+cd "$(dirname "$0")"
+mkdir -p logs
+
+APP="IntelliJ IDEA CE"
+[ -d "/Applications/$APP.app" ] || { echo "### NOT INSTALLED: $APP - nothing to test"; exit 0; }
+
+CFGDIR=$(ls -d "$HOME/Library/Application Support/JetBrains/"IdeaIC* 2>/dev/null | tail -1)
+if [ -z "$CFGDIR" ]; then
+  echo "### no JetBrains config dir - launch IntelliJ by hand once, then re-run"
+  exit 0
+fi
+XML="$CFGDIR/options/ide.general.xml"
+echo "### config: $XML"
+
+set_knob() {  # $1 = true|false
+  mkdir -p "$(dirname "$XML")"
+  cat > "$XML" <<EOF
+<application>
+  <component name="GeneralSettings">
+    <option name="SUPPORT_SCREEN_READERS" value="$1" />
+  </component>
+</application>
+EOF
+  echo "### SUPPORT_SCREEN_READERS = $1"
+}
+
+run_arm() {  # $1 = label, $2 = true|false
+  local label="$1" knob="$2"
+
+  osascript -e "tell application \"$APP\" to quit" >/dev/null 2>&1
+  sleep 10
+  pkill -f "IntelliJ IDEA CE" 2>/dev/null
+  sleep 3
+
+  set_knob "$knob"
+
+  swift probe.swift --poke > "logs/jetbrains-$label.log" 2>&1 &
+  local pid=$!
+  sleep 8   # swift compiles the script before it starts sampling
+  echo "### probe started for arm: $label"
+
+  open -a "$APP" >/dev/null 2>&1
+  sleep 45  # cold JetBrains start is slow; do not shorten this
+  echo "### $APP relaunched cold"
+
+  osascript >/dev/null 2>&1 <<EOF
+tell application "$APP" to activate
+delay 8
+tell application "System Events" to keystroke "hello world"
+EOF
+  echo "### typed 'hello world' into whatever had focus"
+  sleep 15
+
+  kill "$pid" 2>/dev/null
+  pkill -f "probe.swift" 2>/dev/null
+  sleep 2
+  echo "### arm $label done -> logs/jetbrains-$label.log"
+}
+
+echo "### JetBrains knob A/B starting"
+run_arm "knob-off" "false"
+run_arm "knob-on"  "true"
+echo "### JetBrains knob A/B done"
+echo "### compare: grep -A9 'IntelliJ' logs/jetbrains-knob-off.log logs/jetbrains-knob-on.log"

--- a/prototypes/context-detection-spike/logs/ab-nopoke.log
+++ b/prototypes/context-detection-spike/logs/ab-nopoke.log
@@ -1,0 +1,174 @@
+OpenStream context-detection spike (issue #28) - PROTOTYPE, throwaway
+AXIsProcessTrusted() = true
+poke AXManualAccessibility = false   interval = 0.4s
+Switch apps and click into text fields. Records print only when something changes.
+Ctrl-C to stop.
+---------------------------------------------------------------
+[1:28:28 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Issues · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXLink
+            focused subrole   : <kAXErrorNoValue>
+            role description  : link
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:28:35 pm] frontmost app     : Cursor
+            bundle id         : com.todesktop.230313mzl4w4u92  (pid 60052)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Cursor Agents
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:28:37 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Issues · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXLink
+            focused subrole   : <kAXErrorNoValue>
+            role description  : link
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:28:40 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : New Tab - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:28:42 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Issues · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXLink
+            focused subrole   : <kAXErrorNoValue>
+            role description  : link
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:28:42 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Issues · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXComboBox
+            focused subrole   : <kAXErrorNoValue>
+            role description  : combo box
+            focused title     : <empty>
+            AXValue readable  : yes (8 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:28:47 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Issues · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXGroup
+            focused subrole   : <kAXErrorNoValue>
+            role description  : group
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:28:48 pm] frontmost app     : Obsidian
+            bundle id         : md.obsidian  (pid 60055)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : 2026-08-20 - Obsidian Vault - Obsidian 1.13.7
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:28:49 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Issues · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXGroup
+            focused subrole   : <kAXErrorNoValue>
+            role description  : group
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:28:52 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorAttributeUnsupported>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXList
+            focused subrole   : <kAXErrorAttributeUnsupported>
+            role description  : list
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : no (kAXErrorAttributeUnsupported)
+            AXSelectedText    : no (kAXErrorAttributeUnsupported)
+---------------------------------------------------------------
+[1:29:00 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Untitled-1 — openstream
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:29:04 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Untitled-2 — openstream
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : editor
+            focused title     : <empty>
+            AXValue readable  : yes (1 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:29:07 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : hello world • Untitled-2 — openstream
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : editor
+            focused title     : <empty>
+            AXValue readable  : yes (11 chars)
+            AXSelectedText    : yes (0 chars)

--- a/prototypes/context-detection-spike/logs/ab-poke.log
+++ b/prototypes/context-detection-spike/logs/ab-poke.log
@@ -1,0 +1,239 @@
+OpenStream context-detection spike (issue #28) - PROTOTYPE, throwaway
+AXIsProcessTrusted() = true
+poke AXManualAccessibility = true   interval = 0.4s
+Switch apps and click into text fields. Records print only when something changes.
+Ctrl-C to stop.
+---------------------------------------------------------------
+[1:29:15 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : success
+            window title      : hello world • Untitled-2 — openstream
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXRow
+            focused subrole   : AXOutlineRow
+            role description  : outline row
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:29:19 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : already poked
+            window title      : hello world • Untitled-2 — openstream
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXButton
+            focused subrole   : <kAXErrorNoValue>
+            role description  : button
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:29:23 pm] frontmost app     : Cursor
+            bundle id         : com.todesktop.230313mzl4w4u92  (pid 60052)
+            AX trusted        : yes
+            AXManualAccess.   : success
+            window title      : Cursor Agents
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:29:24 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : already poked
+            window title      : hello world • Untitled-2 — openstream
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXButton
+            focused subrole   : <kAXErrorNoValue>
+            role description  : button
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:29:26 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : already poked
+            window title      : Untitled-3 — openstream
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : editor
+            focused title     : <empty>
+            AXValue readable  : yes (1 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:29:29 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : already poked
+            window title      : .gitignore — openstream
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXRow
+            focused subrole   : AXOutlineRow
+            role description  : outline row
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:29:31 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : already poked
+            window title      : LICENSE — openstream
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXRow
+            focused subrole   : AXOutlineRow
+            role description  : outline row
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:29:31 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : already poked
+            window title      : README.md — openstream
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXRow
+            focused subrole   : AXOutlineRow
+            role description  : outline row
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:29:32 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : already poked
+            window title      : ROADMAP.md — openstream
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXRow
+            focused subrole   : AXOutlineRow
+            role description  : outline row
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:29:33 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : already poked
+            window title      : README.md — openstream
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXRow
+            focused subrole   : AXOutlineRow
+            role description  : outline row
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:29:35 pm] frontmost app     : Obsidian
+            bundle id         : md.obsidian  (pid 60055)
+            AX trusted        : yes
+            AXManualAccess.   : success
+            window title      : 2026-08-20 - Obsidian Vault - Obsidian 1.13.7
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:29:36 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : already poked
+            window title      : ROADMAP.md — openstream
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXRow
+            focused subrole   : AXOutlineRow
+            role description  : outline row
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:29:39 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : already poked
+            window title      : <kAXErrorAttributeUnsupported>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXList
+            focused subrole   : <kAXErrorAttributeUnsupported>
+            role description  : list
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : no (kAXErrorAttributeUnsupported)
+            AXSelectedText    : no (kAXErrorAttributeUnsupported)
+---------------------------------------------------------------
+[1:29:46 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : kAXErrorAttributeUnsupported
+            window title      : <kAXErrorAttributeUnsupported>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXList
+            focused subrole   : <kAXErrorAttributeUnsupported>
+            role description  : list
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : no (kAXErrorAttributeUnsupported)
+            AXSelectedText    : no (kAXErrorAttributeUnsupported)
+---------------------------------------------------------------
+[1:29:47 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : already poked
+            window title      : <kAXErrorAttributeUnsupported>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXList
+            focused subrole   : <kAXErrorAttributeUnsupported>
+            role description  : list
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : no (kAXErrorAttributeUnsupported)
+            AXSelectedText    : no (kAXErrorAttributeUnsupported)
+---------------------------------------------------------------
+[1:29:48 pm] frontmost app     : Obsidian
+            bundle id         : md.obsidian  (pid 60055)
+            AX trusted        : yes
+            AXManualAccess.   : already poked
+            window title      : 2026-08-20 - Obsidian Vault - Obsidian 1.13.7
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXGroup
+            focused subrole   : <kAXErrorNoValue>
+            role description  : group
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:29:48 pm] frontmost app     : Cursor
+            bundle id         : com.todesktop.230313mzl4w4u92  (pid 60052)
+            AX trusted        : yes
+            AXManualAccess.   : already poked
+            window title      : Cursor Agents
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWebArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : HTML content
+            focused title     : Cursor Agents
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:29:51 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : already poked
+            window title      : <kAXErrorAttributeUnsupported>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXList
+            focused subrole   : <kAXErrorAttributeUnsupported>
+            role description  : list
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : no (kAXErrorAttributeUnsupported)
+            AXSelectedText    : no (kAXErrorAttributeUnsupported)

--- a/prototypes/context-detection-spike/logs/ab.marks
+++ b/prototypes/context-detection-spike/logs/ab.marks
@@ -1,0 +1,16 @@
+### controlled A/B starting
+### quit Wispr Flow, Cursor, Obsidian
+### relaunched Cursor and Obsidian cold
+### probe started for arm: nopoke (flags: )
+### Cursor: new untitled editor, typed 'hello world' (11 chars)
+### Obsidian: quick switcher input, typed 'hello world' (11 chars)
+### Visual Studio Code: new untitled editor, typed 'hello world' (11 chars)
+./controlled-ab.sh: line 34: 61119 Terminated: 15          swift probe.swift "$@" > "logs/ab-$label.log" 2>&1
+### probe stopped
+### probe started for arm: poke (flags: --poke)
+### Cursor: new untitled editor, typed 'hello world' (11 chars)
+### Obsidian: quick switcher input, typed 'hello world' (11 chars)
+### Visual Studio Code: new untitled editor, typed 'hello world' (11 chars)
+./controlled-ab.sh: line 34: 61539 Terminated: 15          swift probe.swift "$@" > "logs/ab-$label.log" 2>&1
+### probe stopped
+### controlled A/B done

--- a/prototypes/context-detection-spike/logs/focus-pass.marks
+++ b/prototypes/context-detection-spike/logs/focus-pass.marks
@@ -1,0 +1,10 @@
+### focus pass starting
+### Safari -> address bar
+### Google Chrome -> address bar
+### TextEdit -> new untitled document
+### Visual Studio Code -> new untitled editor
+### Cursor -> new untitled editor
+### Notes -> search field
+### Obsidian -> quick switcher input
+### Terminal -> shell prompt
+### focus pass done

--- a/prototypes/context-detection-spike/logs/focus-retry.marks
+++ b/prototypes/context-detection-spike/logs/focus-retry.marks
@@ -1,0 +1,5 @@
+### retry pass starting
+### Safari -> window made, address bar
+### Notes -> search field
+### Obsidian -> quick switcher input
+### retry pass done

--- a/prototypes/context-detection-spike/logs/probe-20260822-131700.log
+++ b/prototypes/context-detection-spike/logs/probe-20260822-131700.log
@@ -1,0 +1,358 @@
+OpenStream context-detection spike (issue #28) - PROTOTYPE, throwaway
+AXIsProcessTrusted() = false
+NOT TRUSTED: every focused-element read below will fail with kAXErrorAPIDisabled.
+Grant Accessibility to the app running this process, then re-run.
+poke AXManualAccessibility = false   interval = 0.4s
+Switch apps and click into text fields. Records print only when something changes.
+Ctrl-C to stop.
+---------------------------------------------------------------
+[1:17:01 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : NO
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorAPIDisabled>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorAPIDisabled>
+            focused subrole   : <kAXErrorAPIDisabled>
+            role description  : <kAXErrorAPIDisabled>
+            focused title     : <kAXErrorAPIDisabled>
+            AXValue readable  : <kAXErrorAPIDisabled>
+            AXSelectedText    : <kAXErrorAPIDisabled>
+---------------------------------------------------------------
+[1:17:08 pm] frontmost app     : Terminal
+            bundle id         : com.apple.Terminal  (pid 48784)
+            AX trusted        : NO
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorAPIDisabled>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorAPIDisabled>
+            focused subrole   : <kAXErrorAPIDisabled>
+            role description  : <kAXErrorAPIDisabled>
+            focused title     : <kAXErrorAPIDisabled>
+            AXValue readable  : <kAXErrorAPIDisabled>
+            AXSelectedText    : <kAXErrorAPIDisabled>
+---------------------------------------------------------------
+[1:17:20 pm] frontmost app     : universalAccessAuthWarn
+            bundle id         : com.apple.accessibility.universalAccessAuthWarn  (pid 43570)
+            AX trusted        : NO
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorAPIDisabled>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorAPIDisabled>
+            focused subrole   : <kAXErrorAPIDisabled>
+            role description  : <kAXErrorAPIDisabled>
+            focused title     : <kAXErrorAPIDisabled>
+            AXValue readable  : <kAXErrorAPIDisabled>
+            AXSelectedText    : <kAXErrorAPIDisabled>
+---------------------------------------------------------------
+[1:17:21 pm] frontmost app     : System Settings
+            bundle id         : com.apple.systempreferences  (pid 51729)
+            AX trusted        : NO
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorCannotComplete>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorCannotComplete>
+            focused subrole   : <kAXErrorCannotComplete>
+            role description  : <kAXErrorCannotComplete>
+            focused title     : <kAXErrorCannotComplete>
+            AXValue readable  : <kAXErrorCannotComplete>
+            AXSelectedText    : <kAXErrorCannotComplete>
+---------------------------------------------------------------
+[1:17:22 pm] frontmost app     : System Settings
+            bundle id         : com.apple.systempreferences  (pid 51729)
+            AX trusted        : NO
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorAPIDisabled>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorAPIDisabled>
+            focused subrole   : <kAXErrorAPIDisabled>
+            role description  : <kAXErrorAPIDisabled>
+            focused title     : <kAXErrorAPIDisabled>
+            AXValue readable  : <kAXErrorAPIDisabled>
+            AXSelectedText    : <kAXErrorAPIDisabled>
+---------------------------------------------------------------
+[1:17:30 pm] frontmost app     : System Settings
+            bundle id         : com.apple.systempreferences  (pid 51729)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Accessibility
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXOutline
+            focused subrole   : <kAXErrorAttributeUnsupported>
+            role description  : list
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : no (kAXErrorAttributeUnsupported)
+            AXSelectedText    : no (kAXErrorAttributeUnsupported)
+---------------------------------------------------------------
+[1:17:31 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : domain.md — openstream — Untracked
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:18:35 pm] frontmost app     : Terminal
+            bundle id         : com.apple.Terminal  (pid 48784)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : zazai — swift-frontend ◂ run.sh --prompt — 80×24
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextArea
+            focused subrole   : <kAXErrorAttributeUnsupported>
+            role description  : text entry area
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : yes (5673 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:18:40 pm] frontmost app     : TextEdit
+            bundle id         : com.apple.TextEdit  (pid 52341)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Open
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXList
+            focused subrole   : <kAXErrorAttributeUnsupported>
+            role description  : list
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : no (kAXErrorAttributeUnsupported)
+            AXSelectedText    : no (kAXErrorAttributeUnsupported)
+---------------------------------------------------------------
+[1:18:43 pm] frontmost app     : Notes
+            bundle id         : com.apple.Notes  (pid 52376)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Notes
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWindow
+            focused subrole   : AXStandardWindow
+            role description  : standard window
+            focused title     : Notes
+            AXValue readable  : no (kAXErrorAttributeUnsupported)
+            AXSelectedText    : no (kAXErrorAttributeUnsupported)
+---------------------------------------------------------------
+[1:18:46 pm] frontmost app     : Safari
+            bundle id         : com.apple.Safari  (pid 44573)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:18:50 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : New chat - Claude - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXButton
+            focused subrole   : <kAXErrorNoValue>
+            role description  : button
+            focused title     : Usage
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:18:52 pm] frontmost app     : TextEdit
+            bundle id         : com.apple.TextEdit  (pid 52341)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Open
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXList
+            focused subrole   : <kAXErrorAttributeUnsupported>
+            role description  : list
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : no (kAXErrorAttributeUnsupported)
+            AXSelectedText    : no (kAXErrorAttributeUnsupported)
+---------------------------------------------------------------
+[1:18:53 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : domain.md — openstream — Untracked
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:18:54 pm] frontmost app     : Terminal
+            bundle id         : com.apple.Terminal  (pid 48784)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : zazai — swift-frontend ◂ run.sh --prompt — 80×24
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextArea
+            focused subrole   : <kAXErrorAttributeUnsupported>
+            role description  : text entry area
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : yes (10310 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:19:02 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : domain.md — openstream — Untracked
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:19:08 pm] frontmost app     : Cursor
+            bundle id         : com.todesktop.230313mzl4w4u92  (pid 52484)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:19:09 pm] frontmost app     : Cursor
+            bundle id         : com.todesktop.230313mzl4w4u92  (pid 52484)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Cursor Agents
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:19:10 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : domain.md — openstream — Untracked
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:19:12 pm] frontmost app     : Obsidian
+            bundle id         : md.obsidian  (pid 52865)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:19:13 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : domain.md — openstream — Untracked
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:19:16 pm] frontmost app     : ‎WhatsApp
+            bundle id         : net.whatsapp.WhatsApp  (pid 670)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:19:17 pm] frontmost app     : UserNotificationCenter
+            bundle id         : com.apple.UserNotificationCenter  (pid 8495)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <empty>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWindow
+            focused subrole   : AXSystemDialog
+            role description  : system dialogue
+            focused title     : <empty>
+            AXValue readable  : no (kAXErrorAttributeUnsupported)
+            AXSelectedText    : no (kAXErrorAttributeUnsupported)
+---------------------------------------------------------------
+[1:19:17 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : domain.md — openstream — Untracked
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:19:20 pm] frontmost app     : Finder
+            bundle id         : com.apple.finder  (pid 681)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXGroup
+            focused subrole   : <kAXErrorNoValue>
+            role description  : group
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : no (kAXErrorNoValue)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:19:23 pm] frontmost app     : Cursor
+            bundle id         : com.todesktop.230313mzl4w4u92  (pid 52484)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Cursor Agents
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:19:24 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : domain.md — openstream — Untracked
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)

--- a/prototypes/context-detection-spike/logs/probe-20260822-131955.log
+++ b/prototypes/context-detection-spike/logs/probe-20260822-131955.log
@@ -1,0 +1,213 @@
+OpenStream context-detection spike (issue #28) - PROTOTYPE, throwaway
+AXIsProcessTrusted() = true
+poke AXManualAccessibility = true   interval = 0.4s
+Switch apps and click into text fields. Records print only when something changes.
+Ctrl-C to stop.
+---------------------------------------------------------------
+[1:19:58 pm] frontmost app     : Cursor
+            bundle id         : com.todesktop.230313mzl4w4u92  (pid 52484)
+            AX trusted        : yes
+            AXManualAccess.   : success
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:20:00 pm] frontmost app     : Terminal
+            bundle id         : com.apple.Terminal  (pid 48784)
+            AX trusted        : yes
+            AXManualAccess.   : kAXErrorAttributeUnsupported
+            window title      : zazai — swift-frontend ◂ run.sh --poke — 80×24
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextArea
+            focused subrole   : <kAXErrorAttributeUnsupported>
+            role description  : text entry area
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : yes (1335 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:20:09 pm] frontmost app     : TextEdit
+            bundle id         : com.apple.TextEdit  (pid 52341)
+            AX trusted        : yes
+            AXManualAccess.   : kAXErrorAttributeUnsupported
+            window title      : Open
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXList
+            focused subrole   : <kAXErrorAttributeUnsupported>
+            role description  : list
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : no (kAXErrorAttributeUnsupported)
+            AXSelectedText    : no (kAXErrorAttributeUnsupported)
+---------------------------------------------------------------
+[1:20:11 pm] frontmost app     : TextEdit
+            bundle id         : com.apple.TextEdit  (pid 52341)
+            AX trusted        : yes
+            AXManualAccess.   : already poked
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:20:13 pm] frontmost app     : Notes
+            bundle id         : com.apple.Notes  (pid 52376)
+            AX trusted        : yes
+            AXManualAccess.   : kAXErrorAttributeUnsupported
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:20:16 pm] frontmost app     : Safari
+            bundle id         : com.apple.Safari  (pid 44573)
+            AX trusted        : yes
+            AXManualAccess.   : kAXErrorAttributeUnsupported
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:20:19 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : kAXErrorAttributeUnsupported
+            window title      : New chat - Claude - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXButton
+            focused subrole   : <kAXErrorNoValue>
+            role description  : button
+            focused title     : Usage
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:20:22 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : success
+            window title      : domain.md — openstream
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:20:22 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : already poked
+            window title      : New chat - Claude - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXButton
+            focused subrole   : <kAXErrorNoValue>
+            role description  : button
+            focused title     : Usage
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:20:24 pm] frontmost app     : Cursor
+            bundle id         : com.todesktop.230313mzl4w4u92  (pid 52484)
+            AX trusted        : yes
+            AXManualAccess.   : already poked
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:20:26 pm] frontmost app     : Terminal
+            bundle id         : com.apple.Terminal  (pid 48784)
+            AX trusted        : yes
+            AXManualAccess.   : already poked
+            window title      : zazai — swift-frontend ◂ run.sh --poke — 80×24
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextArea
+            focused subrole   : <kAXErrorAttributeUnsupported>
+            role description  : text entry area
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : yes (7363 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:20:28 pm] frontmost app     : Obsidian
+            bundle id         : md.obsidian  (pid 52865)
+            AX trusted        : yes
+            AXManualAccess.   : success
+            window title      : 2026-08-20 - Obsidian Vault - Obsidian 1.13.7
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:20:30 pm] frontmost app     : Obsidian
+            bundle id         : md.obsidian  (pid 52865)
+            AX trusted        : yes
+            AXManualAccess.   : already poked
+            window title      : 2026-08-20 - Obsidian Vault - Obsidian 1.13.7
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXGroup
+            focused subrole   : <kAXErrorNoValue>
+            role description  : group
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:20:31 pm] frontmost app     : ‎WhatsApp
+            bundle id         : net.whatsapp.WhatsApp  (pid 670)
+            AX trusted        : yes
+            AXManualAccess.   : kAXErrorAttributeUnsupported
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:20:35 pm] frontmost app     : Finder
+            bundle id         : com.apple.finder  (pid 681)
+            AX trusted        : yes
+            AXManualAccess.   : kAXErrorAttributeUnsupported
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXGroup
+            focused subrole   : <kAXErrorNoValue>
+            role description  : group
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : no (kAXErrorNoValue)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:20:37 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : already poked
+            window title      : domain.md — openstream — Deleted
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)

--- a/prototypes/context-detection-spike/logs/probe-20260822-132125.log
+++ b/prototypes/context-detection-spike/logs/probe-20260822-132125.log
@@ -1,0 +1,954 @@
+OpenStream context-detection spike (issue #28) - PROTOTYPE, throwaway
+AXIsProcessTrusted() = true
+poke AXManualAccessibility = false   interval = 0.4s
+Switch apps and click into text fields. Records print only when something changes.
+Ctrl-C to stop.
+---------------------------------------------------------------
+[1:21:25 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : domain.md — openstream — Deleted
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:21:38 pm] frontmost app     : Safari
+            bundle id         : com.apple.Safari  (pid 44573)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:21:40 pm] frontmost app     : UserNotificationCenter
+            bundle id         : com.apple.UserNotificationCenter  (pid 8495)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <empty>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWindow
+            focused subrole   : AXSystemDialog
+            role description  : system dialogue
+            focused title     : <empty>
+            AXValue readable  : no (kAXErrorAttributeUnsupported)
+            AXSelectedText    : no (kAXErrorAttributeUnsupported)
+---------------------------------------------------------------
+[1:21:41 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : domain.md — openstream — Deleted
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:21:46 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : New chat - Claude - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXButton
+            focused subrole   : <kAXErrorNoValue>
+            role description  : button
+            focused title     : Usage
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:21:48 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : New chat - Claude - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (36 chars)
+            AXSelectedText    : yes (36 chars)
+---------------------------------------------------------------
+[1:21:48 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : domain.md — openstream — Deleted
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:21:51 pm] frontmost app     : TextEdit
+            bundle id         : com.apple.TextEdit  (pid 52341)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:21:52 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : domain.md — openstream — Deleted
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:21:57 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Untitled-1 — openstream
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : editor
+            focused title     : <empty>
+            AXValue readable  : yes (1 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:21:59 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Untitled-1 — openstream
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:22:00 pm] frontmost app     : Cursor
+            bundle id         : com.todesktop.230313mzl4w4u92  (pid 52484)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:22:01 pm] frontmost app     : Cursor
+            bundle id         : com.todesktop.230313mzl4w4u92  (pid 52484)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Cursor Agents
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:22:02 pm] frontmost app     : Cursor
+            bundle id         : com.todesktop.230313mzl4w4u92  (pid 52484)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Cursor Agents
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWebArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : HTML content
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:22:03 pm] frontmost app     : Cursor
+            bundle id         : com.todesktop.230313mzl4w4u92  (pid 52484)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Cursor Agents
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWebArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : HTML content
+            focused title     : Cursor Agents
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:22:05 pm] frontmost app     : Notes
+            bundle id         : com.apple.Notes  (pid 52376)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:22:05 pm] frontmost app     : TextEdit
+            bundle id         : com.apple.TextEdit  (pid 52341)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Untitled
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextArea
+            focused subrole   : <kAXErrorAttributeUnsupported>
+            role description  : text entry area
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:22:06 pm] frontmost app     : TextEdit
+            bundle id         : com.apple.TextEdit  (pid 52341)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Untitled
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : AXSearchField
+            role description  : search text field
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:22:07 pm] frontmost app     : TextEdit
+            bundle id         : com.apple.TextEdit  (pid 52341)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:22:08 pm] frontmost app     : Terminal
+            bundle id         : com.apple.Terminal  (pid 48784)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : zazai — sleep ◂ focus.sh — 80×24
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextArea
+            focused subrole   : <kAXErrorAttributeUnsupported>
+            role description  : text entry area
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : yes (446 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:22:10 pm] frontmost app     : Obsidian
+            bundle id         : md.obsidian  (pid 52865)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:22:10 pm] frontmost app     : Terminal
+            bundle id         : com.apple.Terminal  (pid 48784)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : zazai — swift-frontend ◂ run.sh — 80×24
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextArea
+            focused subrole   : <kAXErrorAttributeUnsupported>
+            role description  : text entry area
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : yes (14280 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:22:12 pm] frontmost app     : Terminal
+            bundle id         : com.apple.Terminal  (pid 48784)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Open
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXList
+            focused subrole   : <kAXErrorAttributeUnsupported>
+            role description  : list
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : no (kAXErrorAttributeUnsupported)
+            AXSelectedText    : no (kAXErrorAttributeUnsupported)
+---------------------------------------------------------------
+[1:22:15 pm] frontmost app     : Terminal
+            bundle id         : com.apple.Terminal  (pid 48784)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : zazai — swift-frontend ◂ run.sh — 80×24
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextArea
+            focused subrole   : <kAXErrorAttributeUnsupported>
+            role description  : text entry area
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : yes (15646 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:22:17 pm] frontmost app     : Code
+            bundle id         : com.microsoft.VSCode  (pid 8648)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Untitled-1 — openstream
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:22:26 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : New chat - Claude - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (28 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:22:28 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <empty>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:22:31 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <empty>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWebArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : HTML content
+            focused title     : New Tab
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:22:31 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <empty>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:22:32 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : GitHub - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:22:32 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : GitHub - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWebArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : HTML content
+            focused title     : GitHub
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:22:36 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : GitHub - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXLink
+            focused subrole   : <kAXErrorNoValue>
+            role description  : link
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:22:37 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Nabzx/openstream: A free, fully local, zero-setup voice dictation app for macOS - built specifically for developers. - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:22:37 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Nabzx/openstream: A free, fully local, zero-setup voice dictation app for macOS - built specifically for developers. - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWebArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : HTML content
+            focused title     : Nabzx/openstream: A free, fully local, zero-setup voice dictation app for macOS - built specifically for developers.
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:22:44 pm] frontmost app     : Safari
+            bundle id         : com.apple.Safari  (pid 44573)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:22:45 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Nabzx/openstream: A free, fully local, zero-setup voice dictation app for macOS - built specifically for developers. - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWebArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : HTML content
+            focused title     : Nabzx/openstream: A free, fully local, zero-setup voice dictation app for macOS - built specifically for developers.
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:22:48 pm] frontmost app     : Terminal
+            bundle id         : com.apple.Terminal  (pid 48784)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : zazai — osascript ◂ focus-retry.sh — 80×24
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextArea
+            focused subrole   : <kAXErrorAttributeUnsupported>
+            role description  : text entry area
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : yes (460 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:22:49 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Nabzx/openstream: A free, fully local, zero-setup voice dictation app for macOS - built specifically for developers. - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWebArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : HTML content
+            focused title     : Nabzx/openstream: A free, fully local, zero-setup voice dictation app for macOS - built specifically for developers.
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:22:50 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Nabzx/openstream: A free, fully local, zero-setup voice dictation app for macOS - built specifically for developers. - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (35 chars)
+            AXSelectedText    : yes (35 chars)
+---------------------------------------------------------------
+[1:22:51 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Nabzx/openstream: A free, fully local, zero-setup voice dictation app for macOS - built specifically for developers. - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXLink
+            focused subrole   : <kAXErrorNoValue>
+            role description  : link
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:22:52 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Issues · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXLink
+            focused subrole   : <kAXErrorNoValue>
+            role description  : link
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:22:56 pm] frontmost app     : Notes
+            bundle id         : com.apple.Notes  (pid 52376)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:22:58 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Issues · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXLink
+            focused subrole   : <kAXErrorNoValue>
+            role description  : link
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:22:58 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Issues · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:23:00 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Issues · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXLink
+            focused subrole   : <kAXErrorNoValue>
+            role description  : link
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:23:00 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Pull requests · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXLink
+            focused subrole   : <kAXErrorNoValue>
+            role description  : link
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:23:04 pm] frontmost app     : Obsidian
+            bundle id         : md.obsidian  (pid 52865)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorNoValue>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:23:05 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Pull requests · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXLink
+            focused subrole   : <kAXErrorNoValue>
+            role description  : link
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:23:07 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : <kAXErrorAttributeUnsupported>
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXList
+            focused subrole   : <kAXErrorAttributeUnsupported>
+            role description  : list
+            focused title     : <kAXErrorAttributeUnsupported>
+            AXValue readable  : no (kAXErrorAttributeUnsupported)
+            AXSelectedText    : no (kAXErrorAttributeUnsupported)
+---------------------------------------------------------------
+[1:23:09 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Pull requests · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXLink
+            focused subrole   : <kAXErrorNoValue>
+            role description  : link
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:23:15 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Comparing Nabzx:main...Zazai840:chore/agent-skills-config · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : Add a title *
+            AXValue readable  : yes (37 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:23:24 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Comparing Nabzx:main...Zazai840:chore/agent-skills-config · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWebArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : HTML content
+            focused title     : Comparing Nabzx:main...Zazai840:chore/agent-skills-config · Nabzx/openstream
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:23:26 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Comparing Nabzx:main...Zazai840:chore/agent-skills-config · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:23:26 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : chore: add agent skills configuration by Zazai840 · Pull Request #35 · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWebArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : HTML content
+            focused title     : chore: add agent skills configuration by Zazai840 · Pull Request #35 · Nabzx/openstream
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:23:32 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : chore: add agent skills configuration by Zazai840 · Pull Request #35 · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : Commit message
+            AXValue readable  : yes (62 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:23:34 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : chore: add agent skills configuration by Zazai840 · Pull Request #35 · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXButton
+            focused subrole   : <kAXErrorNoValue>
+            role description  : button
+            focused title     : Confirm merge
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:23:36 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : chore: add agent skills configuration by Zazai840 · Pull Request #35 · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWebArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : HTML content
+            focused title     : chore: add agent skills configuration by Zazai840 · Pull Request #35 · Nabzx/openstream
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:23:43 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Comparing Nabzx:main...Zazai840:chore/agent-skills-config · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWebArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : HTML content
+            focused title     : Comparing Nabzx:main...Zazai840:chore/agent-skills-config · Nabzx/openstream
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:23:45 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : chore: add agent skills configuration by Zazai840 · Pull Request #35 · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWebArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : HTML content
+            focused title     : chore: add agent skills configuration by Zazai840 · Pull Request #35 · Nabzx/openstream
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:23:45 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Comparing Nabzx:main...Zazai840:chore/agent-skills-config · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWebArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : HTML content
+            focused title     : Comparing Nabzx:main...Zazai840:chore/agent-skills-config · Nabzx/openstream
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:23:46 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Pull requests · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWebArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : HTML content
+            focused title     : Comparing Nabzx:main...Zazai840:chore/agent-skills-config · Nabzx/openstream
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:23:46 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Pull requests · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWebArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : HTML content
+            focused title     : Pull requests · Nabzx/openstream
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:23:48 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Pull requests · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXLink
+            focused subrole   : <kAXErrorNoValue>
+            role description  : link
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:23:49 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Comparing Nabzx:main...Zazai840:prototype/context-detection-28 · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : Add a title *
+            AXValue readable  : yes (56 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:24:16 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Comparing Nabzx:main...Zazai840:prototype/context-detection-28 · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWebArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : HTML content
+            focused title     : Comparing Nabzx:main...Zazai840:prototype/context-detection-28 · Nabzx/openstream
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:24:18 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : spike: probe macOS Accessibility context detection (#28) by Zazai840 · Pull Request #36 · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : <kAXErrorNoValue>
+            focused subrole   : <kAXErrorNoValue>
+            role description  : <kAXErrorNoValue>
+            focused title     : <kAXErrorNoValue>
+            AXValue readable  : <kAXErrorNoValue>
+            AXSelectedText    : <kAXErrorNoValue>
+---------------------------------------------------------------
+[1:24:19 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : spike: probe macOS Accessibility context detection (#28) by Zazai840 · Pull Request #36 · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWebArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : HTML content
+            focused title     : spike: probe macOS Accessibility context detection (#28) by Zazai840 · Pull Request #36 · Nabzx/openstream
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:24:23 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : spike: probe macOS Accessibility context detection (#28) by Zazai840 · Pull Request #36 · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : Commit message
+            AXValue readable  : yes (67 chars)
+            AXSelectedText    : yes (0 chars)
+---------------------------------------------------------------
+[1:24:24 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : spike: probe macOS Accessibility context detection (#28) by Zazai840 · Pull Request #36 · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXButton
+            focused subrole   : <kAXErrorNoValue>
+            role description  : button
+            focused title     : Confirm merge
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:24:26 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : spike: probe macOS Accessibility context detection (#28) by Zazai840 · Pull Request #36 · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXWebArea
+            focused subrole   : <kAXErrorNoValue>
+            role description  : HTML content
+            focused title     : spike: probe macOS Accessibility context detection (#28) by Zazai840 · Pull Request #36 · Nabzx/openstream
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:24:37 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : spike: probe macOS Accessibility context detection (#28) by Zazai840 · Pull Request #36 · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXLink
+            focused subrole   : <kAXErrorNoValue>
+            role description  : link
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:24:38 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Nabzx/openstream: A free, fully local, zero-setup voice dictation app for macOS - built specifically for developers. - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXLink
+            focused subrole   : <kAXErrorNoValue>
+            role description  : link
+            focused title     : <empty>
+            AXValue readable  : yes (0 chars)
+            AXSelectedText    : no (kAXErrorNoValue)
+---------------------------------------------------------------
+[1:24:41 pm] frontmost app     : Google Chrome
+            bundle id         : com.google.Chrome  (pid 2520)
+            AX trusted        : yes
+            AXManualAccess.   : <skipped>
+            window title      : Comparing Nabzx:main...Zazai840:research/model-licensing · Nabzx/openstream - Google Chrome – Abdulaziz
+            system-wide focus : <kAXErrorCannotComplete>
+            focused role      : AXTextField
+            focused subrole   : <kAXErrorNoValue>
+            role description  : text field
+            focused title     : Add a title *
+            AXValue readable  : yes (61 chars)
+            AXSelectedText    : yes (0 chars)

--- a/prototypes/context-detection-spike/probe.swift
+++ b/prototypes/context-detection-spike/probe.swift
@@ -114,6 +114,10 @@ struct Sample {
     }
 }
 
+/// Apps already poked this run, so the one-second settle wait is paid once per
+/// app rather than on every sample.
+var pokedPIDs = Set<pid_t>()
+
 func sampleNow() -> Sample {
     let trusted = AXIsProcessTrusted()
     var s = Sample(frontApp: "<none>", bundleID: "<none>", pid: "<none>",
@@ -135,7 +139,16 @@ func sampleNow() -> Sample {
     // actually publish a tree.
     let appElement = AXUIElementCreateApplication(app.processIdentifier)
     if wantPoke {
-        s.pokeResult = pokeManualAccessibility(appElement)
+        if pokedPIDs.contains(app.processIdentifier) {
+            s.pokeResult = "already poked"
+        } else {
+            s.pokeResult = pokeManualAccessibility(appElement)
+            pokedPIDs.insert(app.processIdentifier)
+            // Chromium builds its accessibility tree asynchronously after the
+            // flag is set. Reading in the same breath as the poke shows nothing
+            // even when the poke worked, so give it a beat before the first read.
+            Thread.sleep(forTimeInterval: 1.0)
+        }
     }
 
     let systemWide = AXUIElementCreateSystemWide()

--- a/prototypes/context-detection-spike/run-all-42.sh
+++ b/prototypes/context-detection-spike/run-all-42.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# PROTOTYPE - throwaway spike for issue #42. Drives the whole second pass in one
+# go, so it can run unattended on a quiet machine.
+#
+# MUST be launched from Terminal.app, because every keystroke here goes through
+# System Events and the process that needs Accessibility trust is the one making
+# the call. Terminal.app was granted during issue #28 and still holds it.
+#
+#   osascript -e 'tell app "Terminal" to do script "<abs path>/run-all-42.sh"'
+set -u
+cd "$(dirname "$0")"
+mkdir -p logs
+
+STAMP=$(date +%Y%m%d-%H%M%S)
+MAIN="logs/probe-42-$STAMP.log"
+TRACE="logs/run-all-42-$STAMP.trace"
+
+exec > >(tee -a "$TRACE") 2>&1
+
+echo "### run-all-42 starting at $(date)"
+swift probe.swift --once | head -3
+
+# One long-lived probe covers the sweep, the field pass and the focus retry.
+# controlled-ab-42.sh and jetbrains-knob-ab.sh start their own probes, so this
+# one is stopped before they run.
+swift probe.swift --poke > "$MAIN" 2>&1 &
+PROBE=$!
+sleep 10
+echo "### probe running -> $MAIN"
+
+./sweep-42.sh
+./field-pass-42.sh
+./focus-retry-42.sh
+
+kill "$PROBE" 2>/dev/null
+pkill -f "probe.swift" 2>/dev/null
+sleep 3
+echo "### main probe stopped"
+
+./controlled-ab-42.sh
+
+echo "### run-all-42 done at $(date)"
+echo "### logs: $MAIN, logs/ab42-nopoke.log, logs/ab42-poke.log"
+echo "### jetbrains-knob-ab.sh is NOT run here - IntelliJ needs one manual first launch"

--- a/prototypes/context-detection-spike/sweep-42.sh
+++ b/prototypes/context-detection-spike/sweep-42.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# PROTOTYPE - throwaway spike for issue #42. App-level (layer 1) sweep over the
+# three slots issue #28 could not install, plus the three apps whose layer-2
+# cells came back inconclusive because a person was stealing focus with Chrome
+# during that pass.
+#
+# Same shape as sweep.sh, two differences: the new app list, and a much longer
+# dwell. Issue #28's inconclusive cells are a dwell artifact, so this pass does
+# not repeat a three-second dwell.
+set -u
+cd "$(dirname "$0")"
+
+DWELL="${DWELL:-10}"
+
+APPS=(
+  "Slack"
+  "Hyper"
+  "IntelliJ IDEA CE"
+  "Safari"
+  "Notes"
+  "WhatsApp"
+)
+
+RETURN_TO="${RETURN_TO:-Terminal}"
+
+for app in "${APPS[@]}"; do
+  if [ ! -d "/Applications/$app.app" ]; then
+    echo "### NOT INSTALLED: $app"
+    continue
+  fi
+  if osascript -e "tell application \"$app\" to activate" >/dev/null 2>&1; then
+    echo "### activated: $app"
+  else
+    echo "### ACTIVATION FAILED: $app"
+  fi
+  sleep "$DWELL"
+done
+
+osascript -e "tell application \"$RETURN_TO\" to activate" >/dev/null 2>&1
+echo "### sweep-42 done, returned to $RETURN_TO"


### PR DESCRIPTION
Extends the throwaway context-detection probe to the three app slots #28 could not test because the apps were not installed, and fixes the two defects that left cells inconclusive there.

New scripts:
- sweep-42.sh, field-pass-42.sh: layer 1 and layer 2 over Slack, Hyper and IntelliJ IDEA CE.
- jetbrains-knob-ab.sh: the third-category test. JetBrains renders in Swing, so AXManualAccessibility does nothing and the tree appears only when the IDE's own "Support screen readers" option is on. Both arms are driven from disk via ide.general.xml with a cold relaunch, since the setting is read at startup.
- focus-retry-42.sh, controlled-ab-42.sh: re-runs of the two #28 passes whose cells failed for test-artifact reasons. Both replace sleep-through-the-dwell with re-asserted activation every two seconds, so no other app can hold focus for more than two seconds, and both print the re-assertion count so the dwell is auditable rather than assumed.
- run-all-42.sh: drives the whole pass unattended in one command.

Two preconditions that could have blocked the ticket are cleared and recorded: Terminal.app still holds the Accessibility grant from #28, and Slack 4.51.191, Hyper 3.4.1 and IntelliJ IDEA CE 2025.2.5 are installed. Hyper is the only genuinely Electron option of the three terminals the issue named; Warp is Rust and Ghostty is Zig, so neither would test the Electron shape.

The measurement itself has not been run: the pass drives focus through osascript, which this session is not permitted to invoke. RESULTS-42.md states every cell as unmeasured rather than filling in expectations, and carries the one command needed to fill them.

Prototype code. Throwaway, no tests, not to be built on.