### PR TITLE
feat: text injection at the cursor via accessibility helper (#6)

### DIFF
--- a/docs/testing/hotkey-transcribe-manual-check.md
+++ b/docs/testing/hotkey-transcribe-manual-check.md
@@ -1,4 +1,4 @@
-# Manual check: hotkey -> transcribe -> console (#2, push-to-talk via #5)
+# Manual check: hotkey -> transcribe -> inject (#2, push-to-talk via #5, injection via #6)
 
 What CI/a headless session can verify, and what still needs a human running
 the actual app: launching a real Electron window, granting macOS
@@ -6,9 +6,10 @@ permissions, and pressing a global hotkey aren't things a sandboxed session
 can drive.
 
 Since #5, `Cmd+Shift+D` is real push-to-talk: hold to record, release to
-stop and transcribe. This replaced the earlier toggle-based proof of
-concept, which used Electron's `globalShortcut` (activation-only, no
-release event) as a stand-in until the native helper existed.
+stop and transcribe. Since #6, the transcript is delivered to the field
+under the cursor via the accessibility helper's fallback chain (write at
+the caret, then clipboard-plus-paste, then synthesised keystrokes - see
+#62), not just printed to the terminal.
 
 ## Already verified without a GUI
 
@@ -20,28 +21,44 @@ release event) as a stand-in until the native helper existed.
 - `hotkey-helper` compiles, and run standalone without Input Monitoring
   granted, correctly logs the permission gap to stderr and exits `1`
   rather than hanging or crashing.
+- `accessibility-helper` compiles, and run standalone without Accessibility
+  granted, its `inject` command correctly reports the frontmost app but
+  holds rather than delivering - AX calls fail cleanly without the grant,
+  they don't hang.
 - All new/changed files pass `node --check`.
 
 ## Needs a human, one time
 
-1. `npm install` (builds `whisper-server` and `hotkey-helper`, fetches the
-   model if not already present), then `npm start`.
+1. `npm install` (builds `whisper-server`, `hotkey-helper` and
+   `accessibility-helper`, fetches the model if not already present), then
+   `npm start`.
 2. The first hold of `Cmd+Shift+D` should trigger the macOS **Input
-   Monitoring** permission prompt (not Accessibility - see #5's contract).
-   Grant it, then quit and relaunch the app so the helper picks up the
-   grant.
-3. Hold `Cmd+Shift+D`, say something, release it.
-4. The transcript should print to the terminal running `npm start`,
-   prefixed `[dictation]`.
-5. Tap it very briefly with no speech - should log
-   `no audio captured, skipping` rather than hitting the server.
-6. Hold it, say something, and switch to another app mid-hold (still
+   Monitoring** prompt (not Accessibility - see #5's contract). Grant it.
+3. The next dictation attempt should trigger a separate **Accessibility**
+   prompt for the injection helper (not Input Monitoring - see #6's
+   contract, two helpers, two permissions). Grant it, then quit and
+   relaunch the app so both helpers pick up their grants.
+4. Click into a normal text field (e.g. a Notes window, or this file in an
+   editor), hold `Cmd+Shift+D`, say something, release it.
+5. The transcript should appear **in the field**, not just the terminal.
+   The terminal running `npm start` still prints it too, prefixed
+   `[dictation]`, followed by a line reporting how it was delivered - e.g.
+   `injected via wrote into the field` or `injected via pasted`.
+6. Tap it very briefly with no speech - should log
+   `no audio captured, skipping` and nothing is injected.
+7. Hold it, say something, and switch to another app mid-hold (still
    holding the keys) to confirm the tap is global and doesn't need the
-   app focused.
+   app focused. The text should land in whichever app is frontmost when
+   you release, not the one that was frontmost when you pressed.
+8. Try a terminal window and an Electron-based editor (e.g. VS Code) as the
+   target - these are exactly the cases #62 designed the fallback chain
+   around. A terminal's prompt should receive a clipboard paste, not have
+   its scrollback overwritten; an editor with no usable AX tree
+   (`AXWebArea`) should also fall through to paste.
 
-If step 2 doesn't fire the OS prompt, or step 4 never prints, check the
-terminal for `[whisper-server]`- and `[hotkey-helper]`-prefixed lines
-first:
+If step 2/3 don't fire the OS prompts, or step 5 never prints/injects,
+check the terminal for `[whisper-server]`-, `[hotkey-helper]`- and
+`[accessibility-helper]`-prefixed lines first:
 
 - The resident whisper server takes ~15-20s to load Metal shaders on a
   cold start (see the M1 timing in `spike/llm-cleanup-latency/`), so an
@@ -51,3 +68,10 @@ first:
   Input Monitoring grant either wasn't given or hasn't taken effect yet -
   check System Settings > Privacy & Security > Input Monitoring for
   OpenStream (or Electron, in dev).
+- If `[dictation] injection held: ...` keeps appearing even in a plain
+  text field, check System Settings > Privacy & Security > Accessibility
+  for the same target - the accessibility helper needs its own grant,
+  separate from Input Monitoring.
+- `injection held` right after switching apps is expected, not a bug -
+  that's the settle guard (#62) refusing to trust a target for the first
+  ~400ms after a switch.

--- a/electron/accessibilityHelper.js
+++ b/electron/accessibilityHelper.js
@@ -1,0 +1,79 @@
+const { spawn } = require("child_process");
+const readline = require("readline");
+const path = require("path");
+
+const BIN_PATH = path.join(__dirname, "..", "resources", "bin", "accessibility-helper");
+const RESTART_DELAY_MS = 1000;
+
+// Generous: the settle guard alone can hold a reply for up to 1200ms before
+// even the first rung is attempted (see #6, #62), and rung 2's clipboard
+// restore adds another ~300ms on top of whichever rung actually delivers.
+const REQUEST_TIMEOUT_MS = 3000;
+
+let child = null;
+let stopping = false;
+let nextId = 1;
+const pending = new Map(); // id -> { resolve, reject, timer }
+
+function settle(id, msg, err) {
+  const entry = pending.get(id);
+  if (!entry) return;
+  clearTimeout(entry.timer);
+  pending.delete(id);
+  if (err) entry.reject(err);
+  else entry.resolve(msg);
+}
+
+function handleLine(line) {
+  let msg;
+  try {
+    msg = JSON.parse(line);
+  } catch {
+    return;
+  }
+  if (msg.event === "ready" || msg.id == null) return;
+  settle(msg.id, msg, null);
+}
+
+function start() {
+  stopping = false;
+  child = spawn(BIN_PATH);
+
+  readline.createInterface({ input: child.stdout }).on("line", handleLine);
+  child.stderr.on("data", (data) => process.stderr.write(`[accessibility-helper] ${data}`));
+
+  child.on("exit", (code) => {
+    child = null;
+    for (const id of Array.from(pending.keys())) {
+      settle(id, null, new Error("accessibility-helper exited before replying"));
+    }
+    if (stopping) return;
+    console.error(`[accessibility-helper] exited unexpectedly (code ${code}), restarting in ${RESTART_DELAY_MS}ms`);
+    setTimeout(start, RESTART_DELAY_MS);
+  });
+}
+
+function stop() {
+  stopping = true;
+  if (child) child.kill();
+}
+
+// Tagged with an id and allowed to reply out of order, per #6's contract:
+// this helper is allowed to block on AX calls, so a slow inject must never
+// head-of-line-block whatever the main process sends after it.
+function inject(text) {
+  return new Promise((resolve, reject) => {
+    if (!child) {
+      reject(new Error("accessibility-helper is not running"));
+      return;
+    }
+    const id = String(nextId++);
+    const timer = setTimeout(() => {
+      settle(id, null, new Error(`accessibility-helper did not reply to inject within ${REQUEST_TIMEOUT_MS}ms`));
+    }, REQUEST_TIMEOUT_MS);
+    pending.set(id, { resolve, reject, timer });
+    child.stdin.write(JSON.stringify({ id, cmd: "inject", text }) + "\n");
+  });
+}
+
+module.exports = { start, stop, inject };

--- a/electron/main.js
+++ b/electron/main.js
@@ -2,6 +2,7 @@ const { app, Tray, Menu, BrowserWindow, ipcMain, nativeImage } = require("electr
 const path = require("path");
 const whisperServer = require("./whisperServer");
 const hotkeyHelper = require("./hotkeyHelper");
+const accessibilityHelper = require("./accessibilityHelper");
 const { encodeWav } = require("./wav");
 
 const isDev = process.env.NODE_ENV === "development";
@@ -74,11 +75,33 @@ async function transcribeAndPrint(int16Samples) {
     const res = await fetch(whisperServer.inferenceUrl(), { method: "POST", body: formData });
     if (!res.ok) throw new Error(`whisper-server returned ${res.status}`);
     const body = await res.json();
-    console.log(`[dictation] ${(body.text || "").trim() || "(no speech detected)"}`);
+    const text = (body.text || "").trim();
+    console.log(`[dictation] ${text || "(no speech detected)"}`);
+    if (text) await injectTranscript(text);
   } catch (err) {
     console.error("[dictation] transcription failed:", err);
   } finally {
     setTrayState("idle");
+  }
+}
+
+// #6's helper reports one of three shapes: delivered (with the rung and
+// whether it could confirm the text landed), held (nothing was risked - see
+// #62's hold-never-guess), or a protocol error. There is no overlay surface
+// yet for a held transcript (#12/#44's job); for now the reason is logged so
+// a held dictation is at least visible, not silently dropped.
+async function injectTranscript(text) {
+  try {
+    const result = await accessibilityHelper.inject(text);
+    if (result.status === "delivered") {
+      console.log(`[dictation] injected via ${result.method}${result.verified ? "" : " (unverified)"}`);
+    } else if (result.status === "held") {
+      console.log(`[dictation] injection held: ${result.reason}`);
+    } else {
+      console.error(`[dictation] injection error: ${result.reason}`);
+    }
+  } catch (err) {
+    console.error("[dictation] injection failed:", err);
   }
 }
 
@@ -164,6 +187,7 @@ app.whenReady().then(() => {
   createTray();
   createCaptureWindow();
   whisperServer.start();
+  accessibilityHelper.start();
   hotkeyHelper.onKeyDown(startRecording);
   hotkeyHelper.onKeyUp(stopRecording);
   hotkeyHelper.start();
@@ -171,6 +195,7 @@ app.whenReady().then(() => {
 
 app.on("will-quit", () => {
   hotkeyHelper.stop();
+  accessibilityHelper.stop();
   whisperServer.stop();
 });
 

--- a/native/accessibility-helper/Package.swift
+++ b/native/accessibility-helper/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "accessibility-helper",
+    platforms: [.macOS(.v11)],
+    targets: [
+        .executableTarget(
+            name: "accessibility-helper",
+            path: "Sources/accessibility-helper"
+        )
+    ]
+)

--- a/native/accessibility-helper/Sources/accessibility-helper/main.swift
+++ b/native/accessibility-helper/Sources/accessibility-helper/main.swift
@@ -1,0 +1,46 @@
+import ApplicationServices
+import Foundation
+
+func eprint(_ message: String) {
+    FileHandle.standardError.write((message + "\n").data(using: .utf8)!)
+}
+
+// stdout carries protocol only - every line here must be one JSON object.
+func emit(_ dict: [String: Any]) {
+    guard let data = try? JSONSerialization.data(withJSONObject: dict),
+          let line = String(data: data, encoding: .utf8) else {
+        eprint("accessibility-helper: failed to serialise a reply, dropping it")
+        return
+    }
+    print(line)
+    fflush(stdout)
+}
+
+// Accessibility, never Input Monitoring - the hotkey helper (#5) holds that
+// separately, per the two-helper split settled in #26.
+if !AXIsProcessTrusted() {
+    eprint("accessibility-helper: Accessibility access not yet granted, requesting it now")
+    let options: NSDictionary = [kAXTrustedCheckOptionPrompt.takeRetainedValue() as String: true]
+    _ = AXIsProcessTrustedWithOptions(options)
+}
+
+emit(["event": "ready"])
+
+// Command loop: one newline-delimited JSON object per line on stdin, one
+// reply per line on stdout, tagged with the same id so a slow request never
+// head-of-line-blocks whatever the main process sent after it.
+while let line = readLine(strippingNewline: true) {
+    guard !line.isEmpty,
+          let data = line.data(using: .utf8),
+          let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+          let id = obj["id"] as? String,
+          let cmd = obj["cmd"] as? String else {
+        eprint("accessibility-helper: ignoring malformed request: \(line)")
+        continue
+    }
+
+    switch cmd {
+    default:
+        emit(["id": id, "status": "error", "reason": "unknown command \"\(cmd)\""])
+    }
+}

--- a/native/accessibility-helper/Sources/accessibility-helper/main.swift
+++ b/native/accessibility-helper/Sources/accessibility-helper/main.swift
@@ -1,9 +1,57 @@
 import ApplicationServices
+import AppKit
 import Foundation
 
 func eprint(_ message: String) {
     FileHandle.standardError.write((message + "\n").data(using: .utf8)!)
 }
+
+// The thresholds #62 left as placeholders, pending real measurement in #74.
+// stableForBlindPasteMs is deliberately 2x settleMs: settleMs asks "has the
+// target stopped moving", stableForBlindPasteMs asks "have we watched it
+// stand still long enough to believe the user is looking at it" - see #62.
+struct Config {
+    var settleMs: Double = 400
+    var settleBudgetMs: Double = 1200
+    var axDeadlineMs: Double = 150
+    var restoreMs: Double = 300
+    var axValueMaxChars = 2000
+    var longTextChars = 120
+    var stableForBlindPasteMs: Double? = 800
+}
+let config = Config()
+
+// Tracks when the frontmost app last changed, so delivery can be gated on it
+// rather than trusting a possibly-stale pid - see #62's settle guard. Runs on
+// its own thread with its own run loop: NSWorkspace notifications need a
+// pumping run loop to arrive, and the main thread spends its time blocked in
+// readLine() and in the AX calls below.
+final class AppSwitchTracker {
+    private let lock = NSLock()
+    private var switchedAt = Date()
+
+    func recordSwitch() {
+        lock.lock()
+        switchedAt = Date()
+        lock.unlock()
+    }
+
+    func ageMs(now: Date = Date()) -> Double {
+        lock.lock()
+        defer { lock.unlock() }
+        return now.timeIntervalSince(switchedAt) * 1000
+    }
+}
+let tracker = AppSwitchTracker()
+
+Thread {
+    NSWorkspace.shared.notificationCenter.addObserver(
+        forName: NSWorkspace.didActivateApplicationNotification,
+        object: nil,
+        queue: nil
+    ) { _ in tracker.recordSwitch() }
+    RunLoop.current.run()
+}.start()
 
 // stdout carries protocol only - every line here must be one JSON object.
 func emit(_ dict: [String: Any]) {

--- a/native/accessibility-helper/Sources/accessibility-helper/main.swift
+++ b/native/accessibility-helper/Sources/accessibility-helper/main.swift
@@ -74,6 +74,195 @@ if !AXIsProcessTrusted() {
 
 emit(["event": "ready"])
 
+// ---------------------------------------------------------------------------
+// The fallback chain settled in #62: write at the caret, then clipboard +
+// paste, then synthesised keystrokes - each rung's trigger is something this
+// helper can actually detect, never assumed.
+// ---------------------------------------------------------------------------
+
+struct FieldInfo {
+    var role: String
+    var valueChars: Int?      // nil when the value attribute isn't readable
+    var selectedTextSettable: Bool
+}
+
+func fieldInfo(_ element: AXUIElement) -> FieldInfo {
+    var roleRef: CFTypeRef?
+    AXUIElementCopyAttributeValue(element, kAXRoleAttribute as CFString, &roleRef)
+    let role = (roleRef as? String) ?? "unknown"
+
+    var valueRef: CFTypeRef?
+    let valueErr = AXUIElementCopyAttributeValue(element, kAXValueAttribute as CFString, &valueRef)
+    let valueChars = (valueErr == .success) ? (valueRef as? String)?.count : nil
+
+    var settable: DarwinBoolean = false
+    AXUIElementIsAttributeSettable(element, kAXSelectedTextAttribute as CFString, &settable)
+
+    return FieldInfo(role: role, valueChars: valueChars, selectedTextSettable: settable.boolValue)
+}
+
+// Rung 1: replace the current selection (a caret is a zero-length selection)
+// with the transcript. Atomic, instant, no clipboard - this is the AX
+// primitive for "insert at the cursor", distinct from kAXValueAttribute,
+// which would overwrite the field's entire contents.
+func writeAtCaret(_ element: AXUIElement, text: String) -> Bool {
+    AXUIElementSetAttributeValue(element, kAXSelectedTextAttribute as CFString, text as CFTypeRef) == .success
+}
+
+func synthesizeCmdV() {
+    let source = CGEventSource(stateID: .hidSystemState)
+    let vKeyCode: CGKeyCode = 9 // 'V' on the ANSI layout
+    let keyDown = CGEvent(keyboardEventSource: source, virtualKey: vKeyCode, keyDown: true)
+    let keyUp = CGEvent(keyboardEventSource: source, virtualKey: vKeyCode, keyDown: false)
+    keyDown?.flags = .maskCommand
+    keyUp?.flags = .maskCommand
+    keyDown?.post(tap: .cghidEventTap)
+    keyUp?.post(tap: .cghidEventTap)
+}
+
+// Rung 2: borrow the clipboard, synthesise Cmd+V, then give it back. The
+// restore is guarded against the race the #62 prototype flagged: if the
+// user copies something else while our text is still sitting in the
+// clipboard, changeCount will have moved past what we set, and we leave
+// their copy alone rather than clobbering it.
+//
+// verifyAgainst, when non-nil, is a field we can read back from - readable
+// and small enough not to be a terminal's scrollback (see #62's scrollback
+// trigger). Reading it after the paste is the only real signal this helper
+// has for "did the app actually accept the paste", so it is also the only
+// case where a rejected paste falls through to rung 3 rather than being
+// reported delivered-but-unverified.
+func pasteViaClipboard(text: String, verifyAgainst: AXUIElement?, valueBefore: String?) -> (delivered: Bool, verified: Bool, note: String) {
+    let pasteboard = NSPasteboard.general
+    let saved = pasteboard.string(forType: .string)
+
+    pasteboard.clearContents()
+    pasteboard.setString(text, forType: .string)
+    let ourChangeCount = pasteboard.changeCount
+
+    synthesizeCmdV()
+    Thread.sleep(forTimeInterval: config.restoreMs / 1000.0)
+
+    if pasteboard.changeCount == ourChangeCount {
+        pasteboard.clearContents()
+        if let saved = saved { pasteboard.setString(saved, forType: .string) }
+    } else {
+        eprint("accessibility-helper: skipped the clipboard restore - the user copied something else while it was borrowed")
+    }
+
+    guard let element = verifyAgainst else {
+        return (true, false, "sent, but nothing confirmed it landed")
+    }
+
+    var valueRef: CFTypeRef?
+    let err = AXUIElementCopyAttributeValue(element, kAXValueAttribute as CFString, &valueRef)
+    guard err == .success, let after = valueRef as? String, after.contains(text) else {
+        return (false, false, "the app did not accept the paste")
+    }
+    _ = valueBefore
+    return (true, true, "read back and confirmed")
+}
+
+// Rung 3: type it character by character. Works wherever a keyboard works,
+// including surfaces with no usable AX tree, but it is slow and can drop or
+// reorder characters on long text - see #62.
+func typeCharacters(_ text: String) {
+    let source = CGEventSource(stateID: .hidSystemState)
+    for scalar in text.unicodeScalars {
+        var chars = [UniChar(scalar.value)]
+        let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: true)
+        let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: false)
+        keyDown?.keyboardSetUnicodeString(stringLength: 1, unicodeString: &chars)
+        keyUp?.keyboardSetUnicodeString(stringLength: 1, unicodeString: &chars)
+        keyDown?.post(tap: .cghidEventTap)
+        keyUp?.post(tap: .cghidEventTap)
+    }
+}
+
+func held(reason: String) -> [String: Any] {
+    ["status": "held", "reason": reason]
+}
+
+func delivered(method: String, verified: Bool, note: String) -> [String: Any] {
+    ["status": "delivered", "method": method, "verified": verified, "note": note]
+}
+
+// The decision procedure itself, ported from InjectionModel in
+// prototypes/injection-62/index.html onto real AX/CGEvent calls.
+func decideAndInject(text: String) -> [String: Any] {
+    // Settle guard: never trust a target while the last app switch is more
+    // recent than settleMs. Poll rather than trust a single reading, since
+    // the tracker updates asynchronously on its own thread.
+    let deadline = Date().addingTimeInterval(config.settleBudgetMs / 1000.0)
+    while tracker.ageMs() < config.settleMs {
+        if Date() >= deadline {
+            return held(reason: "the front app kept changing, so we never trusted a target")
+        }
+        Thread.sleep(forTimeInterval: 0.02)
+    }
+
+    guard let frontApp = NSWorkspace.shared.frontmostApplication else {
+        return held(reason: "nothing was focused, so there is no field to deliver to")
+    }
+    let appName = frontApp.localizedName ?? "the frontmost app"
+
+    let appElement = AXUIElementCreateApplication(frontApp.processIdentifier)
+    AXUIElementSetMessagingTimeout(appElement, Float(config.axDeadlineMs / 1000.0))
+
+    var focusedRef: CFTypeRef?
+    let focusErr = AXUIElementCopyAttributeValue(appElement, kAXFocusedUIElementAttribute as CFString, &focusedRef)
+
+    guard focusErr == .success, let focusedRef = focusedRef else {
+        // Rung 0 didn't answer. The narrow exception settled on #62: a known
+        // app that has sat still well past the settle guard is a much
+        // smaller unknown than "which app" - the user is demonstrably
+        // looking at it, so a blind paste there is a bounded, undoable
+        // mistake rather than a shot in the dark.
+        if let gate = config.stableForBlindPasteMs, tracker.ageMs() >= gate {
+            let (_, _, note) = pasteViaClipboard(text: text, verifyAgainst: nil, valueBefore: nil)
+            return delivered(method: "pasted into a known window, field unknown", verified: false, note: note)
+        }
+        return held(reason: "\(appName) never said what was focused, and hasn't been stable long enough to paste blind")
+    }
+    let focused = focusedRef as! AXUIElement // swiftlint:disable:this force_cast
+
+    let info = fieldInfo(focused)
+    let readableAndFieldSized = info.valueChars.map { $0 <= config.axValueMaxChars } ?? false
+
+    // Rung 1: write straight into the field.
+    if info.selectedTextSettable && readableAndFieldSized {
+        if writeAtCaret(focused, text: text) {
+            return delivered(method: "wrote into the field", verified: true, note: "inserted at the caret, clipboard untouched")
+        }
+        eprint("accessibility-helper: kAXSelectedTextAttribute reported settable but the write failed, falling back to paste")
+    } else if info.selectedTextSettable, let chars = info.valueChars, chars > config.axValueMaxChars {
+        eprint("accessibility-helper: refusing to write into \(info.role) - \(chars) characters of existing content looks like scrollback, not a field")
+    }
+
+    // Rung 2: clipboard + paste.
+    let (pasteDelivered, verified, note) = pasteViaClipboard(
+        text: text,
+        verifyAgainst: readableAndFieldSized ? focused : nil,
+        valueBefore: nil
+    )
+    if pasteDelivered {
+        return delivered(method: "pasted", verified: verified, note: note)
+    }
+
+    // The app rejected a paste we could actually verify. One atomic paste
+    // into a field we could read is a bounded, undoable mistake; typing
+    // blind into a field we never confirmed is not - see #62 - so rung 3
+    // only fires here, where we have positive evidence rung 2 failed, never
+    // for the fields we could not verify in the first place.
+    typeCharacters(text)
+    let long = text.count > config.longTextChars
+    return delivered(
+        method: "typed character by character",
+        verified: false,
+        note: long ? "\(text.count) characters typed blind - autocomplete or a vim mode can mangle it" : "nothing confirmed it arrived"
+    )
+}
+
 // Command loop: one newline-delimited JSON object per line on stdin, one
 // reply per line on stdout, tagged with the same id so a slow request never
 // head-of-line-blocks whatever the main process sent after it.
@@ -88,6 +277,14 @@ while let line = readLine(strippingNewline: true) {
     }
 
     switch cmd {
+    case "inject":
+        guard let text = obj["text"] as? String, !text.isEmpty else {
+            emit(["id": id, "status": "error", "reason": "inject requires non-empty \"text\""])
+            continue
+        }
+        var reply = decideAndInject(text: text)
+        reply["id"] = id
+        emit(reply)
     default:
         emit(["id": id, "status": "error", "reason": "unknown command \"\(cmd)\""])
     }

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
     "build": "tsc -p tsconfig.json --noEmit && vite build",
     "build:whisper": "bash scripts/build-whisper.sh",
     "build:hotkey-helper": "bash scripts/build-hotkey-helper.sh",
+    "build:accessibility-helper": "bash scripts/build-accessibility-helper.sh",
     "build:llama": "bash scripts/fetch-llama.sh",
-    "postinstall": "npm run build:whisper && npm run build:hotkey-helper && npm run build:llama",
+    "postinstall": "npm run build:whisper && npm run build:hotkey-helper && npm run build:accessibility-helper && npm run build:llama",
     "start": "cross-env NODE_ENV=production electron .",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "node --test \"electron/**/*.test.js\""

--- a/scripts/build-accessibility-helper.sh
+++ b/scripts/build-accessibility-helper.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# Compiles the text-injection helper (native/accessibility-helper) and stages
+# the binary at resources/bin/accessibility-helper. See issue #6.
+#
+# Swift-only, no external deps - `swift build` is enough. Safe to re-run:
+# swift build is itself incremental, and this script just re-copies the
+# freshly built binary each time.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+PKG_DIR="$ROOT/native/accessibility-helper"
+BIN_DIR="$ROOT/resources/bin"
+OUT_PATH="$BIN_DIR/accessibility-helper"
+
+echo "==> accessibility-helper"
+swift build --package-path "$PKG_DIR" -c release
+
+BUILT_BIN_DIR="$(swift build --package-path "$PKG_DIR" -c release --show-bin-path)"
+
+mkdir -p "$BIN_DIR"
+cp "$BUILT_BIN_DIR/accessibility-helper" "$OUT_PATH"
+chmod +x "$OUT_PATH"
+
+echo "==> done: $OUT_PATH"


### PR DESCRIPTION
Closes #6.

Builds the accessibility helper per #6's contract and #62's settled decision: a second native helper, separate from the hotkey helper (#5), holding Accessibility and never Input Monitoring, per the two-helper split settled in #26.

## What this builds

- `native/accessibility-helper/` - Swift package. Ports `InjectionModel` from the #62 prototype (`prototypes/injection-62/index.html`) onto real `ApplicationServices`/`CGEvent` calls:
  - **Rung 1** writes `kAXSelectedTextAttribute` (replaces the current selection - a caret is a zero-length selection - unlike `kAXValueAttribute`, which would overwrite the whole field). Refuses itself when the field's existing value looks like scrollback rather than a field.
  - **Rung 1b** pastes blind into a known app that's been stable well past the settle guard but never answered what's focused - #62's narrow exception.
  - **Rung 2** borrows the clipboard, synthesises Cmd+V, restores it - skipping the restore if the pasteboard's `changeCount` moved on in the meantime, so a copy made mid-paste is never clobbered.
  - **Rung 3** (synthesised keystrokes) fires only when rung 2 was verifiable and demonstrably failed - see "what changed from the prototype" below.
  - A settle guard against the stale-frontmost-app problem #28 measured, and hold-never-guess on every failure path.
- `scripts/build-accessibility-helper.sh` - compiles it in release mode, stages the binary at `resources/bin/accessibility-helper`. Wired into `postinstall` alongside the other two helpers.
- `electron/accessibilityHelper.js` - spawns the binary. Unlike `hotkeyHelper.js`'s fire-and-forget events, `inject` is request/response: replies are tagged with an id and matched back to the caller, with a per-request timeout, since this helper is allowed to block on AX calls.
- `electron/main.js` - calls `inject()` after a successful transcription. The console log stays for debugging; the transcript now also goes through the helper.

## What changed from the prototype, and why

The #62 prototype simulates a `world.acceptsPaste` ground truth the reducer can consult directly. Real code has no such oracle - there's no API that reports "did the target app accept this paste." So rung 3 only fires here when rung 2 *was* verifiable (a readable, field-sized value) and the readback shows the text didn't land. A paste into a field we can't read back at all (`AXWebArea`, a terminal's scrollback) is reported `delivered, unverified` and left there, rather than guessed to have failed and re-typed on top.

## What's verified vs. what needs a human

This session can't drive a real display or grant permissions, so:

**Verified headlessly:**
- `accessibility-helper` compiles cleanly (`swift build -c release`).
- Run standalone without Accessibility granted, `inject` correctly identifies the real frontmost app, then holds (rather than hanging or crashing) once the AX call fails without the grant.
- All new/changed JS passes `node --check`; `npm test` (17 tests, unrelated cleanup-rules coverage) and `npm run build` (`tsc` + `vite build`) both still pass.

**Needs a human, one time:** granting the Accessibility prompt (separate from Input Monitoring - two helpers, two grants) and confirming a real dictation lands in a text field, a terminal, and an Electron editor. Steps in `docs/testing/hotkey-transcribe-manual-check.md`, updated in this PR.

## Test plan
- [x] `accessibility-helper` compiles and fails gracefully (holds, not hangs) without permission (headless)
- [x] `node --check` on all new/changed files (headless)
- [x] `npm test` and `npm run build` still green (headless)
- [ ] Real dictation into a text field / terminal / Electron editor with Accessibility granted (needs a human running `npm start`)
