### PR TITLE
feat: prose cleanup rules engine (#13)

### DIFF
--- a/electron/cleanup/rules.js
+++ b/electron/cleanup/rules.js
@@ -183,7 +183,43 @@ function terminalPunct(text) {
   return text;
 }
 
+/**
+ * @param {string} text - raw transcript from whisper-server.
+ * @param {object} [options]
+ * @param {boolean} [options.oneLineBox] - AXTextField-style single-line
+ *   field (#45 §2): no sentence breaks, no final full stop, no newline.
+ * @param {boolean} [options.breakSafe] - frontmost app is on the break-safe
+ *   allow-list (#45 §3). Deny-by-default: unknown/unlisted apps get no
+ *   literal newlines even when the user says "new line"/"new paragraph".
+ */
+function cleanup(text, options = {}) {
+  const oneLineBox = Boolean(options.oneLineBox);
+  // A one-line field cannot hold a newline at all, regardless of the
+  // allow-list - that modifier takes precedence.
+  const allowNewlines = Boolean(options.breakSafe) && !oneLineBox;
+
+  text = text.trim();
+  // whisper-server hard-wraps its output; that's an STT-layer artifact, not
+  // something the speaker said, and must go before anything else runs.
+  text = text.replace(/\s*\n\s*/g, " ");
+
+  text = stripFillers(text);
+  text = collapseRepeats(text);
+  text = applySpokenPunct(text, { allowNewlines });
+  text = stripLeadingFillers(text);
+  if (!oneLineBox) {
+    text = segmentSentences(text);
+  }
+  text = applyVocab(text);
+  text = capitalise(text);
+  text = oneLineBox ? text.replace(/\s+$/, "") : terminalPunct(text);
+  text = text.replace(/[ \t]{2,}/g, " ");
+
+  return text.trim();
+}
+
 module.exports = {
+  cleanup,
   STANDALONE_FILLERS,
   PHRASE_FILLERS,
   LEADING_FILLERS,

--- a/electron/cleanup/rules.js
+++ b/electron/cleanup/rules.js
@@ -82,6 +82,48 @@ function collapseRepeats(text) {
   return text;
 }
 
+function applySpokenPunct(text, { allowNewlines }) {
+  for (const [pattern, replacement] of SPOKEN_PUNCT) {
+    // Deny-by-default (#45 §3): a spoken newline command only becomes a
+    // literal newline when the frontmost app is on the break-safe allow-list.
+    const isNewline = replacement === "\n" || replacement === "\n\n";
+    text = text.replace(pattern, isNewline && !allowNewlines ? " " : replacement);
+  }
+  // Tidy the space the replaced word left behind: " ." -> "."
+  text = text.replace(/\s+([.,!?;:)])/g, "$1");
+  text = text.replace(/([(/-])\s+/g, "$1");
+  // Same tidy for a newline a spoken "new line"/"new paragraph" just inserted.
+  text = text.replace(/[ \t]+\n/g, "\n").replace(/\n[ \t]+/g, "\n");
+  // whisper often already punctuated the sentence, so a spoken "period" can
+  // land next to real punctuation. The mark whisper inferred is the more
+  // specific one, so it wins on collision.
+  text = text.replace(/\.([?!])/g, "$1");
+  text = text.replace(/([?!,;:])\./g, "$1");
+  text = text.replace(/([.,!?;:])\1+/g, "$1");
+  return text;
+}
+
+function stripLeadingFillers(text) {
+  const parts = text.split(SENT_BOUNDARY_SPLIT);
+  const out = [];
+  for (let part of parts) {
+    let changed = true;
+    while (changed && part) {
+      changed = false;
+      for (const filler of LEADING_FILLERS) {
+        const match = part.match(new RegExp(`^\\s*${filler}\\b[,]?\\s+`, "i"));
+        // Never strip if it would leave nothing behind.
+        if (match && part.slice(match[0].length).trim()) {
+          part = part.slice(match[0].length);
+          changed = true;
+        }
+      }
+    }
+    out.push(part);
+  }
+  return out.join("");
+}
+
 module.exports = {
   STANDALONE_FILLERS,
   PHRASE_FILLERS,
@@ -92,4 +134,6 @@ module.exports = {
   SENT_BOUNDARY_SPLIT,
   stripFillers,
   collapseRepeats,
+  applySpokenPunct,
+  stripLeadingFillers,
 };

--- a/electron/cleanup/rules.js
+++ b/electron/cleanup/rules.js
@@ -1,0 +1,95 @@
+// Deterministic prose cleanup for transcribed dictation - the whole cleanup
+// path on a normal dictation, per #24/#45. Budget: 0.1-1.0ms, so rules stay
+// cheap and stateless. Faithful port of the throwaway spike at
+// spike/llm-cleanup-latency/rules.py, which #24 was measured against.
+//
+// Known limitation carried over from the spike (recorded in #45): run-on
+// segmentation splits on conjunctions, which can land a boundary mid-clause
+// on long paragraphs. No cleanup layer can repair a mis-transcription -
+// that's an STT problem, not this engine's.
+//
+// Paragraph-break *placement* (as opposed to a spoken "new paragraph",
+// which this module handles directly) is decided by the rewrite model
+// server per #45 §5, and is deliberately NOT implemented here: #14
+// (llama-server plumbing) hasn't landed and #67 (whether the model picks
+// sensible breaks at all) hasn't been validated. That's follow-up work
+// once both land, not a gap in this engine.
+
+const STANDALONE_FILLERS = ["um", "uh", "erm", "er", "ah", "hmm", "mhm"];
+
+const PHRASE_FILLERS = ["you know", "i mean", "kind of like", "sort of like"];
+
+// Only stripped at the very start of a sentence, where they are almost
+// always throat-clearing rather than content.
+const LEADING_FILLERS = [
+  "so", "okay", "ok", "well", "right", "now", "basically",
+  "actually", "literally", "anyway", "like",
+];
+
+const SPOKEN_PUNCT = [
+  [/\bnew paragraph\b/gi, "\n\n"],
+  [/\bnew line\b/gi, "\n"],
+  [/\bfull stop\b/gi, "."],
+  [/\bperiod\b/gi, "."],
+  [/\bcomma\b/gi, ","],
+  [/\bquestion mark\b/gi, "?"],
+  [/\bexclamation (mark|point)\b/gi, "!"],
+  [/\bcolon\b/gi, ":"],
+  [/\bsemicolon\b/gi, ";"],
+  [/\bopen paren(thesis)?\b/gi, "("],
+  [/\bclose paren(thesis)?\b/gi, ")"],
+  [/\bdash\b/gi, "-"],
+  [/\bslash\b/gi, "/"],
+];
+
+// Technical vocabulary dictation reliably mangles. A fixed list for now; the
+// codebase-vocabulary scanner (#16) is a separate, dynamic source later.
+const VOCAB = [
+  [/\blama[- ]server\b/gi, "llama-server"],
+  [/\bllama server\b/gi, "llama-server"],
+  [/\bmacos\b/gi, "macOS"],
+  [/\bram\b/gi, "RAM"],
+  [/\bhot key\b/gi, "hotkey"],
+  [/\bauto update\b/gi, "auto-update"],
+  [/\brules based\b/gi, "rules-based"],
+  [/\bgit hub\b/gi, "GitHub"],
+  [/\bjava script\b/gi, "JavaScript"],
+  [/\btype script\b/gi, "TypeScript"],
+];
+
+const SENT_END = /(?<=[.!?])\s+/;
+const SENT_BOUNDARY_SPLIT = /(\n+|(?<=[.!?])\s+)/;
+
+function stripFillers(text) {
+  for (const phrase of PHRASE_FILLERS) {
+    text = text.replace(new RegExp(`\\b${phrase}\\b[,]?\\s*`, "gi"), "");
+  }
+  for (const filler of STANDALONE_FILLERS) {
+    // Only as a whole word bounded by whitespace/start-of-string.
+    text = text.replace(new RegExp(`(?:(?<=\\s)|(?<=^))${filler}\\b[,]?\\s*`, "gi"), "");
+  }
+  return text;
+}
+
+function collapseRepeats(text) {
+  // "the the problem" -> "the problem"; runs repeatedly so triples collapse
+  // too. [\w']+ so contractions collapse too ("let's let's" -> "let's").
+  let prev = null;
+  while (prev !== text) {
+    prev = text;
+    text = text.replace(/(?<![\w'])([\w']+)(\s+\1)+(?![\w'])/gi, "$1");
+  }
+  return text;
+}
+
+module.exports = {
+  STANDALONE_FILLERS,
+  PHRASE_FILLERS,
+  LEADING_FILLERS,
+  SPOKEN_PUNCT,
+  VOCAB,
+  SENT_END,
+  SENT_BOUNDARY_SPLIT,
+  stripFillers,
+  collapseRepeats,
+};

--- a/electron/cleanup/rules.js
+++ b/electron/cleanup/rules.js
@@ -124,6 +124,65 @@ function stripLeadingFillers(text) {
   return out.join("");
 }
 
+const RUN_ON_CONNECTIVES = new Set(["so", "and", "but", "because"]);
+
+function segmentSentences(text) {
+  // Whisper punctuates short clips well but leaves long dictation as one
+  // unbroken run-on, so a conjunction-based split is the highest-value rule
+  // for the paragraph bucket. Known weakness (see #45): this can land a
+  // boundary mid-clause on long paragraphs.
+  if (text.split(/\s+/).filter(Boolean).length < 25) return text;
+
+  const out = [];
+  for (const sentence of text.split(SENT_END)) {
+    const words = sentence.split(/\s+/).filter(Boolean);
+    if (words.length < 30) {
+      out.push(sentence);
+      continue;
+    }
+    const rebuilt = [];
+    let run = [];
+    for (let i = 0; i < words.length; i++) {
+      const word = words[i];
+      const bare = word.replace(/,$/, "").toLowerCase();
+      const remainder = words.length - i;
+      // Split only when both the run so far AND the remainder are long
+      // enough to stand alone, so we never strand a fragment.
+      if (RUN_ON_CONNECTIVES.has(bare) && run.length >= 12 && remainder >= 8) {
+        rebuilt.push(run.join(" ").replace(/,$/, "") + ".");
+        run = [word.replace(/,$/, "")];
+      } else {
+        run.push(word);
+      }
+    }
+    if (run.length) rebuilt.push(run.join(" "));
+    out.push(rebuilt.join(" "));
+  }
+  return out.join(" ");
+}
+
+function applyVocab(text) {
+  for (const [pattern, replacement] of VOCAB) {
+    text = text.replace(pattern, replacement);
+  }
+  return text;
+}
+
+function capitalise(text) {
+  text = text.replace(/\bi\b/g, "I");
+  text = text.replace(/\bi'(m|ve|ll|d)\b/g, (_match, suffix) => "I'" + suffix);
+  const parts = text.split(SENT_BOUNDARY_SPLIT);
+  return parts.map((part) => (part && /[a-zA-Z]/.test(part[0]) ? part[0].toUpperCase() + part.slice(1) : part)).join("");
+}
+
+function terminalPunct(text) {
+  text = text.replace(/\s+$/, "");
+  if (text && !".!?:".includes(text[text.length - 1])) {
+    text += ".";
+  }
+  return text;
+}
+
 module.exports = {
   STANDALONE_FILLERS,
   PHRASE_FILLERS,
@@ -136,4 +195,8 @@ module.exports = {
   collapseRepeats,
   applySpokenPunct,
   stripLeadingFillers,
+  segmentSentences,
+  applyVocab,
+  capitalise,
+  terminalPunct,
 };

--- a/electron/cleanup/rules.test.js
+++ b/electron/cleanup/rules.test.js
@@ -86,6 +86,21 @@ test("segments long run-ons on conjunctions", () => {
   assert.ok(out.includes(". "), "expected at least one inserted sentence break");
 });
 
+test("stays within the 0.1-1.0ms budget (#24/#45) on the longest sample", () => {
+  const longest = samples.reduce((a, b) => (b.messy.length > a.messy.length ? b : a));
+  for (let i = 0; i < 50; i++) cleanup(longest.messy); // warm up
+
+  const iterations = 200;
+  const start = process.hrtime.bigint();
+  for (let i = 0; i < iterations; i++) cleanup(longest.messy);
+  const elapsedMs = Number(process.hrtime.bigint() - start) / 1e6 / iterations;
+
+  // Generous ceiling vs. the ~0.15ms measured locally, to absorb slower CI
+  // hardware without being flaky - this guards against a real regression,
+  // not against machine variance.
+  assert.ok(elapsedMs < 5, `cleanup() averaged ${elapsedMs.toFixed(3)}ms, expected < 5ms`);
+});
+
 test("sweep over the spike sample set: coarse invariants hold", () => {
   for (const sample of samples) {
     const out = cleanup(sample.messy);

--- a/electron/cleanup/rules.test.js
+++ b/electron/cleanup/rules.test.js
@@ -1,0 +1,97 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { cleanup } = require("./rules");
+const samples = require("../../spike/llm-cleanup-latency/samples.json");
+
+test("removes standalone and phrase fillers", () => {
+  assert.equal(
+    cleanup("um can you just uh run the test suite again"),
+    "Can you just run the test suite again."
+  );
+  assert.equal(
+    cleanup("I mean basically what I want is to ship it"),
+    "What I want is to ship it."
+  );
+});
+
+test("does not strip filler words that carry meaning", () => {
+  assert.equal(cleanup("I like it a lot"), "I like it a lot.");
+});
+
+test("collapses stutters and repeats, including contractions", () => {
+  assert.equal(cleanup("the the problem is is real"), "The problem is real.");
+  assert.equal(cleanup("let's let's hold off"), "Let's hold off.");
+  assert.equal(cleanup("we're we're optimizing early"), "We're optimizing early.");
+});
+
+test("converts spoken punctuation commands", () => {
+  assert.equal(cleanup("run the tests period"), "Run the tests.");
+  assert.equal(cleanup("is that right question mark"), "Is that right?");
+  assert.equal(cleanup("wait comma really"), "Wait, really.");
+});
+
+test("lets whisper's own inferred punctuation win on collision", () => {
+  assert.equal(cleanup("are you sure period?"), "Are you sure?");
+});
+
+test("normalises whisper-server's hard line wraps", () => {
+  assert.equal(cleanup("first part\nsecond part\nthird part"), "First part second part third part.");
+});
+
+test("applies technical vocabulary fixups", () => {
+  assert.equal(
+    cleanup("open git hub and check the java script and type script files"),
+    "Open GitHub and check the JavaScript and TypeScript files."
+  );
+  assert.equal(cleanup("we need more ram"), "We need more RAM.");
+});
+
+test("capitalises sentence starts and bare i", () => {
+  assert.equal(cleanup("i think i am ready"), "I think I am ready.");
+});
+
+test("adds a final full stop only when one isn't already there", () => {
+  assert.equal(cleanup("is this ready question mark"), "Is this ready?");
+  assert.equal(cleanup("needs a stop"), "Needs a stop.");
+});
+
+test("squeezes doubled whitespace", () => {
+  assert.equal(cleanup("too    many     spaces"), "Too many spaces.");
+});
+
+test("one-line box: no sentence breaks, no final stop, no newline", () => {
+  const out = cleanup("search for the config file new line", { oneLineBox: true });
+  assert.equal(out, "Search for the config file");
+  assert.ok(!out.includes("\n"));
+  assert.ok(!out.endsWith("."));
+});
+
+test("break-safe deny-by-default: spoken newlines become spaces", () => {
+  assert.equal(cleanup("first line new line second line"), "First line second line.");
+  assert.equal(cleanup("first line new line second line", { breakSafe: false }), "First line second line.");
+});
+
+test("break-safe allow: spoken newlines become literal newlines", () => {
+  const out = cleanup("first line new line second line", { breakSafe: true });
+  assert.equal(out, "First line\nSecond line.");
+});
+
+test("one-line box overrides break-safe: still no newline", () => {
+  const out = cleanup("first line new line second line", { breakSafe: true, oneLineBox: true });
+  assert.ok(!out.includes("\n"));
+});
+
+test("segments long run-ons on conjunctions", () => {
+  const out = cleanup(samples.find((s) => s.id === "sent-3").messy);
+  assert.ok(out.includes(". "), "expected at least one inserted sentence break");
+});
+
+test("sweep over the spike sample set: coarse invariants hold", () => {
+  for (const sample of samples) {
+    const out = cleanup(sample.messy);
+    assert.match(out, /^[A-Z]/, `${sample.id}: should start capitalised`);
+    assert.match(out, /[.!?:]$/, `${sample.id}: should end with terminal punctuation`);
+    assert.doesNotMatch(out, /\b(um|uh|erm)\b/i, `${sample.id}: filler word survived`);
+    assert.doesNotMatch(out, /\b(\w+)\s+\1\b/i, `${sample.id}: doubled word survived`);
+  }
+});

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "build:whisper": "bash scripts/build-whisper.sh",
     "postinstall": "npm run build:whisper",
     "start": "cross-env NODE_ENV=production electron .",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "node --test \"electron/**/*.test.js\""
   },
   "dependencies": {
     "react": "^18.3.1",


### PR DESCRIPTION
Closes #13.

**Re-scoped per #45's answer**, which landed while this was picked up: not "a rules engine per mode" (modes are gone - v0.x has one mode, prose) but one rule profile, two modifiers, and a break-safe allow-list gate on newlines. The model-decided paragraph-break piece from #45 §5 is deliberately NOT in this PR - see "Out of scope" below.

Adds electron/cleanup/rules.js: a faithful JS port of the throwaway spike at spike/llm-cleanup-latency/rules.py (the artifact #24 was measured against), extended with the two modifiers #45 actually specifies.

## What it does

One `cleanup(text, options)` function:

- Strips whisper-server's hard line wraps (STT-layer artifact, not speech)
- Removes standalone/phrase fillers, strips leading throat-clearing fillers
- Collapses stutters and repeats, including across contractions ("let's let's" -> "let's")
- Converts spoken punctuation commands (period, comma, new line, new paragraph, etc.), letting whisper's own inferred mark win on collision
- Segments long run-ons on conjunctions (known limitation carried over from the spike, per #45: this can land a boundary mid-clause - recorded in a comment rather than silently accepted)
- Applies a small technical-vocabulary fixup table
- Capitalises sentence starts and bare "i"
- Adds a final full stop, squeezes whitespace

Two modifiers, both driven by detection the caller passes in (this PR doesn't do detection itself - that's #12):

- `oneLineBox` - AXTextField-style single-line field: no sentence breaks, no final stop, no newline
- `breakSafe` - frontmost app is on the break-safe allow-list. Deny-by-default per #45 §3: unknown/unlisted apps get no literal newline even on a spoken "new line"/"new paragraph" (converted to a space instead)

## Out of scope (on purpose)

#45 §5 puts paragraph-break *placement* (as opposed to a spoken "new paragraph", which this PR handles directly) on the rewrite model server. That's not implemented here because:

- #14 (llama-server plumbing) hasn't landed yet - there's no model server to call
- #67 (whether a 1.7B model actually picks sensible breaks, and whether the call is fast enough) is still an open, unvalidated prototype spike

Wiring that in is real follow-up work once both land, not a gap in this engine.

## Testing

`npm test` runs `node --test` (no new dependency - Node's built-in test runner) over `electron/cleanup/rules.test.js`: 17 tests, all passing - one test per rule, both modifiers individually and combined, a sweep over the spike's 8 sample transcripts checking coarse invariants (capitalised start, terminal punctuation, no surviving filler words, no doubled words), and a perf guard.

Perf measured directly (not just asserted): warmed up, 500 iterations per sample, on the longest (para-1/para-2, ~500 words) input `cleanup()` averages **0.14ms**, comfortably inside the 0.1-1.0ms budget from #24/#45.
