### PR TITLE
Fix accessibility-helper injecting into a stale frontmost app instead of the current one

### DIFF
--- a/native/accessibility-helper/Sources/accessibility-helper/main.swift
+++ b/native/accessibility-helper/Sources/accessibility-helper/main.swift
@@ -29,10 +29,22 @@ let config = Config()
 final class AppSwitchTracker {
     private let lock = NSLock()
     private var switchedAt = Date()
+    // NSWorkspace.frontmostApplication is notification-driven internally and
+    // goes stale on a thread that never pumps a run loop - which is exactly
+    // what the main thread is, parked in readLine() and the AX calls below.
+    // Caching the value here, updated only from the run-loop-pumping thread
+    // below, is what keeps reads of it live instead of frozen at whatever
+    // was frontmost the last time this thread got a turn.
+    private var frontmost: NSRunningApplication?
 
-    func recordSwitch() {
+    init() {
+        frontmost = NSWorkspace.shared.frontmostApplication
+    }
+
+    func recordSwitch(to app: NSRunningApplication?) {
         lock.lock()
         switchedAt = Date()
+        frontmost = app
         lock.unlock()
     }
 
@@ -40,6 +52,12 @@ final class AppSwitchTracker {
         lock.lock()
         defer { lock.unlock() }
         return now.timeIntervalSince(switchedAt) * 1000
+    }
+
+    func currentFrontmost() -> NSRunningApplication? {
+        lock.lock()
+        defer { lock.unlock() }
+        return frontmost
     }
 }
 let tracker = AppSwitchTracker()
@@ -49,7 +67,10 @@ Thread {
         forName: NSWorkspace.didActivateApplicationNotification,
         object: nil,
         queue: nil
-    ) { _ in tracker.recordSwitch() }
+    ) { note in
+        let app = note.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication
+        tracker.recordSwitch(to: app)
+    }
     RunLoop.current.run()
 }.start()
 
@@ -205,7 +226,7 @@ func enableManualAccessibility(_ appElement: AXUIElement) {
 // focus - and so it only ever happens once: everything downstream (the
 // fallback chain below) reuses this same element rather than re-asking.
 func resolveFocusedElement(deadlineMs: Double) -> AXUIElement? {
-    guard let frontApp = NSWorkspace.shared.frontmostApplication else { return nil }
+    guard let frontApp = tracker.currentFrontmost() else { return nil }
 
     let appElement = AXUIElementCreateApplication(frontApp.processIdentifier)
     AXUIElementSetMessagingTimeout(appElement, Float(deadlineMs / 1000.0))
@@ -241,7 +262,7 @@ func decideAndInject(text: String) -> [String: Any] {
         // dark. We have no app name at all when nothing is frontmost, so
         // that case always falls through to hold below.
         if let gate = config.stableForBlindPasteMs, tracker.ageMs() >= gate,
-           let appName = NSWorkspace.shared.frontmostApplication?.localizedName {
+           let appName = tracker.currentFrontmost()?.localizedName {
             let (_, _, note) = pasteViaClipboard(text: text, verifyAgainst: nil, valueBefore: nil)
             return delivered(method: "pasted into \(appName), field unknown", verified: false, note: note)
         }


### PR DESCRIPTION
Closes #112.

Found while manually verifying the packaged v0.1 DMG end-to-end, right after #86 fixed the hotkey itself. Dictation worked, but the transcript always landed in Notes even after switching to a browser search box or a Terminal line and dictating there - it stayed pinned to whichever app was frontmost the first time a dictation succeeded in that process's lifetime.

## Root cause

resolveFocusedElement() and the blind-paste fallback in main.swift both called NSWorkspace.shared.frontmostApplication directly, on the main thread. The main thread spends essentially all its time blocked in readLine() and the AX calls in decideAndInject, and never pumps a run loop. NSWorkspace's frontmost-app tracking is notification-driven internally, so a caller that never pumps a run loop sees it frozen at whatever was frontmost the last time the thread happened to get a turn - not the actual current frontmost app.

The code already had a fix for exactly this class of problem, just not applied here: AppSwitchTracker runs a background thread with its own run loop specifically so NSWorkspace.didActivateApplicationNotification reliably arrives (see the comment above it), and uses that to drive the settle-guard timer. It just never also cached the frontmost app itself for other callers to read - resolveFocusedElement() and the blind-paste appName lookup still read NSWorkspace.shared.frontmostApplication directly instead of going through the tracker.

## Fix

Extended AppSwitchTracker to also cache the current frontmost NSRunningApplication, updated only from the run-loop-pumping background thread via the same notification observer. Both call sites now read tracker.currentFrontmost() instead of NSWorkspace.shared.frontmostApplication directly.

## Verification

Rebuilt the whole DMG fresh (npm run dist) and installed it properly (xattr -cr + one codesign --force --deep --sign - pass, not a hand-patched binary) - a lesson from #86's debugging session, where individually patching files in place repeatedly broke the app bundle's signature seal and orphaned TCC grants. Confirmed live, with a human (the repo owner) actually doing it: dictating into Notes, then switching to a browser and Terminal and dictating again in each, correctly followed focus instead of staying pinned to Notes.

npm run build and npm test (18/18) both pass.

With this, #86, and #82, Phase 1 (v0.1 "It types") is functionally verified end-to-end against the actual packaged DMG, not just npm start.
