### PR TITLE
fix: prevent multiple OpenStream instances from running at once

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -10,6 +10,18 @@ const { createTranscriptionHttpAdapter } = require("./transcriptionHttpAdapter")
 const { runCompletedDictation } = require("./dictationCoordinator");
 const { createPushToTalkCoordinator } = require("./pushToTalkCoordinator");
 
+// Without this, nothing stops a second `npm start` (or a launch someone
+// forgot was already running) from spawning a whole second app: its own
+// tray icon, its own push-to-talk overlay stacked on top of the first
+// one's, its own hotkey helper racing the first for the same global
+// combo, its own model servers. Must be requested before any of that setup
+// below ever runs.
+if (!app.requestSingleInstanceLock()) {
+  console.error("[startup] another OpenStream instance is already running - quitting this one");
+  app.quit();
+  process.exit(0);
+}
+
 const isDev = process.env.NODE_ENV === "development";
 
 const TRAY_ICON_FILES = {
@@ -234,6 +246,13 @@ ipcMain.handle("settings:set-hotkey", (event, hotkey) => {
   const settings = settingsStore.setHotkey(hotkey);
   hotkeyHelper.setHotkey(settings.hotkey);
   return settings;
+});
+
+// A second launch attempt hits this instead of silently doing nothing (or
+// worse, silently doing everything twice) - bring the settings window
+// forward so there's visible proof this instance is the one that's running.
+app.on("second-instance", () => {
+  createWindow();
 });
 
 app.whenReady().then(() => {


### PR DESCRIPTION
Fixes a real bug found while investigating a "no HUD appears / HUD looks messy" report: the app had no single-instance lock at all, so a forgotten already-running `npm start` (easy to lose track of - Electron detaches from the terminal that launched it, so the shell command returning doesn't mean the app quit) plus a fresh `npm start` leaves **two full app instances** running simultaneously. Two overlay windows both showing at once, both trying to position themselves bottom-center on the same screen, looks exactly like one broken, overlapping HUD - which is what got reported.

## The fix

`app.requestSingleInstanceLock()`, requested before any other setup (tray, windows, native helpers, model servers) runs. If the lock can't be obtained, the app quits immediately with a clear terminal message instead of silently running a second, confusing instance. A `second-instance` event now brings the settings window forward, so a second launch attempt gives visible proof of which instance is actually running rather than doing nothing.

## What's verified vs. what needs a human

**Verified headlessly:** `node --check`, and the full `node --test "electron/**/*.test.js"` suite (54/55, the one failure is the same pre-existing, unrelated Metal-backend issue seen on prior PRs).

**Needs a human:** confirming that with this fix, running `npm start` twice actually refuses the second launch and quits cleanly rather than opening a second app - and, downstream of that, confirming the overlay looks clean (not overlapping) once only one instance can ever be running.

## Test plan
- [x] `node --check` (headless)
- [x] `node --test "electron/**/*.test.js"` (54/55, one pre-existing unrelated failure) (headless)
- [ ] A second `npm start` while one is already running refuses and quits, rather than opening a duplicate (needs a human)
- [ ] Overlay no longer looks overlapping/messy once only one instance can run (needs a human)
