### PR TITLE
feat: real push-to-talk hotkey via native CGEventTap helper (#5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ release/
 
 # Native helper build output (Swift/Obj-C binaries, compiled via native build scripts)
 build/
+.build/
 *.xcuserstate
 DerivedData/
 

--- a/docs/testing/hotkey-transcribe-manual-check.md
+++ b/docs/testing/hotkey-transcribe-manual-check.md
@@ -1,9 +1,14 @@
-# Manual check: hotkey -> transcribe -> console (#2)
+# Manual check: hotkey -> transcribe -> console (#2, push-to-talk via #5)
 
 What CI/a headless session can verify, and what still needs a human running
-the actual app: launching a real Electron window, granting microphone
-permission, and pressing a global hotkey aren't things a sandboxed session
+the actual app: launching a real Electron window, granting macOS
+permissions, and pressing a global hotkey aren't things a sandboxed session
 can drive.
+
+Since #5, `Cmd+Shift+D` is real push-to-talk: hold to record, release to
+stop and transcribe. This replaced the earlier toggle-based proof of
+concept, which used Electron's `globalShortcut` (activation-only, no
+release event) as a stand-in until the native helper existed.
 
 ## Already verified without a GUI
 
@@ -12,22 +17,37 @@ can drive.
   uses came back correctly transcribed.
 - `encodeWav` produces a valid mono 16kHz 16-bit WAV (checked against
   `afinfo`).
-- All new files pass `node --check`.
+- `hotkey-helper` compiles, and run standalone without Input Monitoring
+  granted, correctly logs the permission gap to stderr and exits `1`
+  rather than hanging or crashing.
+- All new/changed files pass `node --check`.
 
 ## Needs a human, one time
 
-1. `npm install` (builds whisper-server and fetches the model if not already
-   present), then `npm start`.
-2. First press of `Cmd+Shift+D` should trigger the macOS microphone
-   permission prompt. Grant it.
-3. Say something, press `Cmd+Shift+D` again to stop.
+1. `npm install` (builds `whisper-server` and `hotkey-helper`, fetches the
+   model if not already present), then `npm start`.
+2. The first hold of `Cmd+Shift+D` should trigger the macOS **Input
+   Monitoring** permission prompt (not Accessibility - see #5's contract).
+   Grant it, then quit and relaunch the app so the helper picks up the
+   grant.
+3. Hold `Cmd+Shift+D`, say something, release it.
 4. The transcript should print to the terminal running `npm start`,
    prefixed `[dictation]`.
-5. Press it again with no speech (press-then-immediately-press-again) -
-   should log `no audio captured, skipping` rather than hitting the server.
+5. Tap it very briefly with no speech - should log
+   `no audio captured, skipping` rather than hitting the server.
+6. Hold it, say something, and switch to another app mid-hold (still
+   holding the keys) to confirm the tap is global and doesn't need the
+   app focused.
 
 If step 2 doesn't fire the OS prompt, or step 4 never prints, check the
-terminal for `[whisper-server]`-prefixed lines first - the resident server
-takes ~15-20s to load Metal shaders on a cold start (see the M1 timing
-in `spike/llm-cleanup-latency/`), so an early hotkey press mid-load will log
-a connection error rather than a transcript.
+terminal for `[whisper-server]`- and `[hotkey-helper]`-prefixed lines
+first:
+
+- The resident whisper server takes ~15-20s to load Metal shaders on a
+  cold start (see the M1 timing in `spike/llm-cleanup-latency/`), so an
+  early hotkey press mid-load will log a connection error rather than a
+  transcript.
+- If `[hotkey-helper]` logs `failed to create event tap` repeatedly, the
+  Input Monitoring grant either wasn't given or hasn't taken effect yet -
+  check System Settings > Privacy & Security > Input Monitoring for
+  OpenStream (or Electron, in dev).

--- a/electron/hotkeyHelper.js
+++ b/electron/hotkeyHelper.js
@@ -1,0 +1,59 @@
+const { spawn } = require("child_process");
+const readline = require("readline");
+const path = require("path");
+
+const BIN_PATH = path.join(__dirname, "..", "resources", "bin", "hotkey-helper");
+
+// Keycode 2 is 'D' on the ANSI layout - matches the CommandOrControl+Shift+D
+// hotkey this replaces. The helper only knows keycodes, not accelerator
+// strings, so the mapping lives here.
+const ARGS = ["--keycode", "2", "--modifiers", "cmd,shift"];
+
+const RESTART_DELAY_MS = 1000;
+
+let child = null;
+let stopping = false;
+let onDown = () => {};
+let onUp = () => {};
+
+function handleLine(line) {
+  let msg;
+  try {
+    msg = JSON.parse(line);
+  } catch {
+    return;
+  }
+  if (msg.event === "down") onDown();
+  else if (msg.event === "up") onUp();
+}
+
+function start() {
+  stopping = false;
+  child = spawn(BIN_PATH, ARGS);
+
+  readline.createInterface({ input: child.stdout }).on("line", handleLine);
+  child.stderr.on("data", (data) => process.stderr.write(`[hotkey-helper] ${data}`));
+
+  child.on("exit", (code) => {
+    child = null;
+    if (stopping) return;
+    console.error(`[hotkey-helper] exited unexpectedly (code ${code}), restarting in ${RESTART_DELAY_MS}ms`);
+    setTimeout(start, RESTART_DELAY_MS);
+  });
+}
+
+function stop() {
+  stopping = true;
+  if (child) child.kill();
+}
+
+module.exports = {
+  start,
+  stop,
+  onKeyDown: (callback) => {
+    onDown = callback;
+  },
+  onKeyUp: (callback) => {
+    onUp = callback;
+  },
+};

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,13 +1,10 @@
-const { app, Tray, Menu, BrowserWindow, globalShortcut, ipcMain } = require("electron");
+const { app, Tray, Menu, BrowserWindow, ipcMain } = require("electron");
 const path = require("path");
 const whisperServer = require("./whisperServer");
+const hotkeyHelper = require("./hotkeyHelper");
 const { encodeWav } = require("./wav");
 
 const isDev = process.env.NODE_ENV === "development";
-
-// Phase 0 hardcoded hotkey - proof that record -> transcribe -> console
-// works before any UI is built around it. Real push-to-talk config is #5.
-const DICTATE_HOTKEY = "CommandOrControl+Shift+D";
 
 let tray = null;
 let win = null;
@@ -75,11 +72,17 @@ async function transcribeAndPrint(int16Samples) {
   }
 }
 
-function toggleDictation() {
-  if (!captureWin) return;
-  isRecording = !isRecording;
-  captureWin.webContents.send(isRecording ? "start-recording" : "stop-recording");
-  if (isRecording) console.log("[dictation] recording - press the hotkey again to stop");
+function startRecording() {
+  if (!captureWin || isRecording) return;
+  isRecording = true;
+  captureWin.webContents.send("start-recording");
+  console.log("[dictation] recording - release the hotkey to stop");
+}
+
+function stopRecording() {
+  if (!captureWin || !isRecording) return;
+  isRecording = false;
+  captureWin.webContents.send("stop-recording");
 }
 
 function createTray() {
@@ -117,11 +120,13 @@ app.whenReady().then(() => {
   createTray();
   createCaptureWindow();
   whisperServer.start();
-  globalShortcut.register(DICTATE_HOTKEY, toggleDictation);
+  hotkeyHelper.onKeyDown(startRecording);
+  hotkeyHelper.onKeyUp(stopRecording);
+  hotkeyHelper.start();
 });
 
 app.on("will-quit", () => {
-  globalShortcut.unregisterAll();
+  hotkeyHelper.stop();
   whisperServer.stop();
 });
 

--- a/native/hotkey-helper/Package.swift
+++ b/native/hotkey-helper/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "hotkey-helper",
+    platforms: [.macOS(.v11)],
+    targets: [
+        .executableTarget(
+            name: "hotkey-helper",
+            path: "Sources/hotkey-helper"
+        )
+    ]
+)

--- a/native/hotkey-helper/Sources/hotkey-helper/main.swift
+++ b/native/hotkey-helper/Sources/hotkey-helper/main.swift
@@ -1,0 +1,120 @@
+import CoreGraphics
+import Foundation
+
+// Push-to-talk hotkey helper, per issue #5.
+//
+// Permission: Input Monitoring only, never Accessibility - held separately
+// by the accessibility helper (#6), so a stalled AX call can never starve
+// this tap (#26).
+//
+// Protocol: stdio, newline-delimited JSON, one-way (helper -> main),
+// fire-and-forget. stdout carries protocol only; everything else goes to
+// stderr. The Electron main process decides what a press means - this
+// helper only reports key-down and key-up for the one configured hotkey.
+
+func eprint(_ message: String) {
+    FileHandle.standardError.write((message + "\n").data(using: .utf8)!)
+}
+
+func emit(_ event: String) {
+    // No user text ever crosses this channel, so no escaping is needed here.
+    print("{\"event\":\"\(event)\",\"ts\":\(Date().timeIntervalSince1970)}")
+}
+
+func parseModifiers(_ raw: String) -> CGEventFlags {
+    var flags: CGEventFlags = []
+    for name in raw.split(separator: ",") {
+        switch name.trimmingCharacters(in: .whitespaces) {
+        case "cmd": flags.insert(.maskCommand)
+        case "shift": flags.insert(.maskShift)
+        case "alt", "option": flags.insert(.maskAlternate)
+        case "ctrl", "control": flags.insert(.maskControl)
+        default: eprint("hotkey-helper: ignoring unknown modifier \"\(name)\"")
+        }
+    }
+    return flags
+}
+
+func parseArgs() -> (keyCode: Int64, flags: CGEventFlags) {
+    var keyCode: Int64 = 2 // 'D' on the ANSI layout - matches CommandOrControl+Shift+D
+    var flags: CGEventFlags = [.maskCommand, .maskShift]
+
+    let args = CommandLine.arguments
+    var i = 1
+    while i < args.count {
+        switch args[i] {
+        case "--keycode":
+            i += 1
+            if i < args.count, let parsed = Int64(args[i]) { keyCode = parsed }
+        case "--modifiers":
+            i += 1
+            if i < args.count { flags = parseModifiers(args[i]) }
+        default:
+            eprint("hotkey-helper: ignoring unknown argument \"\(args[i])\"")
+        }
+        i += 1
+    }
+    return (keyCode, flags)
+}
+
+let (targetKeyCode, targetFlags) = parseArgs()
+let relevantFlagsMask: CGEventFlags = [.maskCommand, .maskShift, .maskAlternate, .maskControl]
+
+var tap: CFMachPort?
+
+func handleEvent(proxy: CGEventTapProxy, type: CGEventType, event: CGEvent, refcon: UnsafeMutableRawPointer?) -> Unmanaged<CGEvent>? {
+    if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+        // macOS kills a tap that doesn't respond in time and leaves it dead
+        // until re-enabled - the helper's one piece of native housekeeping.
+        if let tap = tap {
+            CGEvent.tapEnable(tap: tap, enable: true)
+            eprint("hotkey-helper: tap was disabled (\(type)), re-enabled")
+        }
+        return Unmanaged.passRetained(event)
+    }
+
+    guard type == .keyDown || type == .keyUp else {
+        return Unmanaged.passRetained(event)
+    }
+
+    // Key repeat resends keyDown for as long as the key is held - only the
+    // first down and the eventual up are a press/release pair.
+    if type == .keyDown && event.getIntegerValueField(.keyboardEventAutorepeat) != 0 {
+        return Unmanaged.passRetained(event)
+    }
+
+    let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
+    let flags = event.flags.intersection(relevantFlagsMask)
+    if keyCode == targetKeyCode && flags == targetFlags {
+        emit(type == .keyDown ? "down" : "up")
+    }
+
+    return Unmanaged.passRetained(event)
+}
+
+if !CGPreflightListenEventAccess() {
+    eprint("hotkey-helper: Input Monitoring access not yet granted, requesting it now")
+    _ = CGRequestListenEventAccess()
+}
+
+let eventMask: CGEventMask = (1 << CGEventType.keyDown.rawValue) | (1 << CGEventType.keyUp.rawValue)
+
+guard let createdTap = CGEvent.tapCreate(
+    tap: .cgSessionEventTap,
+    place: .headInsertEventTap,
+    options: .listenOnly,
+    eventsOfInterest: eventMask,
+    callback: handleEvent,
+    userInfo: nil
+) else {
+    eprint("hotkey-helper: failed to create event tap - Input Monitoring permission is likely missing")
+    exit(1)
+}
+
+tap = createdTap
+let runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, createdTap, 0)
+CFRunLoopAddSource(CFRunLoopGetCurrent(), runLoopSource, .commonModes)
+CGEvent.tapEnable(tap: createdTap, enable: true)
+
+emit("ready")
+CFRunLoopRun()

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "dev": "concurrently -k \"npm:dev:renderer\" \"npm:dev:electron\"",
     "build": "tsc -p tsconfig.json --noEmit && vite build",
     "build:whisper": "bash scripts/build-whisper.sh",
-    "postinstall": "npm run build:whisper",
+    "build:hotkey-helper": "bash scripts/build-hotkey-helper.sh",
+    "postinstall": "npm run build:whisper && npm run build:hotkey-helper",
     "start": "cross-env NODE_ENV=production electron .",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "node --test \"electron/**/*.test.js\""

--- a/scripts/build-hotkey-helper.sh
+++ b/scripts/build-hotkey-helper.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# Compiles the push-to-talk hotkey helper (native/hotkey-helper) and stages
+# the binary at resources/bin/hotkey-helper. See issue #5.
+#
+# Swift-only, no external deps - `swift build` is enough. Safe to re-run:
+# swift build is itself incremental, and this script just re-copies the
+# freshly built binary each time.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+PKG_DIR="$ROOT/native/hotkey-helper"
+BIN_DIR="$ROOT/resources/bin"
+OUT_PATH="$BIN_DIR/hotkey-helper"
+
+echo "==> hotkey-helper"
+swift build --package-path "$PKG_DIR" -c release
+
+BUILT_BIN_DIR="$(swift build --package-path "$PKG_DIR" -c release --show-bin-path)"
+
+mkdir -p "$BIN_DIR"
+cp "$BUILT_BIN_DIR/hotkey-helper" "$OUT_PATH"
+chmod +x "$OUT_PATH"
+
+echo "==> done: $OUT_PATH"


### PR DESCRIPTION
Closes #5.

Builds the hotkey helper per #5's contract and #26's topology decision: a small, standalone native binary that only ever holds Input Monitoring, never Accessibility, so a stalled AX call in the separate helper (#6) can never starve this tap.

## What this builds

- `native/hotkey-helper/` - Swift package. `CGEventTap` in `.listenOnly` mode watches for one configured keycode+modifier combo (default: keycode 2 + cmd/shift, matching the existing `Cmd+Shift+D`), reports key-down/key-up as newline-JSON on stdout, re-enables itself on `kCGEventTapDisabledByTimeout`/`ByUserInput`, and keeps all logging on stderr per the stdout-carries-protocol-only rule.
- `scripts/build-hotkey-helper.sh` - compiles it in release mode, stages the binary at `resources/bin/hotkey-helper`. Wired into `postinstall` alongside the whisper build.
- `electron/hotkeyHelper.js` - spawns the binary, parses its stdout, restarts on an unexpected exit (same shape as `whisperServer.js`'s supervisor).
- `electron/main.js` - replaces the #2 proof-of-concept's `globalShortcut` toggle with real push-to-talk: `startRecording()`/`stopRecording()` driven by the helper's down/up events. `Cmd+Shift+D` is unchanged from the user's side - only the detection mechanism changes, since `globalShortcut` has no release event and never could.

## What's verified vs. what needs a human

This session can't drive a real display, so:

**Verified headlessly:**
- `hotkey-helper` compiles cleanly (`swift build -c release`).
- Run standalone without Input Monitoring granted, it correctly logs the permission gap to stderr and exits `1` - the expected path in this sandbox, and a sanity check that a missing grant fails loud rather than hanging.
- All new/changed JS passes `node --check`; the existing `npm test` suite (17 tests, unrelated cleanup-rules coverage) still passes untouched.
- No stray references to the removed `globalShortcut`/`toggleDictation` path remain anywhere in the tree.

**Needs a human, one time:** granting the Input Monitoring prompt and confirming a real hold-then-release gesture prints a transcript. Steps in `docs/testing/hotkey-transcribe-manual-check.md`, updated in this PR to match the push-to-talk gesture and the new permission.

## Test plan
- [x] `hotkey-helper` compiles and fails loud (not silently) without permission (headless)
- [x] `node --check` on all new/changed files (headless)
- [x] `npm test` still green (headless)
- [ ] Real hold/release with Input Monitoring granted, transcript prints (needs a human running `npm start`)
