### PR TITLE
feat: anchor the push-to-talk overlay at the bottom of the screen (#116)

### DIFF
--- a/docs/testing/hotkey-transcribe-manual-check.md
+++ b/docs/testing/hotkey-transcribe-manual-check.md
@@ -38,6 +38,12 @@ treated as menu key-equivalents, so nothing beeps.
   gate against fakes - `swift test --package-path native/accessibility-helper`
   (needs a full Xcode install; Command Line Tools alone are missing
   `Testing.framework`'s runtime search path).
+- Since #116, the overlay's bottom-centering math
+  (`computeBottomCenteredPosition` in `electron/overlayPosition.js`) has 4
+  tests covering centering, the bottom margin, an offset work area (a
+  secondary display), and a custom margin - `node --test
+  electron/overlayPosition.test.js`. The actual on-screen placement still
+  needs a human; the math can't confirm it clears the real Dock.
 - All new/changed files pass `node --check`.
 
 ## Needs a human, one time
@@ -63,6 +69,11 @@ treated as menu key-equivalents, so nothing beeps.
    holding the keys) to confirm the tap is global and doesn't need the
    app focused. The text should land in whichever app is frontmost when
    you release, not the one that was frontmost when you pressed.
+7a. While holding the key, check the overlay itself (#116): it should sit
+   bottom-center of the screen, clear of the Dock, like macOS's own
+   dictation HUD - not centered on the screen or wherever it used to land.
+   On a multi-monitor setup, move the cursor to a second display before
+   pressing the key and confirm the overlay follows it there.
 8. Try a terminal window and an Electron-based editor (e.g. VS Code, Slack)
    as the target - these are exactly the cases #62 designed the fallback
    chain around. A terminal's prompt should receive a clipboard paste, not

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,5 +1,6 @@
-const { app, Tray, Menu, BrowserWindow, ipcMain, nativeImage } = require("electron");
+const { app, Tray, Menu, BrowserWindow, ipcMain, nativeImage, screen } = require("electron");
 const path = require("path");
+const { computeBottomCenteredPosition } = require("./overlayPosition");
 const whisperServer = require("./whisperServer");
 const rewriteModelServer = require("./rewriteModelServer");
 const hotkeyHelper = require("./hotkeyHelper");
@@ -143,13 +144,27 @@ function setTrayState(state) {
   tray.setToolTip(state === "idle" ? "OpenStream" : `OpenStream — ${state}`);
 }
 
+// Positioned fresh on every show, not once at creation, so it follows
+// whichever display the user is actually on - #116, same spot macOS's own
+// dictation HUD uses: bottom-center, clear of the Dock.
+function positionOverlayAtBottom() {
+  const display = screen.getDisplayNearestPoint(screen.getCursorScreenPoint());
+  const [width, height] = overlayWin.getSize();
+  const { x, y } = computeBottomCenteredPosition(display.workArea, width, height);
+  overlayWin.setPosition(x, y);
+}
+
 function setUserVisibleState(state) {
   setTrayState(state);
   if (!overlayWin || overlayWin.isDestroyed()) return;
 
   overlayWin.webContents.send("dictation-state", state);
-  if (state === "recording") overlayWin.showInactive();
-  else overlayWin.hide();
+  if (state === "recording") {
+    positionOverlayAtBottom();
+    overlayWin.showInactive();
+  } else {
+    overlayWin.hide();
+  }
 }
 
 function createTray() {

--- a/electron/overlayPosition.js
+++ b/electron/overlayPosition.js
@@ -1,0 +1,14 @@
+// Pure arithmetic, kept separate from main.js so it's testable without a
+// running Electron instance. macOS's own dictation HUD anchors bottom-
+// center, clear of the Dock - this computes the same spot for our overlay,
+// given the target display's work area (which already excludes the Dock
+// and menu bar) and the overlay window's size. See #116.
+const BOTTOM_MARGIN_PX = 32;
+
+function computeBottomCenteredPosition(workArea, windowWidth, windowHeight, marginPx = BOTTOM_MARGIN_PX) {
+  const x = Math.round(workArea.x + (workArea.width - windowWidth) / 2);
+  const y = Math.round(workArea.y + workArea.height - windowHeight - marginPx);
+  return { x, y };
+}
+
+module.exports = { computeBottomCenteredPosition, BOTTOM_MARGIN_PX };

--- a/electron/overlayPosition.test.js
+++ b/electron/overlayPosition.test.js
@@ -1,0 +1,30 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { computeBottomCenteredPosition, BOTTOM_MARGIN_PX } = require("./overlayPosition");
+
+test("centers horizontally within the work area", () => {
+  const workArea = { x: 0, y: 0, width: 1440, height: 900 };
+  const { x } = computeBottomCenteredPosition(workArea, 180, 52);
+  assert.equal(x, (1440 - 180) / 2);
+});
+
+test("sits just above the bottom edge of the work area, clear of the Dock", () => {
+  const workArea = { x: 0, y: 0, width: 1440, height: 900 };
+  const { y } = computeBottomCenteredPosition(workArea, 180, 52);
+  assert.equal(y, 900 - 52 - BOTTOM_MARGIN_PX);
+});
+
+test("accounts for a work area offset from the display origin", () => {
+  // A secondary display sitting to the right of the primary, or a menu bar
+  // display whose work area doesn't start at (0, 0).
+  const workArea = { x: 1440, y: 25, width: 1920, height: 1055 };
+  const position = computeBottomCenteredPosition(workArea, 180, 52);
+  assert.equal(position.x, 1440 + (1920 - 180) / 2);
+  assert.equal(position.y, 25 + 1055 - 52 - BOTTOM_MARGIN_PX);
+});
+
+test("a custom margin overrides the default", () => {
+  const workArea = { x: 0, y: 0, width: 1440, height: 900 };
+  const { y } = computeBottomCenteredPosition(workArea, 180, 52, 0);
+  assert.equal(y, 900 - 52);
+});


### PR DESCRIPTION
Closes #116.

The push-to-talk overlay (`electron/overlay/`) was created with no explicit `x`/`y` in `createOverlayWindow`, so it lands wherever Electron's platform default puts a new borderless window - not a deliberate position. macOS's own dictation HUD anchors bottom-center, clear of the Dock; this makes the overlay do the same.

## What this changes

- `electron/overlayPosition.js` - `computeBottomCenteredPosition(workArea, windowWidth, windowHeight, marginPx)`, a small pure function kept separate from `main.js` so it's testable without a running Electron instance. Given a display's work area (already excludes the Dock and menu bar - `Electron.screen`'s own contract) and the overlay's size, it returns where to put it.
- `electron/main.js` - a new `positionOverlayAtBottom()` calls into that, using `screen.getDisplayNearestPoint(screen.getCursorScreenPoint())` so the overlay follows whichever display the user is actually on, not always the primary one. Called fresh every time the overlay is about to show (in `setUserVisibleState`), not once at window creation, so it stays correct across display changes between dictations.
- 4 tests: centering, the bottom margin, an offset work area (a secondary display doesn't start at `(0, 0)`), and a custom margin override.

## What's verified vs. what needs a human

**Verified headlessly:**
- 4/4 new tests pass (`node --test electron/overlayPosition.test.js`).
- `node --test "electron/**/*.test.js"`: 40/41 pass - the one failure (`rewrite model server...`) is the same pre-existing, unrelated Metal-backend sandbox issue seen on #115, not touched by this branch.
- `npm run build` (`tsc` + `vite build`) passes.
- `node --check` on all new/changed files.

**Needs a human, one time:** confirming the overlay actually sits bottom-center clear of the real Dock (the math is tested, but only a real screen and Dock can confirm nothing overlaps), and that it follows the cursor's display on a multi-monitor setup. Step 7a in `docs/testing/hotkey-transcribe-manual-check.md`, added in this PR.

## Test plan
- [x] 4/4 new positioning tests pass (headless)
- [x] `node --test "electron/**/*.test.js"`: 40/41, one pre-existing unrelated failure (headless)
- [x] `npm run build` (headless)
- [ ] Overlay visually sits bottom-center, clear of the Dock, and follows the cursor's display (needs a human running `npm start`)
