### PR TITLE
feat: hardcoded hotkey records, transcribes and prints to console (#2)

### DIFF
--- a/docs/testing/hotkey-transcribe-manual-check.md
+++ b/docs/testing/hotkey-transcribe-manual-check.md
@@ -1,0 +1,33 @@
+# Manual check: hotkey -> transcribe -> console (#2)
+
+What CI/a headless session can verify, and what still needs a human running
+the actual app: launching a real Electron window, granting microphone
+permission, and pressing a global hotkey aren't things a sandboxed session
+can drive.
+
+## Already verified without a GUI
+
+- `whisper-server` compiles and serves `/inference`: a synthetic TTS clip
+  posted with the exact `encodeWav` + `fetch`/`FormData` code path `main.js`
+  uses came back correctly transcribed.
+- `encodeWav` produces a valid mono 16kHz 16-bit WAV (checked against
+  `afinfo`).
+- All new files pass `node --check`.
+
+## Needs a human, one time
+
+1. `npm install` (builds whisper-server and fetches the model if not already
+   present), then `npm start`.
+2. First press of `Cmd+Shift+D` should trigger the macOS microphone
+   permission prompt. Grant it.
+3. Say something, press `Cmd+Shift+D` again to stop.
+4. The transcript should print to the terminal running `npm start`,
+   prefixed `[dictation]`.
+5. Press it again with no speech (press-then-immediately-press-again) -
+   should log `no audio captured, skipping` rather than hitting the server.
+
+If step 2 doesn't fire the OS prompt, or step 4 never prints, check the
+terminal for `[whisper-server]`-prefixed lines first - the resident server
+takes ~15-20s to load Metal shaders on a cold start (see the M1 timing
+in `spike/llm-cleanup-latency/`), so an early hotkey press mid-load will log
+a connection error rather than a transcript.

--- a/electron/capture/capture.js
+++ b/electron/capture/capture.js
@@ -1,0 +1,65 @@
+// Runs in the hidden capture window's renderer. Captures mono 16kHz PCM
+// while recording is toggled on, and hands it back to main on stop.
+//
+// Per issue #33: acquire the MediaStream and AudioContext once and keep
+// them alive, then let start/stop toggle only whether samples are kept -
+// not per-press getUserMedia calls, which would put an unbounded async
+// step on the critical path of "user pressed the key and started talking".
+let audioContext = null;
+let processorNode = null;
+let isRecording = false;
+let chunks = [];
+
+async function ensureCapture() {
+  if (audioContext) return;
+
+  const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+  audioContext = new AudioContext({ sampleRate: 16000 });
+  const source = audioContext.createMediaStreamSource(stream);
+
+  // ScriptProcessorNode only fires onaudioprocess while connected to a
+  // destination. Route through a silent gain node rather than the real
+  // output so capture keeps running without the user hearing themselves.
+  processorNode = audioContext.createScriptProcessor(4096, 1, 1);
+  processorNode.onaudioprocess = (event) => {
+    if (!isRecording) return;
+    chunks.push(new Float32Array(event.inputBuffer.getChannelData(0)));
+  };
+
+  const silentGain = audioContext.createGain();
+  silentGain.gain.value = 0;
+
+  source.connect(processorNode);
+  processorNode.connect(silentGain);
+  silentGain.connect(audioContext.destination);
+}
+
+function floatTo16BitPCM(chunks) {
+  const totalLength = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+  const result = new Int16Array(totalLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    for (let i = 0; i < chunk.length; i++) {
+      const clamped = Math.max(-1, Math.min(1, chunk[i]));
+      result[offset++] = clamped < 0 ? clamped * 0x8000 : clamped * 0x7fff;
+    }
+  }
+  return result;
+}
+
+window.capture.onStart(async () => {
+  try {
+    await ensureCapture();
+    chunks = [];
+    isRecording = true;
+  } catch (err) {
+    window.capture.sendError(String(err));
+  }
+});
+
+window.capture.onStop(() => {
+  isRecording = false;
+  const samples = floatTo16BitPCM(chunks);
+  chunks = [];
+  window.capture.sendAudio(samples.buffer);
+});

--- a/electron/capture/capturePreload.js
+++ b/electron/capture/capturePreload.js
@@ -1,0 +1,11 @@
+const { contextBridge, ipcRenderer } = require("electron");
+
+// Bridge for the hidden mic-capture window. Never shown to the user - see
+// issue #33: a menu bar app has no visible window, so getUserMedia needs a
+// hidden renderer to live in.
+contextBridge.exposeInMainWorld("capture", {
+  onStart: (callback) => ipcRenderer.on("start-recording", callback),
+  onStop: (callback) => ipcRenderer.on("stop-recording", callback),
+  sendAudio: (int16Buffer) => ipcRenderer.send("recording-data", int16Buffer),
+  sendError: (message) => ipcRenderer.send("recording-error", message),
+});

--- a/electron/capture/captureWindow.html
+++ b/electron/capture/captureWindow.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>OpenStream mic capture</title>
+  </head>
+  <body>
+    <script src="capture.js"></script>
+  </body>
+</html>

--- a/electron/main.js
+++ b/electron/main.js
@@ -68,8 +68,8 @@ async function transcribeAndPrint(int16Samples) {
   try {
     const res = await fetch(whisperServer.inferenceUrl(), { method: "POST", body: formData });
     if (!res.ok) throw new Error(`whisper-server returned ${res.status}`);
-    const { text } = await res.json();
-    console.log(`[dictation] ${text.trim()}`);
+    const body = await res.json();
+    console.log(`[dictation] ${(body.text || "").trim() || "(no speech detected)"}`);
   } catch (err) {
     console.error("[dictation] transcription failed:", err);
   }
@@ -98,6 +98,10 @@ function createTray() {
 ipcMain.on("recording-data", (event, arrayBuffer) => {
   const buffer = Buffer.from(arrayBuffer);
   const samples = new Int16Array(buffer.buffer, buffer.byteOffset, buffer.byteLength / 2);
+  if (samples.length === 0) {
+    console.log("[dictation] no audio captured, skipping");
+    return;
+  }
   transcribeAndPrint(samples);
 });
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,10 +1,18 @@
-const { app, Tray, Menu, BrowserWindow } = require("electron");
+const { app, Tray, Menu, BrowserWindow, globalShortcut, ipcMain } = require("electron");
 const path = require("path");
+const whisperServer = require("./whisperServer");
+const { encodeWav } = require("./wav");
 
 const isDev = process.env.NODE_ENV === "development";
 
+// Phase 0 hardcoded hotkey - proof that record -> transcribe -> console
+// works before any UI is built around it. Real push-to-talk config is #5.
+const DICTATE_HOTKEY = "CommandOrControl+Shift+D";
+
 let tray = null;
 let win = null;
+let captureWin = null;
+let isRecording = false;
 
 function createWindow() {
   if (win) {
@@ -39,6 +47,41 @@ function createWindow() {
   });
 }
 
+function createCaptureWindow() {
+  captureWin = new BrowserWindow({
+    show: false,
+    webPreferences: {
+      preload: path.join(__dirname, "capture", "capturePreload.js"),
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
+  });
+  captureWin.loadFile(path.join(__dirname, "capture", "captureWindow.html"));
+}
+
+async function transcribeAndPrint(int16Samples) {
+  const wavBuffer = encodeWav(int16Samples);
+  const formData = new FormData();
+  formData.append("file", new Blob([wavBuffer], { type: "audio/wav" }), "dictation.wav");
+  formData.append("response_format", "json");
+
+  try {
+    const res = await fetch(whisperServer.inferenceUrl(), { method: "POST", body: formData });
+    if (!res.ok) throw new Error(`whisper-server returned ${res.status}`);
+    const { text } = await res.json();
+    console.log(`[dictation] ${text.trim()}`);
+  } catch (err) {
+    console.error("[dictation] transcription failed:", err);
+  }
+}
+
+function toggleDictation() {
+  if (!captureWin) return;
+  isRecording = !isRecording;
+  captureWin.webContents.send(isRecording ? "start-recording" : "stop-recording");
+  if (isRecording) console.log("[dictation] recording - press the hotkey again to stop");
+}
+
 function createTray() {
   const iconPath = path.join(__dirname, "icons", "iconTemplate.png");
   tray = new Tray(iconPath);
@@ -52,11 +95,30 @@ function createTray() {
   tray.setContextMenu(menu);
 }
 
+ipcMain.on("recording-data", (event, arrayBuffer) => {
+  const buffer = Buffer.from(arrayBuffer);
+  const samples = new Int16Array(buffer.buffer, buffer.byteOffset, buffer.byteLength / 2);
+  transcribeAndPrint(samples);
+});
+
+ipcMain.on("recording-error", (event, message) => {
+  console.error("[dictation] capture failed:", message);
+  isRecording = false;
+});
+
 app.whenReady().then(() => {
   if (process.platform === "darwin") {
     app.dock.hide();
   }
   createTray();
+  createCaptureWindow();
+  whisperServer.start();
+  globalShortcut.register(DICTATE_HOTKEY, toggleDictation);
+});
+
+app.on("will-quit", () => {
+  globalShortcut.unregisterAll();
+  whisperServer.stop();
 });
 
 // Menu bar app: stay alive with no windows open, quit only from the tray menu.

--- a/electron/wav.js
+++ b/electron/wav.js
@@ -1,0 +1,35 @@
+// Wraps mono 16-bit PCM samples in a minimal WAV header. whisper-server's
+// /inference endpoint expects a WAV file, not raw PCM - see the curl example
+// in examples/server/README.md and the mic-capture research in issue #33.
+const SAMPLE_RATE = 16000;
+const BITS_PER_SAMPLE = 16;
+const CHANNELS = 1;
+
+function encodeWav(int16Samples) {
+  const dataSize = int16Samples.length * 2;
+  const buffer = Buffer.alloc(44 + dataSize);
+
+  buffer.write("RIFF", 0, "ascii");
+  buffer.writeUInt32LE(36 + dataSize, 4);
+  buffer.write("WAVE", 8, "ascii");
+
+  buffer.write("fmt ", 12, "ascii");
+  buffer.writeUInt32LE(16, 16); // fmt chunk size
+  buffer.writeUInt16LE(1, 20); // PCM
+  buffer.writeUInt16LE(CHANNELS, 22);
+  buffer.writeUInt32LE(SAMPLE_RATE, 24);
+  buffer.writeUInt32LE(SAMPLE_RATE * CHANNELS * (BITS_PER_SAMPLE / 8), 28); // byte rate
+  buffer.writeUInt16LE(CHANNELS * (BITS_PER_SAMPLE / 8), 32); // block align
+  buffer.writeUInt16LE(BITS_PER_SAMPLE, 34);
+
+  buffer.write("data", 36, "ascii");
+  buffer.writeUInt32LE(dataSize, 40);
+
+  for (let i = 0; i < int16Samples.length; i++) {
+    buffer.writeInt16LE(int16Samples[i], 44 + i * 2);
+  }
+
+  return buffer;
+}
+
+module.exports = { encodeWav, SAMPLE_RATE };

--- a/electron/whisperServer.js
+++ b/electron/whisperServer.js
@@ -1,0 +1,45 @@
+const { spawn } = require("child_process");
+const path = require("path");
+
+// Transcription model server: resident for the life of the app, restarted
+// if it crashes. See #29 - a per-dictation subprocess would pay the model
+// load cost (0.38s) on every dictation, and this is not that.
+const HOST = "127.0.0.1";
+const PORT = 8178;
+const RESTART_DELAY_MS = 1000;
+
+const BIN_PATH = path.join(__dirname, "..", "resources", "bin", "whisper-server");
+const MODEL_PATH = path.join(__dirname, "..", "resources", "models", "ggml-base.en.bin");
+
+let child = null;
+let stopping = false;
+
+function start() {
+  stopping = false;
+  child = spawn(BIN_PATH, [
+    "--model", MODEL_PATH,
+    "--host", HOST,
+    "--port", String(PORT),
+  ]);
+
+  child.stdout.on("data", (data) => process.stdout.write(`[whisper-server] ${data}`));
+  child.stderr.on("data", (data) => process.stderr.write(`[whisper-server] ${data}`));
+
+  child.on("exit", (code) => {
+    child = null;
+    if (stopping) return;
+    console.error(`[whisper-server] exited unexpectedly (code ${code}), restarting in ${RESTART_DELAY_MS}ms`);
+    setTimeout(start, RESTART_DELAY_MS);
+  });
+}
+
+function stop() {
+  stopping = true;
+  if (child) child.kill();
+}
+
+function inferenceUrl() {
+  return `http://${HOST}:${PORT}/inference`;
+}
+
+module.exports = { start, stop, inferenceUrl };

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "openstream",
       "version": "0.0.1",
+      "hasInstallScript": true,
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"


### PR DESCRIPTION
Closes #2.

Re-scoped from the issue body on arrival, same pattern as #8/#13/#14/#15/#17: the original text described a download script and a per-dictation subprocess, both settled against since (#30: acquisition is #8's job, already merged; #29: the transcription model server is resident, not per-dictation).

What this actually builds, per the current Phase 0 line in ROADMAP.md:

- `electron/whisperServer.js` - starts `whisper-server` resident at app launch, restarts it if it exits unexpectedly (#29's model supervisor duty #1)
- `electron/wav.js` - wraps raw PCM in a WAV header for the `/inference` endpoint
- `electron/capture/` - hidden renderer window + preload bridge that captures mono 16kHz PCM via `getUserMedia`, per #33's research (Electron is enough, no native helper, keep the stream open rather than acquiring per press)
- `electron/main.js` - `Cmd+Shift+D` toggles recording, encodes the result as WAV, POSTs it to the resident server, prints the transcript to the console

## What's verified vs. what needs a human

This session can't drive a real display or microphone, so:

**Verified headlessly:**
- `whisper-server` compiles and serves `/inference` correctly (confirmed with a live TTS clip)
- The exact `encodeWav` + `fetch`/`FormData` code path `main.js` uses, run against a live server, returns the correct transcript
- `encodeWav` output validated against `afinfo` (correct sample rate/channels/bit depth)
- All new files pass `node --check`
- The Electron app itself couldn't be launched in this sandbox (GUI processes get killed) - see `docs/testing/hotkey-transcribe-manual-check.md` for the one-time manual check needed: mic permission prompt, hotkey press, console output.

## Test plan
- [x] whisper-server HTTP round trip (headless)
- [x] WAV encoder format (headless)
- [ ] Hotkey + mic permission + live console output (needs a human running `npm start`)
