### PR TITLE
ci: add GitHub Actions build check on every PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,21 @@
+name: Build
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+      - run: npm run build


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/build.yml`: runs on every PR into `main` and on push to `main`
- Job runs on `macos-latest` (project targets macOS), installs Node 20, then `npm ci` + `npm run build` (tsc typecheck + vite build)

Replaces #60, which is closed — that branch picked up unrelated tray-icon commits by mistake (now split out cleanly into #63) and rewriting its pushed history needed a force-push I didn't have permission for, so this is a fresh PR with the same single commit off current main instead.

Closes #3

## Test plan
- [x] `npm ci && npm run build` verified locally, passes cleanly
- [x] Same workflow already confirmed green on GitHub Actions via #60 before it was closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
