### PR TITLE
docs: one prose mode, break-safe apps, model-decided paragraphs (#45)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -27,7 +27,7 @@ The process that turns captured audio into text. Fills the role currently held b
 _Avoid_: whisper, STT engine, the transcriber
 
 **Rewrite model server**:
-The process that rewrites existing text on request, serving voice edits only. Fills the role currently held by `llama-server`, though the model in that role is not settled.
+The process that rewrites existing text on request. It serves voice edits, and it decides break placement during ordinary dictation. Fills the role currently held by `llama-server`, though the model in that role is not settled.
 _Avoid_: llama-server, the LLM, cleanup model
 
 **Model supervisor**:
@@ -45,5 +45,13 @@ _Avoid_: Eviction, unloading, timeout kill
 ### Cleanup
 
 **Rules cleanup**:
-Deterministic, non-model text tidying applied to every dictation. Costs under a millisecond, and is the only cleanup on the dictation path.
+Deterministic, non-model text tidying applied to every dictation. Costs under a millisecond. It does all cleanup except break placement, which it asks the rewrite model server to decide.
 _Avoid_: Post-processing, formatting pass
+
+**Break-safe application**:
+An application where inserting a line break does not submit or send. The app inserts a paragraph break only in these. Every application is treated as unsafe until it is listed.
+_Avoid_: Allow-listed app, multi-line app, safe app
+
+**Break placement**:
+The choice of where paragraph breaks belong in one dictation. The rewrite model server decides it, and answers with sentence numbers rather than with text.
+_Avoid_: Paragraph inference, auto-formatting, LLM cleanup

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ What's still missing: **dictation that knows what you're looking at.** Every exi
 
 ## What OpenStream does differently
 
-1. **Context-aware formatting** — detects the frontmost app/field via the macOS Accessibility API and adapts: no auto-capitalization or punctuation in a terminal, proper comment/docstring formatting in an editor, normal prose everywhere else.
+1. **Context-aware dictation** - detects the frontmost app via the macOS Accessibility API. Text is cleaned the same way everywhere; what changes by app is where it is *safe* to insert a line break, because in a terminal or a chat window Enter submits and a stray break would send half a sentence. In apps where breaks are safe, a small local model decides where paragraphs belong in long dictation. (Earlier drafts promised terminal-specific and editor-specific formatting. That was dropped in #45: dictation into a terminal is dictation into tools like Claude Code, which want ordinary prose.)
 2. **Codebase-aware vocabulary** — reads identifiers, library names, and project-specific terms from the current git repo / open buffer and biases transcription toward them, so technical jargon and your own function/variable names actually transcribe correctly.
 3. **Voice-driven editing, not just dictation** — select existing text anywhere and speak an edit command ("make this a bullet list", "snake_case that", "shorter") to rewrite it in place.
 4. **Build it once, then nothing to set up** — there is no installer and no bundled model. You build from source, and the build compiles whisper.cpp and fetches its model for you. After that: no Ollama, no LM Studio, no manual model downloads, no first-run downloader, no config screens.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -46,10 +46,10 @@ Owns: audio capture, STT, text delivery, packaging.
 - [ ] Code signing + notarization, Homebrew cask, `electron-updater` auto-update
 
 ### Track B — Intelligence
-Owns: context awareness, per-mode formatting rules.
+Owns: context awareness, prose cleanup rules, break safety.
 
-- [ ] Accessibility API: native helper detects frontmost app + focused field type, define discrete "modes" (terminal / code editor / prose)
-- [ ] Formatting rules engine per mode (no auto-caps/punctuation in terminal, proper comment formatting in editors)
+- [ ] Accessibility API: native helper detects the frontmost app + focused field type. **No discrete modes** - #45 deleted terminal mode and editor mode, and #44 closed as invalidated on the same finding. What detection feeds is a break-safe allow-list keyed on bundle id, plus a one-line-field modifier from the AX role
+- [ ] One prose rules-cleanup profile applied to every dictation, plus two modifiers (one-line field; break-safe app). Break placement in long dictation is asked of the **rewrite model server**, which answers with sentence numbers and never with text - see #45, #13, #67. **Unresolved ordering conflict:** break placement needs the `llama-server` plumbing listed in Phase 3 below, so either that moves up into Phase 2 or break placement ships in v0.3 and Phase 2 ends with rules-only cleanup
 - [ ] Prompt design + a small eval set to judge rewrite quality before/after changes
 
 **Definition of done:** Track A ships more reliable, faster, easier-to-install dictation. Track B ships visibly smarter output. Tag `v0.2`.
@@ -62,7 +62,7 @@ Same tracks, harder problems — this is where it gets genuinely complex.
 
 - **Track A:** codebase vocabulary scanner — extract identifiers/terms from the open git repo or editor buffer, feed them into whisper.cpp as an initial prompt / bias list
 - **Track B:** `llama-server` plumbing - fetch the binary and an **Apache 2.0 / MIT, ungated** GGUF (SmolLM2-1.7B-Instruct provisionally; acquisition policy open in #52), start it, confirm a local HTTP round trip (moved here from Phase 2 by #24 and #32)
-- **Track B:** voice-driven editing — select existing text anywhere, speak a command ("make this a bullet list", "snake_case that"), send it to the **rewrite model server** to rewrite the selection in place. That server starts lazily on the first voice-edit command and is released after 5 minutes idle (see #29); it is never resident during ordinary dictation
+- **Track B:** voice-driven editing — select existing text anywhere, speak a command ("make this a bullet list", "snake_case that"), send it to the **rewrite model server** to rewrite the selection in place. **Correction from #45:** that server is now **resident**, started at app launch alongside the transcription model server, because it also decides break placement during ordinary dictation. The lazy-then-idle-released lifecycle #29 chose assumed it served voice edits only
 
 **Definition of done:** dictation that's measurably more accurate on your own codebase's vocabulary, plus voice-editing of existing text. Tag `v0.3`.
 
@@ -71,7 +71,7 @@ Same tracks, harder problems — this is where it gets genuinely complex.
 ## Phase 4 — v1.0: Polish & launch (both, target: 1-2 weeks)
 
 - [ ] Permission state check - build script warns when a helper hash changes, app tests all three grants at launch and blocks on Accessibility / Input Monitoring (#47)
-- [ ] Settings UI complete (hotkey remapping, mode rules) - **no model choice**, see #30
+- [ ] Settings UI complete (hotkey remapping, the user-editable break-safe app list) - **no mode rules** (#45) and **no model choice** (#30)
 - [ ] Release automation (GitHub Releases + Homebrew formula bump on tag, `electron-builder` pipeline)
 - [ ] README demo GIF, short landing page
 - [ ] Public launch (Show HN, r/macapps, etc.)


### PR DESCRIPTION
Fallout of [What do the prose cleanup rules concretely do to text?](https://github.com/Nabzx/openstream/issues/45), on the map [#23](https://github.com/Nabzx/openstream/issues/23). Docs only, no code.

## What the decision was

**One mode: prose.** Terminal mode and editor mode are deleted, not deferred. Nobody dictates shell commands - terminal dictation is dictation into agent CLIs like Claude Code, which take prose - and editor dictation is comments, commit messages and docs, which also take prose. [#44](https://github.com/Nabzx/openstream/issues/44) closed as invalidated on the same finding, independently.

The real app-level difference is **whether Enter submits**. Detection now feeds a break-safe allow-list keyed on bundle id (deny-by-default), plus a one-line-field modifier from the AX role. Break placement in long dictation is asked of the rewrite model server, which answers with **sentence numbers and never with text**.

## What this PR corrects

- **`README.md`** promised "no auto-capitalization or punctuation in a terminal". That is now false. Rewritten to describe break safety and model-decided paragraphs, and it says plainly what was dropped and why.
- **`CONTEXT.md`** had two stale entries: `rules cleanup` claimed to be "the only cleanup on the dictation path", and `rewrite model server` claimed to serve "voice edits only". Both are corrected. Adds **break-safe application** and **break placement**.
- **`ROADMAP.md`** Phase 2 Track B no longer defines discrete modes; Phase 3 Track B records that the rewrite model server is now resident (partially superseding [#29](https://github.com/Nabzx/openstream/issues/29)); the Phase 4 settings item drops mode rules and gains the user-editable break-safe app list.

## One thing left unresolved, deliberately

The diff exposed a **phase ordering conflict**: break placement sits in Phase 2, but the `llama-server` plumbing it needs is listed in Phase 3. Either the plumbing moves up or break placement ships in v0.3. I flagged it in `ROADMAP.md` rather than reordering the roadmap unilaterally.

## Superseding notes posted

[#24](https://github.com/Nabzx/openstream/issues/24) (LLM back on the dictation path, for indices only), [#29](https://github.com/Nabzx/openstream/issues/29) (rewrite model server resident), [#13](https://github.com/Nabzx/openstream/issues/13) (re-scoped: one profile, two modifiers, an allow-list, a new contract).

Raised: [#67](https://github.com/Nabzx/openstream/issues/67), which holds the two unmeasured things this decision rests on - break-position latency, and whether a 1.7B model picks sensible breaks.