### PR TITLE
debug: add temporary diagnostics for the "no HUD appears" report

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -92,6 +92,17 @@ function createOverlayWindow() {
   });
   overlayWin.setIgnoreMouseEvents(true);
   overlayWin.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
+
+  // Temporary diagnostics for the "no HUD appears" report - see the PR this
+  // landed in. Confirms the overlay's own page actually loaded, since a
+  // silent load failure would otherwise look identical to a positioning bug.
+  overlayWin.webContents.on("did-finish-load", () => {
+    console.log("[overlay] page finished loading");
+  });
+  overlayWin.webContents.on("did-fail-load", (_event, errorCode, errorDescription) => {
+    console.error(`[overlay] page failed to load: ${errorCode} ${errorDescription}`);
+  });
+
   overlayWin.loadFile(path.join(__dirname, "overlay", "overlay.html"));
 }
 
@@ -154,6 +165,10 @@ function positionOverlayAtBottom() {
   const [width, height] = overlayWin.getSize();
   const { x, y } = computeBottomCenteredPosition(display.workArea, width, height);
   overlayWin.setPosition(x, y);
+  // Temporary diagnostics for the "no HUD appears" report.
+  console.log(
+    `[overlay] positioned at (${x}, ${y}), size ${width}x${height}, workArea ${JSON.stringify(display.workArea)}`
+  );
 }
 
 function setUserVisibleState(state) {
@@ -164,6 +179,8 @@ function setUserVisibleState(state) {
   if (state === "recording") {
     positionOverlayAtBottom();
     overlayWin.showInactive();
+    // Temporary diagnostics for the "no HUD appears" report.
+    console.log(`[overlay] showInactive() called, isVisible=${overlayWin.isVisible()}, opacity=${overlayWin.getOpacity()}`);
   } else {
     overlayWin.hide();
   }


### PR DESCRIPTION
The main-process show/position logic (setUserVisibleState, positionOverlayAtBottom) and the renderer's state handling (overlay.js, overlayPreload.js) all read correctly on inspection, but a user report says the overlay never appears when recording, even after the Electron 31->43 bump. Can't reproduce without a real display, so instrumenting instead of guessing: logs whether the overlay's page actually finished loading (or failed, and why), the computed position/size/work-area on every show, and the window's isVisible()/getOpacity() right after showInactive(). To be removed once the actual cause is found.