### PR TITLE
Fix push-to-talk: unbuffered hotkey stdout + Cmd-combo system beep

### DIFF
--- a/docs/testing/hotkey-transcribe-manual-check.md
+++ b/docs/testing/hotkey-transcribe-manual-check.md
@@ -5,11 +5,18 @@ the actual app: launching a real Electron window, granting macOS
 permissions, and pressing a global hotkey aren't things a sandboxed session
 can drive.
 
-Since #5, `Cmd+Shift+D` is real push-to-talk: hold to record, release to
-stop and transcribe. Since #6, the transcript is delivered to the field
+Since #5, `Control+Option+D` is real push-to-talk: hold to record, release
+to stop and transcribe. Since #6, the transcript is delivered to the field
 under the cursor via the accessibility helper's fallback chain (write at
 the caret, then clipboard-plus-paste, then synthesised keystrokes - see
 #62), not just printed to the terminal.
+
+The default was originally `Cmd+Shift+D`; #84 moved it to `Control+Option+D`
+after finding that a Cmd-combo with no matching menu item makes AppKit play
+the system alert beep in the focused app (the tap is listen-only, so the
+keystroke still reaches it) - and that beep, landing at the start of the
+clip, got hallucinated by Whisper as "[Music]". Control/Option combos aren't
+treated as menu key-equivalents, so nothing beeps.
 
 ## Already verified without a GUI
 
@@ -32,14 +39,14 @@ the caret, then clipboard-plus-paste, then synthesised keystrokes - see
 1. `npm install` (builds `whisper-server`, `hotkey-helper` and
    `accessibility-helper`, fetches the model if not already present), then
    `npm start`.
-2. The first hold of `Cmd+Shift+D` should trigger the macOS **Input
+2. The first hold of `Control+Option+D` should trigger the macOS **Input
    Monitoring** prompt (not Accessibility - see #5's contract). Grant it.
 3. The next dictation attempt should trigger a separate **Accessibility**
    prompt for the injection helper (not Input Monitoring - see #6's
    contract, two helpers, two permissions). Grant it, then quit and
    relaunch the app so both helpers pick up their grants.
 4. Click into a normal text field (e.g. a Notes window, or this file in an
-   editor), hold `Cmd+Shift+D`, say something, release it.
+   editor), hold `Control+Option+D`, say something, release it.
 5. The transcript should appear **in the field**, not just the terminal.
    The terminal running `npm start` still prints it too, prefixed
    `[dictation]`, followed by a line reporting how it was delivered - e.g.

--- a/electron/hotkeyHelper.js
+++ b/electron/hotkeyHelper.js
@@ -5,10 +5,16 @@ const { resourcesRoot } = require("./paths");
 
 const BIN_PATH = path.join(resourcesRoot(), "bin", "hotkey-helper");
 
-// Keycode 2 is 'D' on the ANSI layout - matches the CommandOrControl+Shift+D
-// hotkey this replaces. The helper only knows keycodes, not accelerator
-// strings, so the mapping lives here.
-const ARGS = ["--keycode", "2", "--modifiers", "cmd,shift"];
+// Keycode 2 is 'D' on the ANSI layout. The helper only knows keycodes, not
+// accelerator strings, so the mapping lives here.
+//
+// Control+Option, not Cmd+Shift: this tap is listen-only (see main.swift),
+// so the keystroke still reaches whatever app is focused. A Cmd-combo that
+// doesn't match a menu item makes AppKit play the system alert beep, which
+// then gets captured at the start of the recording and Whisper hallucinates
+// as "[Music]". Control+Option isn't treated as a menu key-equivalent, so
+// nothing beeps.
+const ARGS = ["--keycode", "2", "--modifiers", "ctrl,alt"];
 
 const RESTART_DELAY_MS = 1000;
 

--- a/native/hotkey-helper/Sources/hotkey-helper/main.swift
+++ b/native/hotkey-helper/Sources/hotkey-helper/main.swift
@@ -19,6 +19,11 @@ func eprint(_ message: String) {
 func emit(_ event: String) {
     // No user text ever crosses this channel, so no escaping is needed here.
     print("{\"event\":\"\(event)\",\"ts\":\(Date().timeIntervalSince1970)}")
+    // stdout is fully buffered, not line-buffered, once it's a pipe rather than
+    // a tty - which is exactly what Electron's spawn() gives it. Without this,
+    // "ready"/"down"/"up" sit in the buffer indefinitely instead of reaching
+    // the parent process, so the hotkey silently does nothing.
+    fflush(stdout)
 }
 
 func parseModifiers(_ raw: String) -> CGEventFlags {


### PR DESCRIPTION
Closes #84.

Found while manually verifying the packaged v0.1 DMG end-to-end (#82). Two compounding bugs made push-to-talk effectively unusable, and a third commit updates the one doc that documented the old hotkey.

## Bug 1: hotkey-helper's stdout was never flushed

emit() in main.swift called print() but never fflush(stdout). Swift/libc stdout is line-buffered only when attached to a tty; once Electron spawns it as a piped child process it's fully block-buffered, so the ready/down/up JSON events sat in the buffer and effectively never reached the parent process during normal operation - no crash, no error, the hotkey just silently did nothing. accessibility-helper already gets this right (fflush(stdout) after every print in its emit path) - hotkey-helper's emit() was just missed.

Confirmed by a temporary debug build that logged every keydown the tap actually saw: with the fflush fix in place, key detection started working immediately.

## Bug 2: the default hotkey (Cmd+Shift+D) produced an audible system beep on every press

The tap is deliberately listen-only (Input Monitoring only, not Accessibility - see the code comment in main.swift referencing #26, so a stalled AX call can never starve the hotkey tap), which means the keystroke still reaches whatever app is focused. In AppKit apps (Notes, etc.) a Cmd-combo that doesn't match any menu item makes the system play the alert beep. That beep landed at the very start of the recorded clip, and Whisper hallucinated it as "[Music]" in the transcript.

Fixed by moving the default hotkey to Control+Option+D. Control/Option combos aren't treated as menu key-equivalents, so nothing beeps.

## Changes

- native/hotkey-helper/Sources/hotkey-helper/main.swift: fflush(stdout) in emit().
- electron/hotkeyHelper.js: ARGS modifiers cmd,shift -> ctrl,alt.
- docs/testing/hotkey-transcribe-manual-check.md: updated the documented hotkey and noted why it changed.

## Verification

Rebuilt hotkey-helper, hot-patched the already-installed v0.1 DMG build in /Applications (binary + the asar's copy of hotkeyHelper.js) rather than rebuilding the whole DMG, and tested live end to end: held Control+Option+D in Notes, spoke, released - transcript landed in the field, no beep, no hallucinated [Music]. Confirmed with a human (the repo owner) actually doing this, not just me.

npm run build and npm test (18/18) both pass.
