### PR TITLE
test: make the injection fallback chain testable, add regression coverage (#10)

### DIFF
--- a/docs/testing/hotkey-transcribe-manual-check.md
+++ b/docs/testing/hotkey-transcribe-manual-check.md
@@ -32,6 +32,12 @@ treated as menu key-equivalents, so nothing beeps.
   granted, its `inject` command correctly reports the frontmost app but
   holds rather than delivering - AX calls fail cleanly without the grant,
   they don't hang.
+- Since #10, the fallback chain's decision logic (`InjectionEngine` in
+  `native/accessibility-helper/Sources/AccessibilityInjection/`) has 12
+  automated tests covering every rung, the settle guard, and the blind-paste
+  gate against fakes - `swift test --package-path native/accessibility-helper`
+  (needs a full Xcode install; Command Line Tools alone are missing
+  `Testing.framework`'s runtime search path).
 - All new/changed files pass `node --check`.
 
 ## Needs a human, one time
@@ -65,6 +71,11 @@ treated as menu key-equivalents, so nothing beeps.
    element (rung 1 or a verified rung 2) rather than the bare `AXWebArea`
    #28 measured without it - either is an acceptable outcome, but the
    difference is worth noting since it's unmeasured until this step runs.
+   This is also the step #10 is actually asking for: real testing across a
+   spread of apps (Electron, terminals, Java/Swing) rather than the
+   automated coverage above, which exercises the decision logic against
+   fakes but can't confirm what a real app actually does with a paste or a
+   synthesised keystroke.
 
 If step 2/3 don't fire the OS prompts, or step 5 never prints/injects,
 check the terminal for `[whisper-server]`-, `[hotkey-helper]`- and

--- a/native/accessibility-helper/Package.swift
+++ b/native/accessibility-helper/Package.swift
@@ -5,9 +5,19 @@ let package = Package(
     name: "accessibility-helper",
     platforms: [.macOS(.v11)],
     targets: [
+        .target(
+            name: "AccessibilityInjection",
+            path: "Sources/AccessibilityInjection"
+        ),
         .executableTarget(
             name: "accessibility-helper",
+            dependencies: ["AccessibilityInjection"],
             path: "Sources/accessibility-helper"
+        ),
+        .testTarget(
+            name: "AccessibilityInjectionTests",
+            dependencies: ["AccessibilityInjection"],
+            path: "Tests/AccessibilityInjectionTests"
         )
     ]
 )

--- a/native/accessibility-helper/Sources/AccessibilityInjection/Config.swift
+++ b/native/accessibility-helper/Sources/AccessibilityInjection/Config.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+// The thresholds #62 left as placeholders, pending real measurement in #74.
+// stableForBlindPasteMs is deliberately 2x settleMs: settleMs asks "has the
+// target stopped moving", stableForBlindPasteMs asks "have we watched it
+// stand still long enough to believe the user is looking at it" - see #62.
+public struct Config {
+    public var settleMs: Double
+    public var settleBudgetMs: Double
+    public var axDeadlineMs: Double
+    public var restoreMs: Double
+    public var axValueMaxChars: Int
+    public var longTextChars: Int
+    public var stableForBlindPasteMs: Double?
+
+    public init(
+        settleMs: Double = 400,
+        settleBudgetMs: Double = 1200,
+        axDeadlineMs: Double = 150,
+        restoreMs: Double = 300,
+        axValueMaxChars: Int = 2000,
+        longTextChars: Int = 120,
+        stableForBlindPasteMs: Double? = 800
+    ) {
+        self.settleMs = settleMs
+        self.settleBudgetMs = settleBudgetMs
+        self.axDeadlineMs = axDeadlineMs
+        self.restoreMs = restoreMs
+        self.axValueMaxChars = axValueMaxChars
+        self.longTextChars = longTextChars
+        self.stableForBlindPasteMs = stableForBlindPasteMs
+    }
+}

--- a/native/accessibility-helper/Sources/AccessibilityInjection/FieldInfo.swift
+++ b/native/accessibility-helper/Sources/AccessibilityInjection/FieldInfo.swift
@@ -1,0 +1,11 @@
+public struct FieldInfo {
+    public var role: String
+    public var valueChars: Int?      // nil when the value attribute isn't readable
+    public var selectedTextSettable: Bool
+
+    public init(role: String, valueChars: Int?, selectedTextSettable: Bool) {
+        self.role = role
+        self.valueChars = valueChars
+        self.selectedTextSettable = selectedTextSettable
+    }
+}

--- a/native/accessibility-helper/Sources/AccessibilityInjection/InjectionEngine.swift
+++ b/native/accessibility-helper/Sources/AccessibilityInjection/InjectionEngine.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+// The decision procedure itself, ported from InjectionModel in
+// prototypes/injection-62/index.html onto real AX/CGEvent calls (see #6),
+// then pulled behind the protocols in Protocols.swift so it can be tested
+// without a live AX tree (#10). `sleep` and `now` are injected rather than
+// called directly - "time is an input", the same principle the #62
+// prototype used to make the settle guard reproducible.
+public final class InjectionEngine {
+    private let config: Config
+    private let focusResolver: FocusResolving
+    private let paster: ClipboardPasting
+    private let typer: KeyTyping
+    private let tracker: AppSwitchTracking
+    private let sleep: (TimeInterval) -> Void
+    private let now: () -> Date
+    private let log: (String) -> Void
+
+    public init(
+        config: Config,
+        focusResolver: FocusResolving,
+        paster: ClipboardPasting,
+        typer: KeyTyping,
+        tracker: AppSwitchTracking,
+        sleep: @escaping (TimeInterval) -> Void = { Thread.sleep(forTimeInterval: $0) },
+        now: @escaping () -> Date = Date.init,
+        log: @escaping (String) -> Void = { _ in }
+    ) {
+        self.config = config
+        self.focusResolver = focusResolver
+        self.paster = paster
+        self.typer = typer
+        self.tracker = tracker
+        self.sleep = sleep
+        self.now = now
+        self.log = log
+    }
+
+    public func decide(text: String) -> InjectionOutcome {
+        // Settle guard: never trust a target while the last app switch is
+        // more recent than settleMs. Poll rather than trust a single
+        // reading, since the tracker updates asynchronously in production.
+        let deadline = now().addingTimeInterval(config.settleBudgetMs / 1000.0)
+        while tracker.ageMs() < config.settleMs {
+            if now() >= deadline {
+                return .held(reason: "the front app kept changing, so we never trusted a target")
+            }
+            sleep(0.02)
+        }
+
+        guard let focused = focusResolver.resolveFocusedElement(deadlineMs: config.axDeadlineMs) else {
+            // Rung 0 didn't answer, or nothing is frontmost at all. The
+            // narrow exception settled on #62: a known app that has sat
+            // still well past the settle guard is a much smaller unknown
+            // than "which app" - the user is demonstrably looking at it,
+            // so a blind paste there is a bounded, undoable mistake rather
+            // than a shot in the dark. We have no app name at all when
+            // nothing is frontmost, so that case always falls through to
+            // hold below.
+            if let gate = config.stableForBlindPasteMs, tracker.ageMs() >= gate,
+               let appName = tracker.currentFrontmostName() {
+                let result = paster.paste(text: text, verifyAgainst: nil)
+                return .delivered(method: "pasted into \(appName), field unknown", verified: false, note: result.note)
+            }
+            return .held(reason: "the frontmost app never said what was focused, and hasn't been stable long enough to paste blind")
+        }
+
+        let info = focused.fieldInfo
+        let readableAndFieldSized = info.valueChars.map { $0 <= config.axValueMaxChars } ?? false
+
+        // Rung 1: write straight into the field.
+        if info.selectedTextSettable && readableAndFieldSized {
+            if focused.writeAtCaret(text) {
+                return .delivered(method: "wrote into the field", verified: true, note: "inserted at the caret, clipboard untouched")
+            }
+            log("kAXSelectedTextAttribute reported settable but the write failed, falling back to paste")
+        } else if info.selectedTextSettable, let chars = info.valueChars, chars > config.axValueMaxChars {
+            log("refusing to write into \(info.role) - \(chars) characters of existing content looks like scrollback, not a field")
+        }
+
+        // Rung 2: clipboard + paste.
+        let pasteResult = paster.paste(text: text, verifyAgainst: readableAndFieldSized ? focused : nil)
+        if pasteResult.delivered {
+            return .delivered(method: "pasted", verified: pasteResult.verified, note: pasteResult.note)
+        }
+
+        // The app rejected a paste we could actually verify. One atomic
+        // paste into a field we could read is a bounded, undoable mistake;
+        // typing blind into a field we never confirmed is not - see #62 -
+        // so rung 3 only fires here, where we have positive evidence rung 2
+        // failed, never for the fields we could not verify in the first
+        // place.
+        typer.type(text)
+        let long = text.count > config.longTextChars
+        return .delivered(
+            method: "typed character by character",
+            verified: false,
+            note: long ? "\(text.count) characters typed blind - autocomplete or a vim mode can mangle it" : "nothing confirmed it arrived"
+        )
+    }
+}

--- a/native/accessibility-helper/Sources/AccessibilityInjection/InjectionOutcome.swift
+++ b/native/accessibility-helper/Sources/AccessibilityInjection/InjectionOutcome.swift
@@ -1,0 +1,17 @@
+// What decideAndInject reports back over the IPC protocol - see #6's
+// contract (stdout carries protocol only). Typed here so tests can assert
+// on it directly; main.swift converts it to the reply's JSON fields at the
+// process boundary.
+public enum InjectionOutcome: Equatable {
+    case delivered(method: String, verified: Bool, note: String)
+    case held(reason: String)
+
+    public var replyFields: [String: Any] {
+        switch self {
+        case .delivered(let method, let verified, let note):
+            return ["status": "delivered", "method": method, "verified": verified, "note": note]
+        case .held(let reason):
+            return ["status": "held", "reason": reason]
+        }
+    }
+}

--- a/native/accessibility-helper/Sources/AccessibilityInjection/Protocols.swift
+++ b/native/accessibility-helper/Sources/AccessibilityInjection/Protocols.swift
@@ -1,0 +1,45 @@
+// Everything InjectionEngine needs from the outside world, abstracted away
+// from the real AX/CGEvent/NSPasteboard calls so the decision logic in
+// InjectionEngine.swift can be driven by fakes in tests - the real
+// implementations, in RealAdapters.swift, are the only place that talks to
+// macOS directly.
+
+public protocol AccessibilityTarget {
+    var fieldInfo: FieldInfo { get }
+    func writeAtCaret(_ text: String) -> Bool
+    func readValue() -> String?
+}
+
+public protocol FocusResolving {
+    func resolveFocusedElement(deadlineMs: Double) -> AccessibilityTarget?
+}
+
+public struct PasteResult {
+    public var delivered: Bool
+    public var verified: Bool
+    public var note: String
+
+    public init(delivered: Bool, verified: Bool, note: String) {
+        self.delivered = delivered
+        self.verified = verified
+        self.note = note
+    }
+}
+
+public protocol ClipboardPasting {
+    // verifyAgainst, when non-nil, is a field the caller can read back from
+    // afterwards - readable and small enough not to be a terminal's
+    // scrollback (see #62's scrollback trigger). This is the only real
+    // signal an implementation has for "did the app actually accept the
+    // paste".
+    func paste(text: String, verifyAgainst: AccessibilityTarget?) -> PasteResult
+}
+
+public protocol KeyTyping {
+    func type(_ text: String)
+}
+
+public protocol AppSwitchTracking {
+    func ageMs() -> Double
+    func currentFrontmostName() -> String?
+}

--- a/native/accessibility-helper/Sources/AccessibilityInjection/RealAdapters.swift
+++ b/native/accessibility-helper/Sources/AccessibilityInjection/RealAdapters.swift
@@ -1,0 +1,216 @@
+import ApplicationServices
+import AppKit
+import Foundation
+
+// The only file in this library that talks to macOS directly. Everything in
+// InjectionEngine.swift goes through the protocols these types conform to.
+
+public final class RealAXTarget: AccessibilityTarget {
+    let element: AXUIElement
+
+    public init(_ element: AXUIElement) {
+        self.element = element
+    }
+
+    public var fieldInfo: FieldInfo {
+        var roleRef: CFTypeRef?
+        AXUIElementCopyAttributeValue(element, kAXRoleAttribute as CFString, &roleRef)
+        let role = (roleRef as? String) ?? "unknown"
+
+        var valueRef: CFTypeRef?
+        let valueErr = AXUIElementCopyAttributeValue(element, kAXValueAttribute as CFString, &valueRef)
+        let valueChars = (valueErr == .success) ? (valueRef as? String)?.count : nil
+
+        var settable: DarwinBoolean = false
+        AXUIElementIsAttributeSettable(element, kAXSelectedTextAttribute as CFString, &settable)
+
+        return FieldInfo(role: role, valueChars: valueChars, selectedTextSettable: settable.boolValue)
+    }
+
+    // Rung 1: replace the current selection (a caret is a zero-length
+    // selection) with the transcript. Atomic, instant, no clipboard - this
+    // is the AX primitive for "insert at the cursor", distinct from
+    // kAXValueAttribute, which would overwrite the field's entire contents.
+    public func writeAtCaret(_ text: String) -> Bool {
+        AXUIElementSetAttributeValue(element, kAXSelectedTextAttribute as CFString, text as CFTypeRef) == .success
+    }
+
+    public func readValue() -> String? {
+        var valueRef: CFTypeRef?
+        let err = AXUIElementCopyAttributeValue(element, kAXValueAttribute as CFString, &valueRef)
+        guard err == .success else { return nil }
+        return valueRef as? String
+    }
+}
+
+// Tracks when the frontmost app last changed, so delivery can be gated on it
+// rather than trusting a possibly-stale pid - see #62's settle guard, and
+// #113 for why NSWorkspace.shared.frontmostApplication can't be read
+// directly here: it's notification-driven internally and goes stale on a
+// thread that never pumps a run loop, which is exactly what the thread
+// handling IPC is, parked in readLine() and the AX calls this file makes.
+// Caching the value here, updated only from startObserving()'s thread,
+// keeps reads of it live instead of frozen at whatever was frontmost the
+// last time that thread got a turn.
+public final class RealAppSwitchTracker: AppSwitchTracking {
+    private let lock = NSLock()
+    private var switchedAt = Date()
+    private var frontmost: NSRunningApplication?
+
+    public init() {
+        frontmost = NSWorkspace.shared.frontmostApplication
+    }
+
+    // Must be called from the thread whose run loop will pump the
+    // notification - see the note above. That thread should then call
+    // RunLoop.current.run() to keep receiving them.
+    public func startObserving() {
+        NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didActivateApplicationNotification,
+            object: nil,
+            queue: nil
+        ) { [weak self] note in
+            let app = note.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication
+            self?.recordSwitch(to: app)
+        }
+    }
+
+    private func recordSwitch(to app: NSRunningApplication?) {
+        lock.lock()
+        switchedAt = Date()
+        frontmost = app
+        lock.unlock()
+    }
+
+    public func ageMs() -> Double {
+        lock.lock()
+        defer { lock.unlock() }
+        return Date().timeIntervalSince(switchedAt) * 1000
+    }
+
+    public func currentFrontmostName() -> String? {
+        currentFrontmostApp()?.localizedName
+    }
+
+    // Not part of AppSwitchTracking - RealFocusResolver needs the actual
+    // NSRunningApplication (for its pid), not just its name.
+    public func currentFrontmostApp() -> NSRunningApplication? {
+        lock.lock()
+        defer { lock.unlock() }
+        return frontmost
+    }
+}
+
+public final class RealFocusResolver: FocusResolving {
+    private let tracker: RealAppSwitchTracker
+
+    public init(tracker: RealAppSwitchTracker) {
+        self.tracker = tracker
+    }
+
+    // Resolves the focused element once per dictation. #12 folded this into
+    // the same helper #6 creates rather than a separate process or command,
+    // specifically so this resolution and inject() never race each other
+    // over focus - and so it only ever happens once: everything downstream
+    // (InjectionEngine's fallback chain) reuses this same target rather
+    // than re-asking.
+    public func resolveFocusedElement(deadlineMs: Double) -> AccessibilityTarget? {
+        guard let frontApp = tracker.currentFrontmostApp() else { return nil }
+
+        let appElement = AXUIElementCreateApplication(frontApp.processIdentifier)
+        AXUIElementSetMessagingTimeout(appElement, Float(deadlineMs / 1000.0))
+        enableManualAccessibility(appElement)
+
+        var focusedRef: CFTypeRef?
+        let focusErr = AXUIElementCopyAttributeValue(appElement, kAXFocusedUIElementAttribute as CFString, &focusedRef)
+        guard focusErr == .success, let focusedRef = focusedRef else { return nil }
+
+        return RealAXTarget(focusedRef as! AXUIElement) // swiftlint:disable:this force_cast
+    }
+
+    // Chromium's own AX tree is normally built lazily, only once Chromium
+    // detects a running assistive technology by its own heuristics - which
+    // a direct AXUIElementCopyAttributeValue call never trips. Setting this
+    // attribute forces the tree to build regardless. #28 found Electron
+    // apps (VS Code, Slack, Discord) exposing nothing but a bare AXWebArea
+    // without it. Unconditional and ignored on failure: on an app that
+    // doesn't recognise the attribute (i.e. anything not Chromium-based),
+    // the set just fails harmlessly - see #12.
+    private func enableManualAccessibility(_ appElement: AXUIElement) {
+        AXUIElementSetAttributeValue(appElement, "AXManualAccessibility" as CFString, kCFBooleanTrue)
+    }
+}
+
+public final class RealClipboardPaster: ClipboardPasting {
+    private let restoreMs: Double
+    private let log: (String) -> Void
+
+    public init(restoreMs: Double, log: @escaping (String) -> Void = { _ in }) {
+        self.restoreMs = restoreMs
+        self.log = log
+    }
+
+    // Rung 2: borrow the clipboard, synthesise Cmd+V, then give it back.
+    // The restore is guarded against the race the #62 prototype flagged: if
+    // the user copies something else while our text is still sitting in
+    // the clipboard, changeCount will have moved past what we set, and we
+    // leave their copy alone rather than clobbering it.
+    public func paste(text: String, verifyAgainst: AccessibilityTarget?) -> PasteResult {
+        let pasteboard = NSPasteboard.general
+        let saved = pasteboard.string(forType: .string)
+
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
+        let ourChangeCount = pasteboard.changeCount
+
+        synthesizeCmdV()
+        Thread.sleep(forTimeInterval: restoreMs / 1000.0)
+
+        if pasteboard.changeCount == ourChangeCount {
+            pasteboard.clearContents()
+            if let saved = saved { pasteboard.setString(saved, forType: .string) }
+        } else {
+            log("skipped the clipboard restore - the user copied something else while it was borrowed")
+        }
+
+        guard let target = verifyAgainst else {
+            return PasteResult(delivered: true, verified: false, note: "sent, but nothing confirmed it landed")
+        }
+
+        guard let after = target.readValue(), after.contains(text) else {
+            return PasteResult(delivered: false, verified: false, note: "the app did not accept the paste")
+        }
+        return PasteResult(delivered: true, verified: true, note: "read back and confirmed")
+    }
+
+    private func synthesizeCmdV() {
+        let source = CGEventSource(stateID: .hidSystemState)
+        let vKeyCode: CGKeyCode = 9 // 'V' on the ANSI layout
+        let keyDown = CGEvent(keyboardEventSource: source, virtualKey: vKeyCode, keyDown: true)
+        let keyUp = CGEvent(keyboardEventSource: source, virtualKey: vKeyCode, keyDown: false)
+        keyDown?.flags = .maskCommand
+        keyUp?.flags = .maskCommand
+        keyDown?.post(tap: .cghidEventTap)
+        keyUp?.post(tap: .cghidEventTap)
+    }
+}
+
+// Rung 3: type it character by character. Works wherever a keyboard works,
+// including surfaces with no usable AX tree, but it is slow and can drop or
+// reorder characters on long text - see #62.
+public final class RealKeyTyper: KeyTyping {
+    public init() {}
+
+    public func type(_ text: String) {
+        let source = CGEventSource(stateID: .hidSystemState)
+        for scalar in text.unicodeScalars {
+            var chars = [UniChar(scalar.value)]
+            let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: true)
+            let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: false)
+            keyDown?.keyboardSetUnicodeString(stringLength: 1, unicodeString: &chars)
+            keyUp?.keyboardSetUnicodeString(stringLength: 1, unicodeString: &chars)
+            keyDown?.post(tap: .cghidEventTap)
+            keyUp?.post(tap: .cghidEventTap)
+        }
+    }
+}

--- a/native/accessibility-helper/Sources/accessibility-helper/main.swift
+++ b/native/accessibility-helper/Sources/accessibility-helper/main.swift
@@ -1,3 +1,4 @@
+import AccessibilityInjection
 import ApplicationServices
 import AppKit
 import Foundation
@@ -5,74 +6,6 @@ import Foundation
 func eprint(_ message: String) {
     FileHandle.standardError.write((message + "\n").data(using: .utf8)!)
 }
-
-// The thresholds #62 left as placeholders, pending real measurement in #74.
-// stableForBlindPasteMs is deliberately 2x settleMs: settleMs asks "has the
-// target stopped moving", stableForBlindPasteMs asks "have we watched it
-// stand still long enough to believe the user is looking at it" - see #62.
-struct Config {
-    var settleMs: Double = 400
-    var settleBudgetMs: Double = 1200
-    var axDeadlineMs: Double = 150
-    var restoreMs: Double = 300
-    var axValueMaxChars = 2000
-    var longTextChars = 120
-    var stableForBlindPasteMs: Double? = 800
-}
-let config = Config()
-
-// Tracks when the frontmost app last changed, so delivery can be gated on it
-// rather than trusting a possibly-stale pid - see #62's settle guard. Runs on
-// its own thread with its own run loop: NSWorkspace notifications need a
-// pumping run loop to arrive, and the main thread spends its time blocked in
-// readLine() and in the AX calls below.
-final class AppSwitchTracker {
-    private let lock = NSLock()
-    private var switchedAt = Date()
-    // NSWorkspace.frontmostApplication is notification-driven internally and
-    // goes stale on a thread that never pumps a run loop - which is exactly
-    // what the main thread is, parked in readLine() and the AX calls below.
-    // Caching the value here, updated only from the run-loop-pumping thread
-    // below, is what keeps reads of it live instead of frozen at whatever
-    // was frontmost the last time this thread got a turn.
-    private var frontmost: NSRunningApplication?
-
-    init() {
-        frontmost = NSWorkspace.shared.frontmostApplication
-    }
-
-    func recordSwitch(to app: NSRunningApplication?) {
-        lock.lock()
-        switchedAt = Date()
-        frontmost = app
-        lock.unlock()
-    }
-
-    func ageMs(now: Date = Date()) -> Double {
-        lock.lock()
-        defer { lock.unlock() }
-        return now.timeIntervalSince(switchedAt) * 1000
-    }
-
-    func currentFrontmost() -> NSRunningApplication? {
-        lock.lock()
-        defer { lock.unlock() }
-        return frontmost
-    }
-}
-let tracker = AppSwitchTracker()
-
-Thread {
-    NSWorkspace.shared.notificationCenter.addObserver(
-        forName: NSWorkspace.didActivateApplicationNotification,
-        object: nil,
-        queue: nil
-    ) { note in
-        let app = note.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication
-        tracker.recordSwitch(to: app)
-    }
-    RunLoop.current.run()
-}.start()
 
 // stdout carries protocol only - every line here must be one JSON object.
 func emit(_ dict: [String: Any]) {
@@ -93,218 +26,27 @@ if !AXIsProcessTrusted() {
     _ = AXIsProcessTrustedWithOptions(options)
 }
 
+let tracker = RealAppSwitchTracker()
+
+// NSWorkspace notifications need a pumping run loop to arrive, and the main
+// thread spends its time blocked in readLine() and the AX calls the engine
+// makes - see RealAppSwitchTracker's doc comment.
+Thread {
+    tracker.startObserving()
+    RunLoop.current.run()
+}.start()
+
+let config = Config()
+let engine = InjectionEngine(
+    config: config,
+    focusResolver: RealFocusResolver(tracker: tracker),
+    paster: RealClipboardPaster(restoreMs: config.restoreMs, log: eprint),
+    typer: RealKeyTyper(),
+    tracker: tracker,
+    log: eprint
+)
+
 emit(["event": "ready"])
-
-// ---------------------------------------------------------------------------
-// The fallback chain settled in #62: write at the caret, then clipboard +
-// paste, then synthesised keystrokes - each rung's trigger is something this
-// helper can actually detect, never assumed.
-// ---------------------------------------------------------------------------
-
-struct FieldInfo {
-    var role: String
-    var valueChars: Int?      // nil when the value attribute isn't readable
-    var selectedTextSettable: Bool
-}
-
-func fieldInfo(_ element: AXUIElement) -> FieldInfo {
-    var roleRef: CFTypeRef?
-    AXUIElementCopyAttributeValue(element, kAXRoleAttribute as CFString, &roleRef)
-    let role = (roleRef as? String) ?? "unknown"
-
-    var valueRef: CFTypeRef?
-    let valueErr = AXUIElementCopyAttributeValue(element, kAXValueAttribute as CFString, &valueRef)
-    let valueChars = (valueErr == .success) ? (valueRef as? String)?.count : nil
-
-    var settable: DarwinBoolean = false
-    AXUIElementIsAttributeSettable(element, kAXSelectedTextAttribute as CFString, &settable)
-
-    return FieldInfo(role: role, valueChars: valueChars, selectedTextSettable: settable.boolValue)
-}
-
-// Rung 1: replace the current selection (a caret is a zero-length selection)
-// with the transcript. Atomic, instant, no clipboard - this is the AX
-// primitive for "insert at the cursor", distinct from kAXValueAttribute,
-// which would overwrite the field's entire contents.
-func writeAtCaret(_ element: AXUIElement, text: String) -> Bool {
-    AXUIElementSetAttributeValue(element, kAXSelectedTextAttribute as CFString, text as CFTypeRef) == .success
-}
-
-func synthesizeCmdV() {
-    let source = CGEventSource(stateID: .hidSystemState)
-    let vKeyCode: CGKeyCode = 9 // 'V' on the ANSI layout
-    let keyDown = CGEvent(keyboardEventSource: source, virtualKey: vKeyCode, keyDown: true)
-    let keyUp = CGEvent(keyboardEventSource: source, virtualKey: vKeyCode, keyDown: false)
-    keyDown?.flags = .maskCommand
-    keyUp?.flags = .maskCommand
-    keyDown?.post(tap: .cghidEventTap)
-    keyUp?.post(tap: .cghidEventTap)
-}
-
-// Rung 2: borrow the clipboard, synthesise Cmd+V, then give it back. The
-// restore is guarded against the race the #62 prototype flagged: if the
-// user copies something else while our text is still sitting in the
-// clipboard, changeCount will have moved past what we set, and we leave
-// their copy alone rather than clobbering it.
-//
-// verifyAgainst, when non-nil, is a field we can read back from - readable
-// and small enough not to be a terminal's scrollback (see #62's scrollback
-// trigger). Reading it after the paste is the only real signal this helper
-// has for "did the app actually accept the paste", so it is also the only
-// case where a rejected paste falls through to rung 3 rather than being
-// reported delivered-but-unverified.
-func pasteViaClipboard(text: String, verifyAgainst: AXUIElement?, valueBefore: String?) -> (delivered: Bool, verified: Bool, note: String) {
-    let pasteboard = NSPasteboard.general
-    let saved = pasteboard.string(forType: .string)
-
-    pasteboard.clearContents()
-    pasteboard.setString(text, forType: .string)
-    let ourChangeCount = pasteboard.changeCount
-
-    synthesizeCmdV()
-    Thread.sleep(forTimeInterval: config.restoreMs / 1000.0)
-
-    if pasteboard.changeCount == ourChangeCount {
-        pasteboard.clearContents()
-        if let saved = saved { pasteboard.setString(saved, forType: .string) }
-    } else {
-        eprint("accessibility-helper: skipped the clipboard restore - the user copied something else while it was borrowed")
-    }
-
-    guard let element = verifyAgainst else {
-        return (true, false, "sent, but nothing confirmed it landed")
-    }
-
-    var valueRef: CFTypeRef?
-    let err = AXUIElementCopyAttributeValue(element, kAXValueAttribute as CFString, &valueRef)
-    guard err == .success, let after = valueRef as? String, after.contains(text) else {
-        return (false, false, "the app did not accept the paste")
-    }
-    _ = valueBefore
-    return (true, true, "read back and confirmed")
-}
-
-// Rung 3: type it character by character. Works wherever a keyboard works,
-// including surfaces with no usable AX tree, but it is slow and can drop or
-// reorder characters on long text - see #62.
-func typeCharacters(_ text: String) {
-    let source = CGEventSource(stateID: .hidSystemState)
-    for scalar in text.unicodeScalars {
-        var chars = [UniChar(scalar.value)]
-        let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: true)
-        let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: false)
-        keyDown?.keyboardSetUnicodeString(stringLength: 1, unicodeString: &chars)
-        keyUp?.keyboardSetUnicodeString(stringLength: 1, unicodeString: &chars)
-        keyDown?.post(tap: .cghidEventTap)
-        keyUp?.post(tap: .cghidEventTap)
-    }
-}
-
-func held(reason: String) -> [String: Any] {
-    ["status": "held", "reason": reason]
-}
-
-func delivered(method: String, verified: Bool, note: String) -> [String: Any] {
-    ["status": "delivered", "method": method, "verified": verified, "note": note]
-}
-
-// Chromium's own AX tree is normally built lazily, only once Chromium
-// detects a running assistive technology by its own heuristics - which our
-// direct AXUIElementCopyAttributeValue calls never trip. Setting this
-// attribute forces the tree to build regardless. #28 found Electron apps
-// (VS Code, Slack, Discord) exposing nothing but a bare AXWebArea without
-// it. Unconditional and ignored on failure: on an app that doesn't
-// recognise the attribute (i.e. anything not Chromium-based), the set just
-// fails harmlessly - see #12.
-func enableManualAccessibility(_ appElement: AXUIElement) {
-    AXUIElementSetAttributeValue(appElement, "AXManualAccessibility" as CFString, kCFBooleanTrue)
-}
-
-// Resolves the focused element once per dictation. #12 folded this into the
-// same helper #6 creates rather than a separate process or command,
-// specifically so this resolution and inject() never race each other over
-// focus - and so it only ever happens once: everything downstream (the
-// fallback chain below) reuses this same element rather than re-asking.
-func resolveFocusedElement(deadlineMs: Double) -> AXUIElement? {
-    guard let frontApp = tracker.currentFrontmost() else { return nil }
-
-    let appElement = AXUIElementCreateApplication(frontApp.processIdentifier)
-    AXUIElementSetMessagingTimeout(appElement, Float(deadlineMs / 1000.0))
-    enableManualAccessibility(appElement)
-
-    var focusedRef: CFTypeRef?
-    let focusErr = AXUIElementCopyAttributeValue(appElement, kAXFocusedUIElementAttribute as CFString, &focusedRef)
-    guard focusErr == .success, let focusedRef = focusedRef else { return nil }
-
-    return (focusedRef as! AXUIElement) // swiftlint:disable:this force_cast
-}
-
-// The decision procedure itself, ported from InjectionModel in
-// prototypes/injection-62/index.html onto real AX/CGEvent calls.
-func decideAndInject(text: String) -> [String: Any] {
-    // Settle guard: never trust a target while the last app switch is more
-    // recent than settleMs. Poll rather than trust a single reading, since
-    // the tracker updates asynchronously on its own thread.
-    let deadline = Date().addingTimeInterval(config.settleBudgetMs / 1000.0)
-    while tracker.ageMs() < config.settleMs {
-        if Date() >= deadline {
-            return held(reason: "the front app kept changing, so we never trusted a target")
-        }
-        Thread.sleep(forTimeInterval: 0.02)
-    }
-
-    guard let focused = resolveFocusedElement(deadlineMs: config.axDeadlineMs) else {
-        // Rung 0 didn't answer, or nothing is frontmost at all. The narrow
-        // exception settled on #62: a known app that has sat still well
-        // past the settle guard is a much smaller unknown than "which
-        // app" - the user is demonstrably looking at it, so a blind paste
-        // there is a bounded, undoable mistake rather than a shot in the
-        // dark. We have no app name at all when nothing is frontmost, so
-        // that case always falls through to hold below.
-        if let gate = config.stableForBlindPasteMs, tracker.ageMs() >= gate,
-           let appName = tracker.currentFrontmost()?.localizedName {
-            let (_, _, note) = pasteViaClipboard(text: text, verifyAgainst: nil, valueBefore: nil)
-            return delivered(method: "pasted into \(appName), field unknown", verified: false, note: note)
-        }
-        return held(reason: "the frontmost app never said what was focused, and hasn't been stable long enough to paste blind")
-    }
-
-    let info = fieldInfo(focused)
-    let readableAndFieldSized = info.valueChars.map { $0 <= config.axValueMaxChars } ?? false
-
-    // Rung 1: write straight into the field.
-    if info.selectedTextSettable && readableAndFieldSized {
-        if writeAtCaret(focused, text: text) {
-            return delivered(method: "wrote into the field", verified: true, note: "inserted at the caret, clipboard untouched")
-        }
-        eprint("accessibility-helper: kAXSelectedTextAttribute reported settable but the write failed, falling back to paste")
-    } else if info.selectedTextSettable, let chars = info.valueChars, chars > config.axValueMaxChars {
-        eprint("accessibility-helper: refusing to write into \(info.role) - \(chars) characters of existing content looks like scrollback, not a field")
-    }
-
-    // Rung 2: clipboard + paste.
-    let (pasteDelivered, verified, note) = pasteViaClipboard(
-        text: text,
-        verifyAgainst: readableAndFieldSized ? focused : nil,
-        valueBefore: nil
-    )
-    if pasteDelivered {
-        return delivered(method: "pasted", verified: verified, note: note)
-    }
-
-    // The app rejected a paste we could actually verify. One atomic paste
-    // into a field we could read is a bounded, undoable mistake; typing
-    // blind into a field we never confirmed is not - see #62 - so rung 3
-    // only fires here, where we have positive evidence rung 2 failed, never
-    // for the fields we could not verify in the first place.
-    typeCharacters(text)
-    let long = text.count > config.longTextChars
-    return delivered(
-        method: "typed character by character",
-        verified: false,
-        note: long ? "\(text.count) characters typed blind - autocomplete or a vim mode can mangle it" : "nothing confirmed it arrived"
-    )
-}
 
 // Command loop: one newline-delimited JSON object per line on stdin, one
 // reply per line on stdout, tagged with the same id so a slow request never
@@ -325,7 +67,7 @@ while let line = readLine(strippingNewline: true) {
             emit(["id": id, "status": "error", "reason": "inject requires non-empty \"text\""])
             continue
         }
-        var reply = decideAndInject(text: text)
+        var reply = engine.decide(text: text).replyFields
         reply["id"] = id
         emit(reply)
     default:

--- a/native/accessibility-helper/Tests/AccessibilityInjectionTests/Fakes.swift
+++ b/native/accessibility-helper/Tests/AccessibilityInjectionTests/Fakes.swift
@@ -1,0 +1,95 @@
+import Foundation
+import AccessibilityInjection
+
+// Drives InjectionEngine's injected `sleep`/`now` deterministically: every
+// simulated sleep advances a counter instead of blocking, so a test that
+// exercises the settle guard's polling loop runs in microseconds rather
+// than the real 400-1200ms. Same "time is an input" principle the #62
+// prototype used.
+final class SimulatedTime {
+    private(set) var elapsedMs: Double = 0
+
+    func sleep(_ seconds: TimeInterval) {
+        elapsedMs += seconds * 1000
+    }
+
+    func now() -> Date {
+        Date(timeIntervalSince1970: elapsedMs / 1000)
+    }
+}
+
+final class FakeAccessibilityTarget: AccessibilityTarget {
+    var fieldInfo: FieldInfo
+    var writeSucceeds: Bool
+    var valueToReadBack: String?
+    private(set) var writtenText: String?
+
+    init(fieldInfo: FieldInfo, writeSucceeds: Bool = true, valueToReadBack: String? = nil) {
+        self.fieldInfo = fieldInfo
+        self.writeSucceeds = writeSucceeds
+        self.valueToReadBack = valueToReadBack
+    }
+
+    func writeAtCaret(_ text: String) -> Bool {
+        writtenText = text
+        return writeSucceeds
+    }
+
+    func readValue() -> String? {
+        valueToReadBack
+    }
+}
+
+final class FakeFocusResolver: FocusResolving {
+    var target: AccessibilityTarget?
+
+    init(target: AccessibilityTarget?) {
+        self.target = target
+    }
+
+    func resolveFocusedElement(deadlineMs _: Double) -> AccessibilityTarget? {
+        target
+    }
+}
+
+final class FakePaster: ClipboardPasting {
+    var result: PasteResult
+    private(set) var callCount = 0
+    private(set) var lastVerifyAgainst: AccessibilityTarget?
+
+    init(result: PasteResult) {
+        self.result = result
+    }
+
+    func paste(text _: String, verifyAgainst: AccessibilityTarget?) -> PasteResult {
+        callCount += 1
+        lastVerifyAgainst = verifyAgainst
+        return result
+    }
+}
+
+final class FakeTyper: KeyTyping {
+    private(set) var typedText: String?
+
+    func type(_ text: String) {
+        typedText = text
+    }
+}
+
+final class FakeTracker: AppSwitchTracking {
+    var ageProvider: () -> Double
+    var appName: String?
+
+    init(age: @escaping () -> Double, appName: String?) {
+        self.ageProvider = age
+        self.appName = appName
+    }
+
+    func ageMs() -> Double {
+        ageProvider()
+    }
+
+    func currentFrontmostName() -> String? {
+        appName
+    }
+}

--- a/native/accessibility-helper/Tests/AccessibilityInjectionTests/InjectionEngineTests.swift
+++ b/native/accessibility-helper/Tests/AccessibilityInjectionTests/InjectionEngineTests.swift
@@ -1,0 +1,243 @@
+import Testing
+import AccessibilityInjection
+
+// Regression coverage for the fallback chain settled in #62 and ported to
+// real AX calls in #6 - see #10, which asked for injection to be hardened
+// against real cross-app failures. This suite can't replace testing
+// against real apps (that still needs a human - see
+// docs/testing/hotkey-transcribe-manual-check.md), but every branch here
+// previously had zero automated coverage.
+struct InjectionEngineTests {
+    let config = Config()
+
+    func makeEngine(
+        focusTarget: AccessibilityTarget?,
+        pasteResult: PasteResult = PasteResult(delivered: true, verified: false, note: ""),
+        trackerAge: @escaping () -> Double = { 10_000 },
+        appName: String? = "TestApp"
+    ) -> (engine: InjectionEngine, time: SimulatedTime, paster: FakePaster, typer: FakeTyper) {
+        let time = SimulatedTime()
+        let paster = FakePaster(result: pasteResult)
+        let typer = FakeTyper()
+        let tracker = FakeTracker(age: trackerAge, appName: appName)
+        let engine = InjectionEngine(
+            config: config,
+            focusResolver: FakeFocusResolver(target: focusTarget),
+            paster: paster,
+            typer: typer,
+            tracker: tracker,
+            sleep: time.sleep,
+            now: time.now,
+            log: { _ in }
+        )
+        return (engine, time, paster, typer)
+    }
+
+    // MARK: - Rung 1: write at the caret
+
+    @Test func rung1WritesAtCaretWhenFieldIsSettableAndSmall() {
+        let target = FakeAccessibilityTarget(
+            fieldInfo: FieldInfo(role: "AXTextField", valueChars: 10, selectedTextSettable: true)
+        )
+        let (engine, _, paster, _) = makeEngine(focusTarget: target)
+
+        let outcome = engine.decide(text: "hello")
+
+        #expect(outcome == .delivered(method: "wrote into the field", verified: true, note: "inserted at the caret, clipboard untouched"))
+        #expect(target.writtenText == "hello")
+        #expect(paster.callCount == 0, "rung 1 succeeded, rung 2 should never fire")
+    }
+
+    @Test func rung1RefusesAScrollbackSizedField() {
+        // A terminal: settable in principle, but #28 measured 5,673-15,646
+        // characters of scrollback as its "value" - rung 1 must refuse.
+        let target = FakeAccessibilityTarget(
+            fieldInfo: FieldInfo(role: "AXTextArea", valueChars: 9412, selectedTextSettable: true)
+        )
+        let (engine, _, paster, _) = makeEngine(
+            focusTarget: target,
+            pasteResult: PasteResult(delivered: true, verified: false, note: "sent, but nothing confirmed it landed")
+        )
+
+        let outcome = engine.decide(text: "hello")
+
+        #expect(outcome == .delivered(method: "pasted", verified: false, note: "sent, but nothing confirmed it landed"))
+        #expect(target.writtenText == nil, "rung 1 must not have attempted to write into scrollback")
+        #expect(paster.callCount == 1)
+        #expect(paster.lastVerifyAgainst == nil, "the value is too large to be a field, so it can't be verified either")
+    }
+
+    @Test func rung1FallsThroughToPasteWhenTheWriteItselfFails() {
+        let target = FakeAccessibilityTarget(
+            fieldInfo: FieldInfo(role: "AXTextField", valueChars: 10, selectedTextSettable: true),
+            writeSucceeds: false
+        )
+        let (engine, _, paster, _) = makeEngine(
+            focusTarget: target,
+            pasteResult: PasteResult(delivered: true, verified: true, note: "read back and confirmed")
+        )
+
+        let outcome = engine.decide(text: "hello")
+
+        #expect(outcome == .delivered(method: "pasted", verified: true, note: "read back and confirmed"))
+        #expect(paster.callCount == 1)
+    }
+
+    // MARK: - Rung 2: clipboard + paste
+
+    @Test func rung2IsUnverifiedForAnUnreadableField() {
+        // AXWebArea/AXGroup: not settable, value unreadable - exactly what
+        // #28 measured for Electron apps without AXManualAccessibility.
+        let target = FakeAccessibilityTarget(
+            fieldInfo: FieldInfo(role: "AXWebArea", valueChars: nil, selectedTextSettable: false)
+        )
+        let (engine, _, paster, _) = makeEngine(
+            focusTarget: target,
+            pasteResult: PasteResult(delivered: true, verified: false, note: "sent, but nothing confirmed it landed")
+        )
+
+        let outcome = engine.decide(text: "hello")
+
+        #expect(outcome == .delivered(method: "pasted", verified: false, note: "sent, but nothing confirmed it landed"))
+        #expect(paster.lastVerifyAgainst == nil, "an unreadable field can never be verified")
+    }
+
+    // MARK: - Rung 3: synthesised keystrokes
+
+    @Test func rung3FiresOnlyWhenRung2WasVerifiableAndDemonstrablyFailed() {
+        let target = FakeAccessibilityTarget(
+            fieldInfo: FieldInfo(role: "AXTextField", valueChars: 10, selectedTextSettable: false)
+        )
+        let (engine, _, _, typer) = makeEngine(
+            focusTarget: target,
+            pasteResult: PasteResult(delivered: false, verified: false, note: "the app did not accept the paste")
+        )
+
+        let outcome = engine.decide(text: "hello")
+
+        guard case .delivered(let method, let verified, _) = outcome else {
+            Issue.record("expected delivered, got \(outcome)")
+            return
+        }
+        #expect(method == "typed character by character")
+        #expect(!verified)
+        #expect(typer.typedText == "hello")
+    }
+
+    @Test func rung3NeverFiresForAPasteThatCouldNotBeVerifiedInTheFirstPlace() {
+        // A paste into a field we could never read back has no positive
+        // evidence it failed. #62/#10: don't guess-retry with keystrokes
+        // into an unidentified field - a vim mode or autocomplete can turn
+        // that into arbitrary input.
+        let target = FakeAccessibilityTarget(
+            fieldInfo: FieldInfo(role: "AXWebArea", valueChars: nil, selectedTextSettable: false)
+        )
+        let (engine, _, _, typer) = makeEngine(
+            focusTarget: target,
+            pasteResult: PasteResult(delivered: true, verified: false, note: "sent, but nothing confirmed it landed")
+        )
+
+        _ = engine.decide(text: "hello")
+
+        #expect(typer.typedText == nil)
+    }
+
+    @Test func longTextTypedBlindGetsAWarningNote() {
+        let target = FakeAccessibilityTarget(
+            fieldInfo: FieldInfo(role: "AXTextField", valueChars: 10, selectedTextSettable: false)
+        )
+        let (engine, _, _, _) = makeEngine(
+            focusTarget: target,
+            pasteResult: PasteResult(delivered: false, verified: false, note: "the app did not accept the paste")
+        )
+        let longText = String(repeating: "a", count: config.longTextChars + 1)
+
+        let outcome = engine.decide(text: longText)
+
+        guard case .delivered(_, _, let note) = outcome else {
+            Issue.record("expected delivered, got \(outcome)")
+            return
+        }
+        #expect(note.contains("typed blind"), "note was: \(note)")
+    }
+
+    // MARK: - Rung 0 / 1b: focus never resolved
+
+    @Test func holdsWhenNothingIsFocusedAndTheAppNeverAnswered() {
+        let (engine, _, paster, _) = makeEngine(focusTarget: nil, appName: nil)
+
+        let outcome = engine.decide(text: "hello")
+
+        #expect(outcome == .held(reason: "the frontmost app never said what was focused, and hasn't been stable long enough to paste blind"))
+        #expect(paster.callCount == 0)
+    }
+
+    @Test func pastesBlindIntoAKnownAppThatHasBeenStableLongEnough() {
+        let (engine, _, paster, _) = makeEngine(
+            focusTarget: nil,
+            pasteResult: PasteResult(delivered: true, verified: false, note: "sent, but nothing confirmed it landed"),
+            trackerAge: { 10_000 }, // well past stableForBlindPasteMs (800ms default)
+            appName: "SomeHungApp"
+        )
+
+        let outcome = engine.decide(text: "hello")
+
+        #expect(outcome == .delivered(method: "pasted into SomeHungApp, field unknown", verified: false, note: "sent, but nothing confirmed it landed"))
+        #expect(paster.callCount == 1)
+        #expect(paster.lastVerifyAgainst == nil, "a blind paste never has a target to verify against")
+    }
+
+    @Test func holdsInsteadOfBlindPasteWhenNotStableLongEnough() {
+        // Past the settle guard (400ms default) so rung 0 is reached at
+        // all, but short of stableForBlindPasteMs (800ms default).
+        let (engine, _, paster, _) = makeEngine(focusTarget: nil, trackerAge: { 500 }, appName: "SomeApp")
+
+        let outcome = engine.decide(text: "hello")
+
+        #expect(outcome == .held(reason: "the frontmost app never said what was focused, and hasn't been stable long enough to paste blind"))
+        #expect(paster.callCount == 0)
+    }
+
+    // MARK: - Settle guard
+
+    @Test func settleGuardHoldsWhenTheFrontAppNeverStabilizes() {
+        // Age is pinned at 50ms forever - simulates the app switching
+        // again on every check, so the settle guard (400ms) never passes
+        // and the settle budget (1200ms of simulated waiting) runs out.
+        let (engine, time, paster, _) = makeEngine(focusTarget: nil, trackerAge: { 50 })
+
+        let outcome = engine.decide(text: "hello")
+
+        #expect(outcome == .held(reason: "the front app kept changing, so we never trusted a target"))
+        #expect(paster.callCount == 0)
+        #expect(time.elapsedMs >= config.settleBudgetMs)
+    }
+
+    @Test func settleGuardPassesOnceTheTargetStabilizes() {
+        let time = SimulatedTime()
+        let target = FakeAccessibilityTarget(
+            fieldInfo: FieldInfo(role: "AXTextField", valueChars: 5, selectedTextSettable: true)
+        )
+        let paster = FakePaster(result: PasteResult(delivered: true, verified: false, note: ""))
+        let typer = FakeTyper()
+        // Age grows with simulated time from 0, so it crosses settleMs
+        // (400ms default) after real polling, not immediately.
+        let tracker = FakeTracker(age: { time.elapsedMs }, appName: "TestApp")
+        let engine = InjectionEngine(
+            config: config,
+            focusResolver: FakeFocusResolver(target: target),
+            paster: paster,
+            typer: typer,
+            tracker: tracker,
+            sleep: time.sleep,
+            now: time.now,
+            log: { _ in }
+        )
+
+        let outcome = engine.decide(text: "hello")
+
+        #expect(outcome == .delivered(method: "wrote into the field", verified: true, note: "inserted at the caret, clipboard untouched"))
+        #expect(time.elapsedMs >= config.settleMs)
+        #expect(time.elapsedMs < config.settleBudgetMs, "should have settled well before the budget ran out")
+    }
+}


### PR DESCRIPTION
Partial progress on #10.

#10 asks for text injection to be hardened across app types, with "real testing across a spread of apps" as the actual ask - that part still needs a human (see below). What this PR does is close a different gap that's been sitting under #10 since #6: the fallback chain's decision logic has had **zero automated coverage**. It's only ever been verified by running the compiled binary and eyeballing stderr, because the code called `AXUIElement`/`CGEvent`/`NSPasteboard` APIs directly with no seam for a test to intercept.

## What this changes

Restructures `native/accessibility-helper` into a library (`AccessibilityInjection`) plus the existing thin executable:

- **`InjectionEngine`** - the exact fallback-chain logic from #6/#12 (write at the caret → clipboard+paste → synthesised keystrokes, settle guard, blind-paste gate), now driven entirely through protocols (`AccessibilityTarget`, `FocusResolving`, `ClipboardPasting`, `KeyTyping`, `AppSwitchTracking`) instead of calling macOS APIs inline. `sleep`/`now` are injected too - "time is an input," the same principle the #62 prototype used to make its settle guard reproducible.
- **`RealAdapters.swift`** - the real macOS-backed implementations. Byte-for-byte the same AX/CGEvent/NSPasteboard/NSWorkspace calls that used to live in `main.swift`, just moved and organised behind the protocols.
- **`main.swift`** - now a thin executable: permission check, the NSWorkspace-observer thread, wiring the real adapters into `InjectionEngine`, and the IPC loop. No behavioural change.
- **12 tests** (`Tests/AccessibilityInjectionTests/`) against `InjectionEngine` using fakes for every dependency, covering what previously had no automated coverage at all - see the commit messages for the full list, but the one worth calling out: rung 3 (synthesised keystrokes) now provably only fires when rung 2 was verifiable *and* demonstrably failed, never for a paste this helper could never read back. That was a real gap between the #62 prototype (which had an oracle - `world.acceptsPaste` - that real code doesn't have) and what #79 actually shipped; it was documented in that PR's commit message but never had a test proving it held.

## What's verified vs. what still needs a human

**Verified headlessly:**
- `swift build -c release` still compiles cleanly, and the production build script (`scripts/build-accessibility-helper.sh`) is unaffected.
- All 12 new tests pass. Verified locally via `swiftpm-testing-helper` directly, since this session's sandbox has Command Line Tools only (no Xcode.app) and `swift test`'s wrapper doesn't inherit `Testing.framework`'s runtime search path here - a real Xcode install, including GitHub's `macos-latest` CI runner, doesn't have this quirk and `swift test --package-path native/accessibility-helper` should just work there.
- `npm run build` (`tsc` + `vite build`) passes.
- `node --test "electron/**/*.test.js"`: 36/37 pass. The one failure (`rewrite model server starts and answers a chat completion over HTTP`) is a Metal-backend context-allocation failure in this sandbox, unrelated to this change - this branch never touches `electron/`, `package.json`, or anything llama-related.
- `vitest run` couldn't run in this sandbox at all: `node_modules/rolldown/...` imports `styleText` from `node:util`, which needs Node ≥20.12/21.7 and this sandbox has v21.6.1. Also unrelated to this change - this branch never touches `package.json`/`package-lock.json`, so this dependency and its Node requirement already exist on `main`.

**Still needs a human, and is the actual remaining scope of #10:** real testing against a spread of real apps (Electron editors, terminals, Java/Swing) to see what they actually do with a paste or a synthesised keystroke - something fakes can't tell you. `docs/testing/hotkey-transcribe-manual-check.md`, updated in this PR, calls this out as step 8's real purpose.

One live side effect worth flagging: an early manual sanity-check run of the real compiled binary (before I switched to testing purely against fakes) actually injected text into whatever field was focused on the developer's screen at the time, since Accessibility happened to be granted for that binary path. Not a defect in this PR - it's rung 1 working exactly as designed - but worth knowing if you're wondering why "hello world" showed up somewhere unexpected.

## Test plan
- [x] `swift build -c release` (headless)
- [x] 12/12 new `InjectionEngine` tests pass (headless, verified via `swiftpm-testing-helper`)
- [x] `npm run build` (headless)
- [x] `node --test "electron/**/*.test.js"`: 36/37, one pre-existing unrelated failure (headless)
- [ ] Real cross-app testing (Electron, terminal, Java/Swing) - the actual remaining scope of #10, needs a human
