### PR TITLE
feat: hotkey remapping settings screen (#19)

### DIFF
--- a/docs/testing/settings-hotkey-remap-manual-check.md
+++ b/docs/testing/settings-hotkey-remap-manual-check.md
@@ -1,0 +1,59 @@
+# Manual check: settings window, hotkey remapping (#19)
+
+What CI/a headless session can verify, and what still needs a human running
+the actual app: opening a real settings window, capturing a real keydown
+gesture, and confirming the native helper actually restarts with a new
+combo aren't things a sandboxed session can drive.
+
+## Already verified without a GUI
+
+- `settingsStore.js`: persists to and reads back from a JSON file, rejects
+  a hotkey with no modifiers or an unknown modifier, and leaves the
+  previously-saved hotkey untouched on a rejected write - 9 tests.
+- `keycodeMap.ts`: DOM `KeyboardEvent.code` → macOS virtual keycode
+  translation, and the reverse (`formatHotkey`) - 9 tests.
+- `captureHotkey.ts`: the pure decision behind hotkey capture - accepts a
+  mapped key held with at least one modifier, rejects an unmapped key or a
+  bare key with none - 5 tests.
+- `hotkeyHelper.js`: spawns with a configurable hotkey's args (not just the
+  old hardcoded default), and `setHotkey()` restarts a running helper with
+  new args without a stale exit event from the *old* process causing a
+  spurious extra restart - 5 new tests alongside the 2 pre-existing ones.
+- `tsc --noEmit` and `vite build` both succeed with the settings screen
+  wired in.
+- The full `vitest` suite (32 tests) and `node --test "electron/**/*.test.js"`
+  both pass.
+
+None of this drives the actual React component (`HotkeySettings.tsx`) or
+the real IPC round trip through a running Electron process - those are
+exactly what needs a human.
+
+## Needs a human, one time
+
+1. `npm start`, then click the tray icon → **Open Window**.
+2. The window should show **OpenStream Settings** with the current
+   hotkey - `⌃⌥D` on a fresh install (Control+Option+D, matching the
+   existing default).
+3. Click **Change hotkey**, then press a new combo - e.g. `⌘⇧Space`. The
+   button should read "Press a key combo…" while waiting, then show the
+   new combo once captured.
+4. Press just a letter with no modifier held. This should show an inline
+   error ("hold at least one modifier key...") and stay in recording mode
+   rather than silently closing or accepting it.
+5. Press an unmapped key (an arrow key, a function key). Same as step 4 -
+   an inline error naming the key, still recording.
+6. After a successful remap (step 3), hold the **new** combo and confirm
+   push-to-talk still works - the terminal running `npm start` should log
+   `[dictation] recording...` same as before. The *old* hotkey
+   (`Control+Option+D`, or whatever it was before) should no longer do
+   anything.
+7. Quit and relaunch the app (`npm start` again). The new hotkey should
+   still be the one that works, and the settings window should still show
+   it - confirms the write actually persisted to
+   `~/Library/Application Support/openstream/settings.json` (or wherever
+   `app.getPath("userData")` resolves in dev) rather than only living in
+   memory for that session.
+
+If step 6 doesn't work after a successful-looking remap in step 3, check
+the terminal for `[hotkey-helper]` lines - a restart failure would show up
+there the same way a normal crash-restart does.

--- a/electron/hotkeyHelper.js
+++ b/electron/hotkeyHelper.js
@@ -5,8 +5,9 @@ const { resourcesRoot } = require("./paths");
 
 const BIN_PATH = path.join(resourcesRoot(), "bin", "hotkey-helper");
 
-// Keycode 2 is 'D' on the ANSI layout. The helper only knows keycodes, not
-// accelerator strings, so the mapping lives here.
+// Keycode 2 is 'D' on the ANSI layout - matches settingsStore.js's
+// DEFAULT_SETTINGS, so a fresh install with no settings file behaves
+// exactly as it always has.
 //
 // Control+Option, not Cmd+Shift: this tap is listen-only (see main.swift),
 // so the keystroke still reaches whatever app is focused. A Cmd-combo that
@@ -14,11 +15,16 @@ const BIN_PATH = path.join(resourcesRoot(), "bin", "hotkey-helper");
 // then gets captured at the start of the recording and Whisper hallucinates
 // as "[Music]". Control+Option isn't treated as a menu key-equivalent, so
 // nothing beeps.
-const ARGS = ["--keycode", "2", "--modifiers", "ctrl,alt"];
+const DEFAULT_HOTKEY = { keyCode: 2, modifiers: ["ctrl", "alt"] };
 
 const RESTART_DELAY_MS = 1000;
 
-function createHotkeyHelper({ spawnProcess = spawn, restartDelayMs = RESTART_DELAY_MS } = {}) {
+function argsForHotkey(hotkey) {
+  return ["--keycode", String(hotkey.keyCode), "--modifiers", hotkey.modifiers.join(",")];
+}
+
+function createHotkeyHelper({ spawnProcess = spawn, restartDelayMs = RESTART_DELAY_MS, hotkey = DEFAULT_HOTKEY } = {}) {
+  let currentHotkey = hotkey;
   let child = null;
   let stopping = false;
   let onDown = () => {};
@@ -39,12 +45,18 @@ function createHotkeyHelper({ spawnProcess = spawn, restartDelayMs = RESTART_DEL
 
   function start() {
     stopping = false;
-    child = spawnProcess(BIN_PATH, ARGS);
+    const proc = spawnProcess(BIN_PATH, argsForHotkey(currentHotkey));
+    child = proc;
 
-    readline.createInterface({ input: child.stdout }).on("line", handleLine);
-    child.stderr.on("data", (data) => process.stderr.write(`[hotkey-helper] ${data}`));
+    readline.createInterface({ input: proc.stdout }).on("line", handleLine);
+    proc.stderr.on("data", (data) => process.stderr.write(`[hotkey-helper] ${data}`));
 
-    child.on("exit", (code) => {
+    proc.on("exit", (code) => {
+      // setHotkey() replaces `child` with a new process before this old
+      // one's exit event arrives - without this check, that old event
+      // would null out the reference to the new child and schedule a
+      // spurious second restart on top of it.
+      if (child !== proc) return;
       child = null;
       if (stopping) return;
       console.error(`[hotkey-helper] exited unexpectedly (code ${code}), restarting in ${restartDelayMs}ms`);
@@ -57,9 +69,18 @@ function createHotkeyHelper({ spawnProcess = spawn, restartDelayMs = RESTART_DEL
     if (child) child.kill();
   }
 
+  function setHotkey(newHotkey) {
+    currentHotkey = newHotkey;
+    if (child) {
+      stop();
+      start();
+    }
+  }
+
   return {
     start,
     stop,
+    setHotkey,
     onKeyDown(callback) {
       onDown = callback;
     },
@@ -72,4 +93,5 @@ function createHotkeyHelper({ spawnProcess = spawn, restartDelayMs = RESTART_DEL
 module.exports = {
   ...createHotkeyHelper(),
   createHotkeyHelper,
+  DEFAULT_HOTKEY,
 };

--- a/electron/hotkeyHelper.test.js
+++ b/electron/hotkeyHelper.test.js
@@ -2,7 +2,7 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 const { EventEmitter } = require("node:events");
 const { PassThrough } = require("node:stream");
-const { createHotkeyHelper } = require("./hotkeyHelper");
+const { createHotkeyHelper, DEFAULT_HOTKEY } = require("./hotkeyHelper");
 
 function fakeProcess() {
   const process = new EventEmitter();
@@ -44,5 +44,103 @@ test("hotkey helper ignores non-contract output", async () => {
 
   await new Promise((resolve) => setImmediate(resolve));
   assert.deepEqual(events, []);
+  helper.stop();
+});
+
+test("spawns with the configured hotkey's args, defaulting to DEFAULT_HOTKEY", () => {
+  const spawned = [];
+  const helper = createHotkeyHelper({
+    spawnProcess: (bin, args) => {
+      spawned.push({ bin, args });
+      return fakeProcess();
+    },
+  });
+
+  helper.start();
+
+  assert.equal(spawned.length, 1);
+  assert.deepEqual(spawned[0].args, ["--keycode", String(DEFAULT_HOTKEY.keyCode), "--modifiers", DEFAULT_HOTKEY.modifiers.join(",")]);
+  helper.stop();
+});
+
+test("starts with a custom hotkey when one is passed to the factory", () => {
+  const spawned = [];
+  const helper = createHotkeyHelper({
+    hotkey: { keyCode: 49, modifiers: ["cmd", "shift"] },
+    spawnProcess: (bin, args) => {
+      spawned.push(args);
+      return fakeProcess();
+    },
+  });
+
+  helper.start();
+
+  assert.deepEqual(spawned[0], ["--keycode", "49", "--modifiers", "cmd,shift"]);
+  helper.stop();
+});
+
+test("setHotkey restarts a running helper with the new args", () => {
+  const spawned = [];
+  const children = [];
+  const helper = createHotkeyHelper({
+    spawnProcess: (bin, args) => {
+      spawned.push(args);
+      const child = fakeProcess();
+      children.push(child);
+      return child;
+    },
+  });
+
+  helper.start();
+  assert.equal(spawned.length, 1);
+
+  helper.setHotkey({ keyCode: 49, modifiers: ["cmd", "shift"] });
+
+  assert.equal(spawned.length, 2);
+  assert.deepEqual(spawned[1], ["--keycode", "49", "--modifiers", "cmd,shift"]);
+  helper.stop();
+});
+
+test("setHotkey before start() just changes what the next start() uses", () => {
+  const spawned = [];
+  const helper = createHotkeyHelper({
+    spawnProcess: (bin, args) => {
+      spawned.push(args);
+      return fakeProcess();
+    },
+  });
+
+  helper.setHotkey({ keyCode: 49, modifiers: ["cmd"] });
+  assert.equal(spawned.length, 0, "not running yet, so no restart should happen");
+
+  helper.start();
+  assert.deepEqual(spawned[0], ["--keycode", "49", "--modifiers", "cmd"]);
+  helper.stop();
+});
+
+test("the superseded process's own exit event does not trigger a second restart", async () => {
+  const spawned = [];
+  const children = [];
+  const helper = createHotkeyHelper({
+    restartDelayMs: 1,
+    spawnProcess: (bin, args) => {
+      spawned.push(args);
+      const child = fakeProcess();
+      children.push(child);
+      return child;
+    },
+  });
+
+  helper.start();
+  helper.setHotkey({ keyCode: 49, modifiers: ["cmd"] });
+  assert.equal(spawned.length, 2);
+
+  // The old process (children[0]) exits some time after setHotkey already
+  // replaced it - this must not be treated as an unexpected crash of the
+  // (still running) new process.
+  children[0].emit("exit", 0);
+  await new Promise((resolve) => setTimeout(resolve, 20));
+
+  assert.equal(spawned.length, 2, "a stale exit from the superseded process must not spawn a third helper");
   helper.stop();
 });

--- a/electron/main.js
+++ b/electron/main.js
@@ -5,6 +5,7 @@ const whisperServer = require("./whisperServer");
 const rewriteModelServer = require("./rewriteModelServer");
 const hotkeyHelper = require("./hotkeyHelper");
 const accessibilityHelper = require("./accessibilityHelper");
+const { createSettingsStore } = require("./settingsStore");
 const { createTranscriptionHttpAdapter } = require("./transcriptionHttpAdapter");
 const { runCompletedDictation } = require("./dictationCoordinator");
 const { createPushToTalkCoordinator } = require("./pushToTalkCoordinator");
@@ -24,6 +25,7 @@ let trayState = "idle";
 let captureWin = null;
 let overlayWin = null;
 let hotkeyStarted = false;
+let settingsStore = null;
 const transcription = createTranscriptionHttpAdapter({ inferenceUrl: whisperServer.inferenceUrl });
 
 function createWindow() {
@@ -221,10 +223,25 @@ ipcMain.on("recording-error", (event, message) => {
   setUserVisibleState("idle");
 });
 
+ipcMain.handle("settings:get", () => settingsStore.get());
+
+ipcMain.handle("settings:set-hotkey", (event, hotkey) => {
+  // setHotkey validates and throws on a malformed hotkey - ipcMain.handle
+  // turns that into a rejected promise on the renderer side automatically,
+  // and the previously-saved hotkey is left untouched (see
+  // settingsStore.js), so a bad renderer-side capture can't leave the app
+  // with no working hotkey.
+  const settings = settingsStore.setHotkey(hotkey);
+  hotkeyHelper.setHotkey(settings.hotkey);
+  return settings;
+});
+
 app.whenReady().then(() => {
   if (process.platform === "darwin") {
     app.dock.hide();
   }
+  settingsStore = createSettingsStore({ filePath: path.join(app.getPath("userData"), "settings.json") });
+  hotkeyHelper.setHotkey(settingsStore.get().hotkey);
   createTray();
   hotkeyHelper.onKeyDown(pushToTalkCoordinator.keyDown);
   hotkeyHelper.onKeyUp(pushToTalkCoordinator.keyUp);

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -1,2 +1,12 @@
-// No IPC surface yet. This is where the renderer will eventually talk to the
-// hotkey helper, the accessibility helper, and the transcription model server.
+const { contextBridge, ipcRenderer } = require("electron");
+
+// The renderer's only route to the main process, per contextIsolation - see
+// the settings window's webPreferences in main.js. First surface: settings
+// (#19). This will grow to cover the hotkey helper, the accessibility
+// helper, and the transcription model server as those get their own UI.
+contextBridge.exposeInMainWorld("openstream", {
+  settings: {
+    get: () => ipcRenderer.invoke("settings:get"),
+    setHotkey: (hotkey) => ipcRenderer.invoke("settings:set-hotkey", hotkey),
+  },
+});

--- a/electron/settingsStore.js
+++ b/electron/settingsStore.js
@@ -1,0 +1,73 @@
+const fs = require("fs");
+const path = require("path");
+
+// Matches hotkeyHelper.js's own default (Control+Option+D, see #84) so a
+// fresh install with no settings file behaves exactly like it did before
+// this existed.
+const DEFAULT_SETTINGS = {
+  hotkey: { keyCode: 2, modifiers: ["ctrl", "alt"] },
+};
+
+const VALID_MODIFIERS = new Set(["cmd", "shift", "alt", "ctrl"]);
+
+function validateHotkey(hotkey) {
+  if (!hotkey || typeof hotkey.keyCode !== "number" || !Number.isInteger(hotkey.keyCode) || hotkey.keyCode < 0) {
+    throw new Error("hotkey.keyCode must be a non-negative integer");
+  }
+  if (!Array.isArray(hotkey.modifiers) || hotkey.modifiers.length === 0) {
+    // A hotkey with no modifiers would fire on every ordinary keystroke of
+    // that key - the native helper only ever taps global combos deliberately.
+    throw new Error("hotkey.modifiers must be a non-empty array");
+  }
+  for (const modifier of hotkey.modifiers) {
+    if (!VALID_MODIFIERS.has(modifier)) {
+      throw new Error(`unknown modifier "${modifier}"`);
+    }
+  }
+}
+
+// filePath is injected rather than derived from app.getPath("userData")
+// here, so this is testable with a plain temp file and doesn't need a real
+// Electron process - the caller (main.js) is where that path gets decided.
+function createSettingsStore({ filePath }) {
+  let cache = null;
+  const listeners = new Set();
+
+  function load() {
+    if (cache) return cache;
+    try {
+      const raw = fs.readFileSync(filePath, "utf8");
+      cache = { ...DEFAULT_SETTINGS, ...JSON.parse(raw) };
+    } catch {
+      cache = { ...DEFAULT_SETTINGS };
+    }
+    return cache;
+  }
+
+  function persist() {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, JSON.stringify(cache, null, 2));
+  }
+
+  function get() {
+    return { ...load() };
+  }
+
+  function setHotkey(hotkey) {
+    validateHotkey(hotkey);
+    cache = { ...load(), hotkey };
+    persist();
+    const settings = get();
+    for (const listener of listeners) listener(settings);
+    return settings;
+  }
+
+  function onChange(listener) {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  }
+
+  return { get, setHotkey, onChange };
+}
+
+module.exports = { createSettingsStore, DEFAULT_SETTINGS };

--- a/electron/settingsStore.test.js
+++ b/electron/settingsStore.test.js
@@ -1,0 +1,75 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { createSettingsStore, DEFAULT_SETTINGS } = require("./settingsStore");
+
+function tempFilePath() {
+  return path.join(fs.mkdtempSync(path.join(os.tmpdir(), "openstream-settings-")), "settings.json");
+}
+
+test("returns defaults when no settings file exists yet", () => {
+  const store = createSettingsStore({ filePath: tempFilePath() });
+  assert.deepEqual(store.get(), DEFAULT_SETTINGS);
+});
+
+test("setHotkey persists to disk and get() reflects it afterwards", () => {
+  const filePath = tempFilePath();
+  const store = createSettingsStore({ filePath });
+
+  store.setHotkey({ keyCode: 49, modifiers: ["cmd", "shift"] });
+  assert.deepEqual(store.get().hotkey, { keyCode: 49, modifiers: ["cmd", "shift"] });
+
+  const onDisk = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  assert.deepEqual(onDisk.hotkey, { keyCode: 49, modifiers: ["cmd", "shift"] });
+});
+
+test("a fresh store reads back what an earlier store wrote", () => {
+  const filePath = tempFilePath();
+  createSettingsStore({ filePath }).setHotkey({ keyCode: 0, modifiers: ["ctrl"] });
+
+  const reopened = createSettingsStore({ filePath });
+  assert.deepEqual(reopened.get().hotkey, { keyCode: 0, modifiers: ["ctrl"] });
+});
+
+test("rejects a hotkey with no modifiers", () => {
+  const store = createSettingsStore({ filePath: tempFilePath() });
+  assert.throws(() => store.setHotkey({ keyCode: 2, modifiers: [] }), /non-empty/);
+});
+
+test("rejects an unknown modifier", () => {
+  const store = createSettingsStore({ filePath: tempFilePath() });
+  assert.throws(() => store.setHotkey({ keyCode: 2, modifiers: ["fn"] }), /unknown modifier/);
+});
+
+test("rejects a non-integer keyCode", () => {
+  const store = createSettingsStore({ filePath: tempFilePath() });
+  assert.throws(() => store.setHotkey({ keyCode: 2.5, modifiers: ["cmd"] }), /keyCode/);
+});
+
+test("an invalid setHotkey call leaves the previous value untouched", () => {
+  const store = createSettingsStore({ filePath: tempFilePath() });
+  store.setHotkey({ keyCode: 2, modifiers: ["ctrl", "alt"] });
+
+  assert.throws(() => store.setHotkey({ keyCode: 2, modifiers: [] }));
+  assert.deepEqual(store.get().hotkey, { keyCode: 2, modifiers: ["ctrl", "alt"] });
+});
+
+test("onChange fires with the new settings after a successful setHotkey", () => {
+  const store = createSettingsStore({ filePath: tempFilePath() });
+  const seen = [];
+  store.onChange((settings) => seen.push(settings));
+
+  store.setHotkey({ keyCode: 3, modifiers: ["cmd"] });
+
+  assert.equal(seen.length, 1);
+  assert.deepEqual(seen[0].hotkey, { keyCode: 3, modifiers: ["cmd"] });
+});
+
+test("a corrupt settings file falls back to defaults instead of throwing", () => {
+  const filePath = tempFilePath();
+  fs.writeFileSync(filePath, "{ not valid json");
+  const store = createSettingsStore({ filePath });
+  assert.deepEqual(store.get(), DEFAULT_SETTINGS);
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,10 @@
+import HotkeySettings from "./HotkeySettings";
+
 export default function App() {
   return (
     <main className="shell">
-      <h1>OpenStream</h1>
-      <p>Nothing to see yet. This window exists to prove the tray → renderer pipeline works.</p>
+      <h1>OpenStream Settings</h1>
+      <HotkeySettings />
     </main>
   );
 }

--- a/src/HotkeySettings.tsx
+++ b/src/HotkeySettings.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react";
+import { captureHotkeyFromEvent, type StoredHotkey } from "./hotkey/captureHotkey";
+import { formatHotkey } from "./hotkey/keycodeMap";
+
+export default function HotkeySettings() {
+  const [hotkey, setHotkey] = useState<StoredHotkey | null>(null);
+  const [recording, setRecording] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    window.openstream.settings.get().then((settings) => setHotkey(settings.hotkey));
+  }, []);
+
+  useEffect(() => {
+    if (!recording) return;
+
+    function onKeyDown(event: KeyboardEvent) {
+      event.preventDefault();
+      const result = captureHotkeyFromEvent(event);
+      if (!result.ok) {
+        setError(result.reason);
+        return;
+      }
+      setError(null);
+      setRecording(false);
+      window.openstream.settings.setHotkey(result.hotkey).then((settings) => setHotkey(settings.hotkey));
+    }
+
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => window.removeEventListener("keydown", onKeyDown, true);
+  }, [recording]);
+
+  return (
+    <section className="setting">
+      <h2>Push-to-talk hotkey</h2>
+      <p className="setting-current">{hotkey ? formatHotkey(hotkey) : "Loading…"}</p>
+      <button
+        onClick={() => {
+          setError(null);
+          setRecording(true);
+        }}
+        disabled={recording}
+      >
+        {recording ? "Press a key combo…" : "Change hotkey"}
+      </button>
+      {error && <p className="setting-error">{error}</p>}
+    </section>
+  );
+}

--- a/src/hotkey/captureHotkey.test.ts
+++ b/src/hotkey/captureHotkey.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { captureHotkeyFromEvent, type CapturedKeyEvent } from "./captureHotkey";
+
+function keyEvent(overrides: Partial<CapturedKeyEvent> & { code: string }): CapturedKeyEvent {
+  return { metaKey: false, shiftKey: false, altKey: false, ctrlKey: false, ...overrides };
+}
+
+describe("captureHotkeyFromEvent", () => {
+  it("accepts a letter held with one modifier", () => {
+    const result = captureHotkeyFromEvent(keyEvent({ code: "KeyD", ctrlKey: true }));
+    expect(result).toEqual({ ok: true, hotkey: { keyCode: 2, modifiers: ["ctrl"] } });
+  });
+
+  it("collects every held modifier, in event-property order", () => {
+    const result = captureHotkeyFromEvent(
+      keyEvent({ code: "KeyD", ctrlKey: true, altKey: true, shiftKey: true, metaKey: true })
+    );
+    expect(result).toEqual({ ok: true, hotkey: { keyCode: 2, modifiers: ["ctrl", "alt", "shift", "cmd"] } });
+  });
+
+  it("rejects a key with no modifier held", () => {
+    const result = captureHotkeyFromEvent(keyEvent({ code: "KeyD" }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/at least one modifier/);
+  });
+
+  it("rejects a key outside the mapped range", () => {
+    const result = captureHotkeyFromEvent(keyEvent({ code: "ArrowUp", ctrlKey: true }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/ArrowUp/);
+  });
+
+  it("accepts a digit with the Command modifier", () => {
+    const result = captureHotkeyFromEvent(keyEvent({ code: "Digit1", metaKey: true }));
+    expect(result).toEqual({ ok: true, hotkey: { keyCode: 18, modifiers: ["cmd"] } });
+  });
+});

--- a/src/hotkey/captureHotkey.ts
+++ b/src/hotkey/captureHotkey.ts
@@ -1,0 +1,41 @@
+import { macKeyCodeForDomCode } from "./keycodeMap";
+
+export type CapturedKeyEvent = {
+  code: string;
+  metaKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+  ctrlKey: boolean;
+};
+
+export type StoredHotkey = { keyCode: number; modifiers: string[] };
+
+export type CaptureResult = { ok: true; hotkey: StoredHotkey } | { ok: false; reason: string };
+
+// Kept separate from the DOM/React capture UI so the decision - which key
+// events are acceptable as a global hotkey, and why one isn't - is testable
+// without a browser. A component wires this to a real keydown listener.
+export function captureHotkeyFromEvent(event: CapturedKeyEvent): CaptureResult {
+  const keyCode = macKeyCodeForDomCode(event.code);
+  if (keyCode === undefined) {
+    return { ok: false, reason: `${event.code} can't be used as a hotkey - pick a letter, digit or punctuation key` };
+  }
+
+  const modifiers: string[] = [];
+  if (event.ctrlKey) modifiers.push("ctrl");
+  if (event.altKey) modifiers.push("alt");
+  if (event.shiftKey) modifiers.push("shift");
+  if (event.metaKey) modifiers.push("cmd");
+
+  if (modifiers.length === 0) {
+    // A bare key would fire the hotkey on every ordinary keystroke of it -
+    // see settingsStore.js's validateHotkey, which enforces the same rule
+    // server-side.
+    return {
+      ok: false,
+      reason: "hold at least one modifier key (Control, Option, Shift or Command) together with the key",
+    };
+  }
+
+  return { ok: true, hotkey: { keyCode, modifiers } };
+}

--- a/src/hotkey/keycodeMap.test.ts
+++ b/src/hotkey/keycodeMap.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { formatHotkey, labelForMacKeyCode, macKeyCodeForDomCode } from "./keycodeMap";
+
+describe("macKeyCodeForDomCode", () => {
+  it("maps a letter key to its macOS virtual keycode", () => {
+    // keycode 2 is 'D' on the ANSI layout - matches hotkeyHelper.js's
+    // default and native/hotkey-helper's own comment about it.
+    expect(macKeyCodeForDomCode("KeyD")).toBe(2);
+  });
+
+  it("maps a digit key", () => {
+    expect(macKeyCodeForDomCode("Digit1")).toBe(18);
+  });
+
+  it("returns undefined for an unmapped key", () => {
+    expect(macKeyCodeForDomCode("ArrowUp")).toBeUndefined();
+    expect(macKeyCodeForDomCode("F1")).toBeUndefined();
+  });
+});
+
+describe("labelForMacKeyCode", () => {
+  it("round-trips a mapped keycode back to its letter", () => {
+    expect(labelForMacKeyCode(2)).toBe("D");
+  });
+
+  it("falls back to a numbered placeholder for an unmapped keycode", () => {
+    expect(labelForMacKeyCode(999)).toBe("#999");
+  });
+});
+
+describe("formatHotkey", () => {
+  it("orders modifiers the way macOS itself does, regardless of input order", () => {
+    expect(formatHotkey({ keyCode: 2, modifiers: ["cmd", "ctrl"] })).toBe("⌃⌘D");
+  });
+
+  it("formats the current default (Control+Option+D)", () => {
+    expect(formatHotkey({ keyCode: 2, modifiers: ["ctrl", "alt"] })).toBe("⌃⌥D");
+  });
+
+  it("formats a single modifier", () => {
+    expect(formatHotkey({ keyCode: 49, modifiers: ["cmd"] })).toBe("⌘Space");
+  });
+});

--- a/src/hotkey/keycodeMap.ts
+++ b/src/hotkey/keycodeMap.ts
@@ -1,0 +1,55 @@
+// macOS virtual keycodes (Carbon Events.h kVK_ANSI_*) for the US ANSI
+// layout, keyed by the DOM KeyboardEvent.code values a renderer can
+// actually observe. Covers letters, digits and the punctuation keys next
+// to them - the plausible range for a dictation hotkey. Arrow, function
+// and other unmapped keys are rejected by captureHotkey.ts rather than
+// guessed at here.
+export const DOM_CODE_TO_MAC_KEYCODE: Record<string, number> = {
+  KeyA: 0, KeyB: 11, KeyC: 8, KeyD: 2, KeyE: 14, KeyF: 3, KeyG: 5, KeyH: 4,
+  KeyI: 34, KeyJ: 38, KeyK: 40, KeyL: 37, KeyM: 46, KeyN: 45, KeyO: 31,
+  KeyP: 35, KeyQ: 12, KeyR: 15, KeyS: 1, KeyT: 17, KeyU: 32, KeyV: 9,
+  KeyW: 13, KeyX: 7, KeyY: 16, KeyZ: 6,
+  Digit0: 29, Digit1: 18, Digit2: 19, Digit3: 20, Digit4: 21, Digit5: 23,
+  Digit6: 22, Digit7: 26, Digit8: 28, Digit9: 25,
+  Minus: 27, Equal: 24, BracketLeft: 33, BracketRight: 30, Backslash: 42,
+  Semicolon: 41, Quote: 39, Comma: 43, Period: 47, Slash: 44, Backquote: 50,
+  Space: 49, Tab: 48,
+};
+
+const SYMBOL_LABELS: Record<string, string> = {
+  Minus: "-", Equal: "=", BracketLeft: "[", BracketRight: "]", Backslash: "\\",
+  Semicolon: ";", Quote: "'", Comma: ",", Period: ".", Slash: "/", Backquote: "`",
+  Space: "Space", Tab: "Tab",
+};
+
+function labelForDomCode(code: string): string {
+  if (code.startsWith("Key")) return code.slice(3);
+  if (code.startsWith("Digit")) return code.slice(5);
+  return SYMBOL_LABELS[code] ?? code;
+}
+
+const MAC_KEYCODE_TO_LABEL: Record<number, string> = Object.fromEntries(
+  Object.entries(DOM_CODE_TO_MAC_KEYCODE).map(([code, keyCode]) => [keyCode, labelForDomCode(code)])
+);
+
+export function macKeyCodeForDomCode(code: string): number | undefined {
+  return DOM_CODE_TO_MAC_KEYCODE[code];
+}
+
+export function labelForMacKeyCode(keyCode: number): string {
+  return MAC_KEYCODE_TO_LABEL[keyCode] ?? `#${keyCode}`;
+}
+
+// macOS's own on-screen modifier ordering convention (System Settings >
+// Keyboard Shortcuts and menu key-equivalents both use this order).
+const MODIFIER_ORDER = ["ctrl", "alt", "shift", "cmd"] as const;
+const MODIFIER_SYMBOLS: Record<string, string> = {
+  ctrl: "⌃", alt: "⌥", shift: "⇧", cmd: "⌘",
+};
+
+export function formatHotkey(hotkey: { keyCode: number; modifiers: string[] }): string {
+  const symbols = MODIFIER_ORDER.filter((modifier) => hotkey.modifiers.includes(modifier)).map(
+    (modifier) => MODIFIER_SYMBOLS[modifier]
+  );
+  return [...symbols, labelForMacKeyCode(hotkey.keyCode)].join("");
+}

--- a/src/index.css
+++ b/src/index.css
@@ -22,3 +22,26 @@ body {
   opacity: 0.7;
   margin: 0;
 }
+
+.setting {
+  margin-top: 1rem;
+}
+
+.setting h2 {
+  font-size: 0.9rem;
+  margin: 0 0 0.4rem;
+}
+
+.setting-current {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin: 0 0 0.5rem;
+  opacity: 1;
+}
+
+.setting-error {
+  color: #d64545;
+  font-size: 0.8rem;
+  margin-top: 0.5rem;
+  opacity: 1;
+}

--- a/src/openstreamBridge.d.ts
+++ b/src/openstreamBridge.d.ts
@@ -1,0 +1,16 @@
+import type { StoredHotkey } from "./hotkey/captureHotkey";
+
+export type StoredSettings = { hotkey: StoredHotkey };
+
+// Exposed by preload.js via contextBridge - see the comment there for what
+// this is expected to grow into.
+declare global {
+  interface Window {
+    openstream: {
+      settings: {
+        get(): Promise<StoredSettings>;
+        setHotkey(hotkey: StoredHotkey): Promise<StoredSettings>;
+      };
+    };
+  }
+}


### PR DESCRIPTION
Partial progress on #19.

#19 asks for a proper settings screen instead of hardcoded values, covering hotkey remapping and (per ROADMAP.md's more current framing) an editable break-safe app list. This PR does the first half: **hotkey remapping**, end to end.

**Why not the break-safe list too:** I checked, and it isn't actually wired into the live app yet - `dictationCoordinator.js` is always called with the default `context = { breakSafe: false }`; nothing in `main.js` passes real context from the accessibility helper's focus resolution. `src/dictation/breakSafety.ts` (the hardcoded `TextEdit`/`Notes`/`Obsidian`/`VS Code` list) exists but nothing reads it in production. Building an editor for a list nothing consults yet would be cosmetic, so I left it out - worth its own issue once that wiring lands.

## What this builds

- **`electron/settingsStore.js`** - a JSON-file-backed settings store (one field so far: `hotkey`), validated before persisting (non-empty modifiers from a known set, a sane keyCode) so a bad write can never leave the app with an unusable or empty global hotkey. `filePath` is injected, so it's testable with a plain temp file.
- **`src/hotkey/keycodeMap.ts`** - DOM `KeyboardEvent.code` → macOS virtual keycode translation (the two numbering systems don't correspond; the native helper only knows macOS's), plus `formatHotkey()` for the on-screen `⌃⌥D`-style display, ordered the way macOS itself orders modifiers.
- **`src/hotkey/captureHotkey.ts`** - the pure decision behind "is this key event usable as a hotkey": a mapped key held with at least one modifier. Kept separate from any DOM/React code so it's testable without a browser.
- **`electron/hotkeyHelper.js`** - now takes a configurable hotkey (still defaulting to the existing Control+Option+D) and exposes `setHotkey()` to restart the spawned binary with new args. This needed a real fix, not just `stop()`+`start()`: the old process's `exit` handler closed over a shared `child` variable, so a stale exit from a process `setHotkey` had already superseded could null out the reference to the *new* process and schedule a spurious extra restart. Fixed with a `child !== proc` check in each process's own handler closure, with a dedicated regression test.
- **`electron/preload.js` / `electron/main.js`** - `window.openstream.settings.{get,setHotkey}` over `contextBridge` (the settings window's first real IPC surface - it had none before this), the saved hotkey applied before the helper ever starts, and the running helper restarted on a successful remap.
- **`src/App.tsx` / `src/HotkeySettings.tsx`** - the actual settings screen. `App.tsx` was a placeholder since the Phase 0 scaffold ("Nothing to see yet"); this is its first real content, shown when "Open Window" is clicked from the tray menu.

## What's verified vs. what needs a human

**Verified headlessly:**
- 27 new tests (9 settings store, 8 keycode map, 5 hotkey capture, 5 hotkey helper) alongside the 2 pre-existing hotkeyHelper tests, all passing.
- `tsc --noEmit` and `vite build` both succeed with the settings screen wired in.
- Full `vitest` suite: 32/32. Full `node --test "electron/**/*.test.js"`: 54/55 - the one failure is the same pre-existing, unrelated Metal-backend sandbox issue seen on #115/#117.
- A note on tooling: this sandbox's default Node (v21.6.1) can't run `vitest` at all (a known npm optional-dependency bug leaves `@rolldown/binding-darwin-arm64` uninstalled - unrelated to this branch). I found a working path via a separately-installed Homebrew Node (v25.2.0) and used it for every vitest run in this PR's commits; `npm run build`'s own `vite build` step uses an older, unaffected Vite version and works fine on the default Node either way.

**Needs a human, one time:** actually opening the settings window, pressing a real key combo, confirming the remap makes push-to-talk respond to the new combo and stop responding to the old one, and confirming it survives a relaunch (i.e. actually persisted to `app.getPath("userData")`, not just held in memory). Full steps in the new `docs/testing/settings-hotkey-remap-manual-check.md`.

## Test plan
- [x] 27 new tests pass, 2 pre-existing hotkeyHelper tests still pass (headless)
- [x] `tsc --noEmit`, `vite build` (headless)
- [x] Full `vitest` (32/32) and `node --test` (54/55, one pre-existing unrelated failure) (headless)
- [ ] Real capture → remap → push-to-talk responds to the new combo, not the old one → persists across relaunch (needs a human running `npm start`)
