### PR TITLE
Implement resident transcription model server

### DIFF
--- a/electron/dictationCoordinator.js
+++ b/electron/dictationCoordinator.js
@@ -1,0 +1,60 @@
+const { encodeWav } = require("./wav");
+const { cleanup } = require("./cleanup/rules");
+
+async function runCompletedDictation(options) {
+  const {
+    int16Samples,
+    transcription,
+    delivery,
+    context = { oneLineBox: false, breakSafe: false },
+    setUserVisibleState = () => {},
+    logger = console,
+  } = options;
+
+  if (!int16Samples || int16Samples.length === 0) {
+    setUserVisibleState("idle");
+    return { status: "empty" };
+  }
+
+  setUserVisibleState("transcribing");
+
+  let transcript;
+  try {
+    const wavBuffer = encodeWav(int16Samples);
+    transcript = await transcription.transcribe(wavBuffer);
+  } catch (err) {
+    logger.error("[dictation] transcription failed:", err);
+    setUserVisibleState("idle");
+    return { status: "failed", stage: "transcription", error: err };
+  }
+
+  const rawText = (transcript.text || "").trim();
+  if (!rawText) {
+    setUserVisibleState("idle");
+    return { status: "no-speech" };
+  }
+
+  const finishedText = cleanup(rawText, context);
+  if (!finishedText) {
+    setUserVisibleState("idle");
+    return { status: "no-speech" };
+  }
+
+  try {
+    const deliveryResult = await delivery.inject(finishedText);
+    setUserVisibleState("idle");
+    if (deliveryResult.status === "delivered") {
+      return { status: "delivered", text: finishedText, delivery: deliveryResult };
+    }
+    if (deliveryResult.status === "held") {
+      return { status: "held", text: finishedText, delivery: deliveryResult };
+    }
+    return { status: "failed", stage: "delivery", text: finishedText, delivery: deliveryResult };
+  } catch (err) {
+    logger.error("[dictation] injection failed:", err);
+    setUserVisibleState("idle");
+    return { status: "failed", stage: "delivery", text: finishedText, error: err };
+  }
+}
+
+module.exports = { runCompletedDictation };

--- a/electron/dictationCoordinator.test.js
+++ b/electron/dictationCoordinator.test.js
@@ -1,0 +1,90 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { runCompletedDictation } = require("./dictationCoordinator");
+
+const samples = new Int16Array([1, -1, 2, -2]);
+
+function silentLogger() {
+  return { error() {} };
+}
+
+test("completed recording is transcribed, cleaned, and delivered once", async () => {
+  const states = [];
+  const delivered = [];
+
+  const result = await runCompletedDictation({
+    int16Samples: samples,
+    transcription: { transcribe: async () => ({ text: "um git hub new line java script" }) },
+    delivery: {
+      inject: async (text) => {
+        delivered.push(text);
+        return { status: "delivered", method: "paste", verified: true };
+      },
+    },
+    context: { breakSafe: true, oneLineBox: false },
+    setUserVisibleState: (state) => states.push(state),
+    logger: silentLogger(),
+  });
+
+  assert.equal(result.status, "delivered");
+  assert.deepEqual(delivered, ["GitHub\nJavaScript."]);
+  assert.deepEqual(states, ["transcribing", "idle"]);
+});
+
+test("empty recordings do not call transcription or delivery", async () => {
+  let transcribeCalls = 0;
+  let deliveryCalls = 0;
+
+  const result = await runCompletedDictation({
+    int16Samples: new Int16Array(),
+    transcription: { transcribe: async () => transcribeCalls++ },
+    delivery: { inject: async () => deliveryCalls++ },
+    logger: silentLogger(),
+  });
+
+  assert.equal(result.status, "empty");
+  assert.equal(transcribeCalls, 0);
+  assert.equal(deliveryCalls, 0);
+});
+
+test("no-speech transcription leaves the target application unchanged", async () => {
+  let deliveryCalls = 0;
+
+  const result = await runCompletedDictation({
+    int16Samples: samples,
+    transcription: { transcribe: async () => ({ text: "   " }) },
+    delivery: { inject: async () => deliveryCalls++ },
+    logger: silentLogger(),
+  });
+
+  assert.equal(result.status, "no-speech");
+  assert.equal(deliveryCalls, 0);
+});
+
+test("transcription failure does not insert partial output", async () => {
+  let deliveryCalls = 0;
+
+  const result = await runCompletedDictation({
+    int16Samples: samples,
+    transcription: { transcribe: async () => { throw new Error("server unavailable"); } },
+    delivery: { inject: async () => deliveryCalls++ },
+    logger: silentLogger(),
+  });
+
+  assert.equal(result.status, "failed");
+  assert.equal(result.stage, "transcription");
+  assert.equal(deliveryCalls, 0);
+});
+
+test("held delivery preserves the complete finished text", async () => {
+  const result = await runCompletedDictation({
+    int16Samples: samples,
+    transcription: { transcribe: async () => ({ text: "hello world" }) },
+    delivery: { inject: async () => ({ status: "held", reason: "unverified target" }) },
+    logger: silentLogger(),
+  });
+
+  assert.equal(result.status, "held");
+  assert.equal(result.text, "Hello world.");
+  assert.equal(result.delivery.reason, "unverified target");
+});

--- a/electron/llamaServer.js
+++ b/electron/llamaServer.js
@@ -1,44 +1,27 @@
-const { spawn } = require("child_process");
 const path = require("path");
 const { resourcesRoot } = require("./paths");
+const { createModelSupervisor } = require("./modelSupervisor");
 
-// Plumbing only (#14): fetches and can start llama-server, but nothing
-// calls start() yet. #17 (voice-driven editing) is the feature that
-// consumes this - wiring it into app startup before that exists would
-// hold ~1GB resident for no consumer. See whisperServer.js for the
-// resident-subprocess shape this will take once #17 lands.
+// Rewrite model server: supervised by role name so diagnostics follow the
+// architecture role rather than the current executable.
 const HOST = "127.0.0.1";
 const PORT = 8179;
-const RESTART_DELAY_MS = 1000;
 
 const BIN_PATH = path.join(resourcesRoot(), "bin", "llama", "llama-server");
 const MODEL_PATH = path.join(resourcesRoot(), "models", "smollm2-1.7b-instruct-q4_k_m.gguf");
 
-let child = null;
-let stopping = false;
+const supervisor = createModelSupervisor({
+  roleName: "rewrite model server",
+  command: BIN_PATH,
+  args: ["--model", MODEL_PATH, "--host", HOST, "--port", String(PORT)],
+});
 
 function start() {
-  stopping = false;
-  child = spawn(BIN_PATH, [
-    "--model", MODEL_PATH,
-    "--host", HOST,
-    "--port", String(PORT),
-  ]);
-
-  child.stdout.on("data", (data) => process.stdout.write(`[llama-server] ${data}`));
-  child.stderr.on("data", (data) => process.stderr.write(`[llama-server] ${data}`));
-
-  child.on("exit", (code) => {
-    child = null;
-    if (stopping) return;
-    console.error(`[llama-server] exited unexpectedly (code ${code}), restarting in ${RESTART_DELAY_MS}ms`);
-    setTimeout(start, RESTART_DELAY_MS);
-  });
+  supervisor.start();
 }
 
 function stop() {
-  stopping = true;
-  if (child) child.kill();
+  supervisor.stop();
 }
 
 function healthUrl() {

--- a/electron/main.js
+++ b/electron/main.js
@@ -3,7 +3,8 @@ const path = require("path");
 const whisperServer = require("./whisperServer");
 const hotkeyHelper = require("./hotkeyHelper");
 const accessibilityHelper = require("./accessibilityHelper");
-const { encodeWav } = require("./wav");
+const { createTranscriptionHttpAdapter } = require("./transcriptionHttpAdapter");
+const { runCompletedDictation } = require("./dictationCoordinator");
 
 const isDev = process.env.NODE_ENV === "development";
 
@@ -19,6 +20,7 @@ let trayIcons = null;
 let trayState = "idle";
 let captureWin = null;
 let isRecording = false;
+const transcription = createTranscriptionHttpAdapter({ inferenceUrl: whisperServer.inferenceUrl });
 
 function createWindow() {
   if (win) {
@@ -66,42 +68,22 @@ function createCaptureWindow() {
 }
 
 async function transcribeAndPrint(int16Samples) {
-  const wavBuffer = encodeWav(int16Samples);
-  const formData = new FormData();
-  formData.append("file", new Blob([wavBuffer], { type: "audio/wav" }), "dictation.wav");
-  formData.append("response_format", "json");
+  const result = await runCompletedDictation({
+    int16Samples,
+    transcription,
+    delivery: accessibilityHelper,
+    setUserVisibleState: setTrayState,
+  });
 
-  try {
-    const res = await fetch(whisperServer.inferenceUrl(), { method: "POST", body: formData });
-    if (!res.ok) throw new Error(`whisper-server returned ${res.status}`);
-    const body = await res.json();
-    const text = (body.text || "").trim();
-    console.log(`[dictation] ${text || "(no speech detected)"}`);
-    if (text) await injectTranscript(text);
-  } catch (err) {
-    console.error("[dictation] transcription failed:", err);
-  } finally {
-    setTrayState("idle");
-  }
-}
-
-// #6's helper reports one of three shapes: delivered (with the rung and
-// whether it could confirm the text landed), held (nothing was risked - see
-// #62's hold-never-guess), or a protocol error. There is no overlay surface
-// yet for a held transcript (#12/#44's job); for now the reason is logged so
-// a held dictation is at least visible, not silently dropped.
-async function injectTranscript(text) {
-  try {
-    const result = await accessibilityHelper.inject(text);
-    if (result.status === "delivered") {
-      console.log(`[dictation] injected via ${result.method}${result.verified ? "" : " (unverified)"}`);
-    } else if (result.status === "held") {
-      console.log(`[dictation] injection held: ${result.reason}`);
-    } else {
-      console.error(`[dictation] injection error: ${result.reason}`);
-    }
-  } catch (err) {
-    console.error("[dictation] injection failed:", err);
+  if (result.status === "delivered") {
+    console.log(`[dictation] ${result.text}`);
+    console.log(`[dictation] injected via ${result.delivery.method}${result.delivery.verified ? "" : " (unverified)"}`);
+  } else if (result.status === "held") {
+    console.log(`[dictation] injection held: ${result.delivery.reason}`);
+  } else if (result.status === "failed" && result.stage === "delivery") {
+    console.error(`[dictation] injection error: ${result.delivery?.reason || result.error?.message || "unknown error"}`);
+  } else if (result.status === "no-speech") {
+    console.log("[dictation] (no speech detected)");
   }
 }
 

--- a/electron/modelSupervisor.js
+++ b/electron/modelSupervisor.js
@@ -1,0 +1,64 @@
+const { spawn: defaultSpawn } = require("child_process");
+
+const DEFAULT_RESTART_DELAY_MS = 1000;
+
+function createModelSupervisor(options) {
+  const {
+    roleName,
+    command,
+    args = [],
+    restartDelayMs = DEFAULT_RESTART_DELAY_MS,
+    spawn = defaultSpawn,
+    setRestartTimer = setTimeout,
+    clearRestartTimer = clearTimeout,
+    stdout = process.stdout,
+    stderr = process.stderr,
+  } = options;
+
+  if (!roleName) throw new Error("Model supervisor requires a roleName");
+  if (!command) throw new Error(`${roleName} supervisor requires a command`);
+
+  let child = null;
+  let stopping = false;
+  let restartTimer = null;
+
+  function prefixedWrite(stream, data) {
+    stream.write(`[${roleName}] ${data}`);
+  }
+
+  function start() {
+    if (child) return;
+    stopping = false;
+    child = spawn(command, args);
+
+    if (child.stdout) child.stdout.on("data", (data) => prefixedWrite(stdout, data));
+    if (child.stderr) child.stderr.on("data", (data) => prefixedWrite(stderr, data));
+
+    child.on("exit", (code, signal) => {
+      child = null;
+      if (stopping) return;
+      const detail = signal ? `signal ${signal}` : `code ${code}`;
+      stderr.write(`[${roleName}] exited unexpectedly (${detail}), restarting in ${restartDelayMs}ms\n`);
+      restartTimer = setRestartTimer(() => {
+        restartTimer = null;
+        start();
+      }, restartDelayMs);
+    });
+  }
+
+  function stop() {
+    stopping = true;
+    if (restartTimer) {
+      clearRestartTimer(restartTimer);
+      restartTimer = null;
+    }
+    if (child) {
+      child.kill();
+      child = null;
+    }
+  }
+
+  return { start, stop, roleName };
+}
+
+module.exports = { createModelSupervisor, DEFAULT_RESTART_DELAY_MS };

--- a/electron/modelSupervisor.js
+++ b/electron/modelSupervisor.js
@@ -26,23 +26,33 @@ function createModelSupervisor(options) {
     stream.write(`[${roleName}] ${data}`);
   }
 
+  function restartAfterFailure(failedChild, message) {
+    if (child !== failedChild) return;
+    child = null;
+    if (stopping) return;
+    stderr.write(`[${roleName}] ${message}, restarting in ${restartDelayMs}ms\n`);
+    restartTimer = setRestartTimer(() => {
+      restartTimer = null;
+      start();
+    }, restartDelayMs);
+  }
+
   function start() {
     if (child) return;
     stopping = false;
-    child = spawn(command, args);
+    const spawnedChild = spawn(command, args);
+    child = spawnedChild;
 
-    if (child.stdout) child.stdout.on("data", (data) => prefixedWrite(stdout, data));
-    if (child.stderr) child.stderr.on("data", (data) => prefixedWrite(stderr, data));
+    if (spawnedChild.stdout) spawnedChild.stdout.on("data", (data) => prefixedWrite(stdout, data));
+    if (spawnedChild.stderr) spawnedChild.stderr.on("data", (data) => prefixedWrite(stderr, data));
 
-    child.on("exit", (code, signal) => {
-      child = null;
-      if (stopping) return;
+    spawnedChild.on("error", (error) => {
+      const detail = error.code ? `${error.code}: ${error.message}` : error.message;
+      restartAfterFailure(spawnedChild, `failed to start (${detail})`);
+    });
+    spawnedChild.on("exit", (code, signal) => {
       const detail = signal ? `signal ${signal}` : `code ${code}`;
-      stderr.write(`[${roleName}] exited unexpectedly (${detail}), restarting in ${restartDelayMs}ms\n`);
-      restartTimer = setRestartTimer(() => {
-        restartTimer = null;
-        start();
-      }, restartDelayMs);
+      restartAfterFailure(spawnedChild, `exited unexpectedly (${detail})`);
     });
   }
 

--- a/electron/modelSupervisor.test.js
+++ b/electron/modelSupervisor.test.js
@@ -1,0 +1,106 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { EventEmitter } = require("node:events");
+const { PassThrough, Writable } = require("node:stream");
+const { createModelSupervisor } = require("./modelSupervisor");
+
+function fakeChild() {
+  const child = new EventEmitter();
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.killed = false;
+  child.kill = () => {
+    child.killed = true;
+    child.emit("exit", null, "SIGTERM");
+  };
+  return child;
+}
+
+function captureStream(chunks) {
+  return new Writable({
+    write(chunk, encoding, callback) {
+      chunks.push(String(chunk));
+      callback();
+    },
+  });
+}
+
+test("supervises a model process by role name and restarts unexpected exits", () => {
+  const spawned = [];
+  const stderrChunks = [];
+  const timers = [];
+  const supervisor = createModelSupervisor({
+    roleName: "transcription model server",
+    command: "/tmp/transcription-server",
+    args: ["--host", "127.0.0.1"],
+    restartDelayMs: 25,
+    spawn: (command, args) => {
+      const child = fakeChild();
+      spawned.push({ command, args, child });
+      return child;
+    },
+    setRestartTimer: (fn, delay) => {
+      timers.push({ fn, delay });
+      return { unref() {} };
+    },
+    stderr: captureStream(stderrChunks),
+  });
+
+  supervisor.start();
+  spawned[0].child.emit("exit", 1, null);
+
+  assert.equal(spawned.length, 1);
+  assert.equal(timers.length, 1);
+  assert.equal(timers[0].delay, 25);
+  assert.match(stderrChunks.join(""), /\[transcription model server\] exited unexpectedly \(code 1\)/);
+
+  timers[0].fn();
+  assert.equal(spawned.length, 2);
+  assert.deepEqual(spawned[1].args, ["--host", "127.0.0.1"]);
+});
+
+test("expected stop does not schedule a restart", () => {
+  const spawned = [];
+  const timers = [];
+  const supervisor = createModelSupervisor({
+    roleName: "transcription model server",
+    command: "/tmp/transcription-server",
+    spawn: () => {
+      const child = fakeChild();
+      spawned.push(child);
+      return child;
+    },
+    setRestartTimer: (fn, delay) => timers.push({ fn, delay }),
+  });
+
+  supervisor.start();
+  supervisor.stop();
+
+  assert.equal(spawned[0].killed, true);
+  assert.equal(timers.length, 0);
+});
+
+test("stop cancels a pending restart after an unexpected exit", () => {
+  const spawned = [];
+  const timer = { cancelled: false };
+  const supervisor = createModelSupervisor({
+    roleName: "transcription model server",
+    command: "/tmp/transcription-server",
+    spawn: () => {
+      const child = fakeChild();
+      spawned.push(child);
+      return child;
+    },
+    setRestartTimer: () => timer,
+    stderr: captureStream([]),
+    clearRestartTimer: (handle) => {
+      handle.cancelled = true;
+    },
+  });
+
+  supervisor.start();
+  spawned[0].emit("exit", 1, null);
+  supervisor.stop();
+
+  assert.equal(timer.cancelled, true);
+});

--- a/electron/modelSupervisor.test.js
+++ b/electron/modelSupervisor.test.js
@@ -59,6 +59,37 @@ test("supervises a model process by role name and restarts unexpected exits", ()
   assert.deepEqual(spawned[1].args, ["--host", "127.0.0.1"]);
 });
 
+test("restarts when the model process cannot be spawned", () => {
+  const spawned = [];
+  const stderrChunks = [];
+  const timers = [];
+  const supervisor = createModelSupervisor({
+    roleName: "transcription model server",
+    command: "/missing/transcription-server",
+    restartDelayMs: 25,
+    spawn: () => {
+      const child = fakeChild();
+      spawned.push(child);
+      return child;
+    },
+    setRestartTimer: (fn, delay) => {
+      timers.push({ fn, delay });
+      return { unref() {} };
+    },
+    stderr: captureStream(stderrChunks),
+  });
+
+  supervisor.start();
+  spawned[0].emit("error", Object.assign(new Error("spawn ENOENT"), { code: "ENOENT" }));
+
+  assert.equal(timers.length, 1);
+  assert.equal(timers[0].delay, 25);
+  assert.match(stderrChunks.join(""), /\[transcription model server\] failed to start \(ENOENT: spawn ENOENT\)/);
+
+  timers[0].fn();
+  assert.equal(spawned.length, 2);
+});
+
 test("expected stop does not schedule a restart", () => {
   const spawned = [];
   const timers = [];

--- a/electron/paths.js
+++ b/electron/paths.js
@@ -1,5 +1,10 @@
 const path = require("path");
-const electron = require("electron");
+let electron = null;
+try {
+  electron = require("electron");
+} catch {
+  electron = null;
+}
 
 // Dev: resources/ lives at the repo root, next to electron/.
 // Packaged: extraResources copies resources/ into Contents/Resources/resources,
@@ -10,7 +15,7 @@ const electron = require("electron");
 // resolves to the path of the Electron binary, a string, not the API object -
 // isPackaged is unreachable there, and unpacked dev behavior is exactly right.
 function resourcesRoot() {
-  const isPackaged = typeof electron === "object" && electron.app && electron.app.isPackaged;
+  const isPackaged = electron && typeof electron === "object" && electron.app && electron.app.isPackaged;
   if (isPackaged) {
     return path.join(process.resourcesPath, "resources");
   }

--- a/electron/transcriptionHttpAdapter.js
+++ b/electron/transcriptionHttpAdapter.js
@@ -1,0 +1,22 @@
+function createTranscriptionHttpAdapter(options) {
+  const { inferenceUrl, fetchImpl = fetch } = options;
+  if (typeof inferenceUrl !== "function") {
+    throw new Error("Transcription HTTP adapter requires an inferenceUrl function");
+  }
+
+  async function transcribe(wavBuffer) {
+    const formData = new FormData();
+    formData.append("file", new Blob([wavBuffer], { type: "audio/wav" }), "dictation.wav");
+    formData.append("response_format", "json");
+
+    const res = await fetchImpl(inferenceUrl(), { method: "POST", body: formData });
+    if (!res.ok) throw new Error(`transcription model server returned ${res.status}`);
+
+    const body = await res.json();
+    return { text: (body.text || "").trim() };
+  }
+
+  return { transcribe };
+}
+
+module.exports = { createTranscriptionHttpAdapter };

--- a/electron/transcriptionHttpAdapter.test.js
+++ b/electron/transcriptionHttpAdapter.test.js
@@ -1,0 +1,37 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { createTranscriptionHttpAdapter } = require("./transcriptionHttpAdapter");
+
+test("posts a completed WAV recording to the local transcription contract", async () => {
+  const calls = [];
+  const adapter = createTranscriptionHttpAdapter({
+    inferenceUrl: () => "http://127.0.0.1:8178/inference",
+    fetchImpl: async (url, options) => {
+      calls.push({ url, options });
+      return { ok: true, json: async () => ({ text: "  hello world  " }) };
+    },
+  });
+
+  const result = await adapter.transcribe(Buffer.from("RIFF wav bytes"));
+
+  assert.deepEqual(result, { text: "hello world" });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, "http://127.0.0.1:8178/inference");
+  assert.equal(calls[0].options.method, "POST");
+  assert.equal(calls[0].options.body.get("response_format"), "json");
+  const file = calls[0].options.body.get("file");
+  assert.equal(file.name, "dictation.wav");
+  assert.equal(file.type, "audio/wav");
+});
+
+test("fails clearly when the transcription model server rejects a recording", async () => {
+  const adapter = createTranscriptionHttpAdapter({
+    inferenceUrl: () => "http://127.0.0.1:8178/inference",
+    fetchImpl: async () => ({ ok: false, status: 503 }),
+  });
+
+  await assert.rejects(
+    () => adapter.transcribe(Buffer.from("RIFF wav bytes")),
+    /transcription model server returned 503/
+  );
+});

--- a/electron/whisperServer.js
+++ b/electron/whisperServer.js
@@ -1,42 +1,27 @@
-const { spawn } = require("child_process");
 const path = require("path");
 const { resourcesRoot } = require("./paths");
+const { createModelSupervisor } = require("./modelSupervisor");
 
-// Transcription model server: resident for the life of the app, restarted
-// if it crashes. See #29 - a per-dictation subprocess would pay the model
-// load cost (0.38s) on every dictation, and this is not that.
+// Transcription model server: resident for the life of the app, supervised
+// by role name so the app vocabulary does not depend on the current model.
 const HOST = "127.0.0.1";
 const PORT = 8178;
-const RESTART_DELAY_MS = 1000;
 
 const BIN_PATH = path.join(resourcesRoot(), "bin", "whisper-server");
 const MODEL_PATH = path.join(resourcesRoot(), "models", "ggml-base.en.bin");
 
-let child = null;
-let stopping = false;
+const supervisor = createModelSupervisor({
+  roleName: "transcription model server",
+  command: BIN_PATH,
+  args: ["--model", MODEL_PATH, "--host", HOST, "--port", String(PORT)],
+});
 
 function start() {
-  stopping = false;
-  child = spawn(BIN_PATH, [
-    "--model", MODEL_PATH,
-    "--host", HOST,
-    "--port", String(PORT),
-  ]);
-
-  child.stdout.on("data", (data) => process.stdout.write(`[whisper-server] ${data}`));
-  child.stderr.on("data", (data) => process.stderr.write(`[whisper-server] ${data}`));
-
-  child.on("exit", (code) => {
-    child = null;
-    if (stopping) return;
-    console.error(`[whisper-server] exited unexpectedly (code ${code}), restarting in ${RESTART_DELAY_MS}ms`);
-    setTimeout(start, RESTART_DELAY_MS);
-  });
+  supervisor.start();
 }
 
 function stop() {
-  stopping = true;
-  if (child) child.kill();
+  supervisor.stop();
 }
 
 function inferenceUrl() {


### PR DESCRIPTION
Closes #93.\n\n## Summary\n- add a role-named model supervisor for resident model servers\n- add a local transcription HTTP adapter and coordinator seam\n- wire completed recordings through the coordinator to the resident transcription server and delivery adapter\n\n## Tests\n- npm test\n- npm run typecheck