### PR TITLE
feat: force Chromium's AX tree open, resolve focus once (#12)

### DIFF
--- a/docs/testing/hotkey-transcribe-manual-check.md
+++ b/docs/testing/hotkey-transcribe-manual-check.md
@@ -1,4 +1,4 @@
-# Manual check: hotkey -> transcribe -> inject (#2, push-to-talk via #5, injection via #6)
+# Manual check: hotkey -> transcribe -> inject (#2, push-to-talk via #5, injection via #6/#12)
 
 What CI/a headless session can verify, and what still needs a human running
 the actual app: launching a real Electron window, granting macOS
@@ -50,11 +50,14 @@ the caret, then clipboard-plus-paste, then synthesised keystrokes - see
    holding the keys) to confirm the tap is global and doesn't need the
    app focused. The text should land in whichever app is frontmost when
    you release, not the one that was frontmost when you pressed.
-8. Try a terminal window and an Electron-based editor (e.g. VS Code) as the
-   target - these are exactly the cases #62 designed the fallback chain
-   around. A terminal's prompt should receive a clipboard paste, not have
-   its scrollback overwritten; an editor with no usable AX tree
-   (`AXWebArea`) should also fall through to paste.
+8. Try a terminal window and an Electron-based editor (e.g. VS Code, Slack)
+   as the target - these are exactly the cases #62 designed the fallback
+   chain around. A terminal's prompt should receive a clipboard paste, not
+   have its scrollback overwritten. In the Electron app, check whether
+   `#12`'s `AXManualAccessibility` forcing actually got a usable focused
+   element (rung 1 or a verified rung 2) rather than the bare `AXWebArea`
+   #28 measured without it - either is an acceptable outcome, but the
+   difference is worth noting since it's unmeasured until this step runs.
 
 If step 2/3 don't fire the OS prompts, or step 5 never prints/injects,
 check the terminal for `[whisper-server]`-, `[hotkey-helper]`- and

--- a/native/accessibility-helper/Sources/accessibility-helper/main.swift
+++ b/native/accessibility-helper/Sources/accessibility-helper/main.swift
@@ -187,6 +187,37 @@ func delivered(method: String, verified: Bool, note: String) -> [String: Any] {
     ["status": "delivered", "method": method, "verified": verified, "note": note]
 }
 
+// Chromium's own AX tree is normally built lazily, only once Chromium
+// detects a running assistive technology by its own heuristics - which our
+// direct AXUIElementCopyAttributeValue calls never trip. Setting this
+// attribute forces the tree to build regardless. #28 found Electron apps
+// (VS Code, Slack, Discord) exposing nothing but a bare AXWebArea without
+// it. Unconditional and ignored on failure: on an app that doesn't
+// recognise the attribute (i.e. anything not Chromium-based), the set just
+// fails harmlessly - see #12.
+func enableManualAccessibility(_ appElement: AXUIElement) {
+    AXUIElementSetAttributeValue(appElement, "AXManualAccessibility" as CFString, kCFBooleanTrue)
+}
+
+// Resolves the focused element once per dictation. #12 folded this into the
+// same helper #6 creates rather than a separate process or command,
+// specifically so this resolution and inject() never race each other over
+// focus - and so it only ever happens once: everything downstream (the
+// fallback chain below) reuses this same element rather than re-asking.
+func resolveFocusedElement(deadlineMs: Double) -> AXUIElement? {
+    guard let frontApp = NSWorkspace.shared.frontmostApplication else { return nil }
+
+    let appElement = AXUIElementCreateApplication(frontApp.processIdentifier)
+    AXUIElementSetMessagingTimeout(appElement, Float(deadlineMs / 1000.0))
+    enableManualAccessibility(appElement)
+
+    var focusedRef: CFTypeRef?
+    let focusErr = AXUIElementCopyAttributeValue(appElement, kAXFocusedUIElementAttribute as CFString, &focusedRef)
+    guard focusErr == .success, let focusedRef = focusedRef else { return nil }
+
+    return (focusedRef as! AXUIElement) // swiftlint:disable:this force_cast
+}
+
 // The decision procedure itself, ported from InjectionModel in
 // prototypes/injection-62/index.html onto real AX/CGEvent calls.
 func decideAndInject(text: String) -> [String: Any] {
@@ -201,30 +232,21 @@ func decideAndInject(text: String) -> [String: Any] {
         Thread.sleep(forTimeInterval: 0.02)
     }
 
-    guard let frontApp = NSWorkspace.shared.frontmostApplication else {
-        return held(reason: "nothing was focused, so there is no field to deliver to")
-    }
-    let appName = frontApp.localizedName ?? "the frontmost app"
-
-    let appElement = AXUIElementCreateApplication(frontApp.processIdentifier)
-    AXUIElementSetMessagingTimeout(appElement, Float(config.axDeadlineMs / 1000.0))
-
-    var focusedRef: CFTypeRef?
-    let focusErr = AXUIElementCopyAttributeValue(appElement, kAXFocusedUIElementAttribute as CFString, &focusedRef)
-
-    guard focusErr == .success, let focusedRef = focusedRef else {
-        // Rung 0 didn't answer. The narrow exception settled on #62: a known
-        // app that has sat still well past the settle guard is a much
-        // smaller unknown than "which app" - the user is demonstrably
-        // looking at it, so a blind paste there is a bounded, undoable
-        // mistake rather than a shot in the dark.
-        if let gate = config.stableForBlindPasteMs, tracker.ageMs() >= gate {
+    guard let focused = resolveFocusedElement(deadlineMs: config.axDeadlineMs) else {
+        // Rung 0 didn't answer, or nothing is frontmost at all. The narrow
+        // exception settled on #62: a known app that has sat still well
+        // past the settle guard is a much smaller unknown than "which
+        // app" - the user is demonstrably looking at it, so a blind paste
+        // there is a bounded, undoable mistake rather than a shot in the
+        // dark. We have no app name at all when nothing is frontmost, so
+        // that case always falls through to hold below.
+        if let gate = config.stableForBlindPasteMs, tracker.ageMs() >= gate,
+           let appName = NSWorkspace.shared.frontmostApplication?.localizedName {
             let (_, _, note) = pasteViaClipboard(text: text, verifyAgainst: nil, valueBefore: nil)
-            return delivered(method: "pasted into a known window, field unknown", verified: false, note: note)
+            return delivered(method: "pasted into \(appName), field unknown", verified: false, note: note)
         }
-        return held(reason: "\(appName) never said what was focused, and hasn't been stable long enough to paste blind")
+        return held(reason: "the frontmost app never said what was focused, and hasn't been stable long enough to paste blind")
     }
-    let focused = focusedRef as! AXUIElement // swiftlint:disable:this force_cast
 
     let info = fieldInfo(focused)
     let readableAndFieldSized = info.valueChars.map { $0 <= config.axValueMaxChars } ?? false


### PR DESCRIPTION
Closes #12.

#12 was re-scoped by #44: it used to be "detect the frontmost app and field type, report back a mode" - v0.x has one mode, prose, so nothing consumes a mode any more. What's left is narrower: resolve *the* focused element, in service of injection rather than formatting. #6 already built the helper this lives in - per #12's own contract ("no new binary, no new permission, no new IPC channel"), this PR is a change to that same file, not a new component.

## What this changes

Two things, both drawn from #12's "measured constraints" section (sourced from #28):

1. **`AXManualAccessibility`, set unconditionally before resolving focus.** #28 found Electron apps (VS Code, Slack, Discord) exposing nothing but a bare `AXWebArea`, because Chromium only builds its real accessibility tree once it detects an assistive technology by its own heuristics - a heuristic a direct `AXUIElementCopyAttributeValue` call never trips. Setting this attribute forces the tree open regardless. It's unconditional and its result is ignored: on anything that isn't Chromium-based, the attribute is simply unrecognised and the set fails harmlessly - #12 calls this out explicitly as free and a no-op elsewhere, so there's no app-detection logic to get wrong.
2. **Focus resolution pulled into its own `resolveFocusedElement()`, called once.** This contract already held in #6's code (one query, reused through the whole fallback chain) but was implicit inside `decideAndInject`. #12 asks for "resolves focus once, and inject uses that same resolution rather than repeating it" as an explicit property, so it's now a named function rather than an inline detail.

The other two things #12's issue names - the stale-pid problem, and terminals reporting scrollback as their value - were already handled by #6's settle guard and scrollback-size guard respectively, so there's nothing left to change for those.

## What's verified vs. what needs a human

**Verified headlessly:**
- Compiles cleanly (`swift build -c release`).
- Run standalone without Accessibility granted, `inject` still resolves the real frontmost app and holds gracefully - no change to that failure path.
- `npm test` and `npm run build` still pass.

**Needs a human, one time:** confirming a dictation into an Electron app (VS Code, Slack) actually gets a resolved field now rather than falling straight to a blind/unverified paste - this is genuinely unmeasured without a live AX tree to query. Step 8 in `docs/testing/hotkey-transcribe-manual-check.md`, updated in this PR, calls this out specifically.

## Test plan
- [x] Compiles (headless)
- [x] Standalone run still holds gracefully without Accessibility granted (headless)
- [x] `npm test` and `npm run build` still green (headless)
- [ ] Dictation into an Electron app resolves a real field, not just `AXWebArea` (needs a human running `npm start`)
