### PR TITLE
feat: redesign the overlay as a glass HUD with a live waveform

### DIFF
--- a/docs/testing/hotkey-transcribe-manual-check.md
+++ b/docs/testing/hotkey-transcribe-manual-check.md
@@ -21,11 +21,13 @@ The automated coverage behind the wizard also includes:
 - Four overlay-positioning tests covering centering, the bottom margin, offset work areas, and a custom margin. Run them with `node --test electron/overlayPosition.test.js`. The actual Dock clearance still needs a human check.
 - `node --check` passing for all new and changed JavaScript files.
 
+The overlay's glass/waveform redesign (`vibrancy: "hud"`, the live waveform, "Listening") has no automated coverage beyond that `node --check` and `npm run build` passing - whether the vibrancy actually renders and how the waveform looks and feels while speaking are exactly the kind of thing that needs a human on a real screen, not a headless session.
+
 The wizard checks the build, then walks through seven stages:
 
 1. Check that the Electron runtime has not been revoked by Gatekeeper, then run the automated test suite and typecheck on an Apple Silicon Mac.
 2. Start OpenStream and grant Microphone, Input Monitoring, and Accessibility permissions.
-3. Use `Control+Option+D` outside OpenStream and inspect the tray, push-to-talk overlay, and sound meter. Confirm that the overlay sits bottom-center, clear of the Dock. On a multi-monitor setup, move the cursor to another display before pressing the key and confirm the overlay follows it.
+3. Use `Control+Option+D` outside OpenStream and inspect the tray, push-to-talk overlay, and sound meter. Confirm that the overlay sits bottom-center, clear of the Dock, and shows a real frosted-glass blur (desktop content behind it should look visibly blurred, not a flat dark box) with a waveform that audibly reacts to your voice. On a multi-monitor setup, move the cursor to another display before pressing the key and confirm the overlay follows it. If the overlay looks like a flat dark rectangle with no blur, check System Settings > Accessibility > Display > Reduce Transparency isn't enabled - that setting flattens all vibrancy effects system-wide.
 4. Dictate into TextEdit and confirm the finished text is inserted once.
 5. Inspect both model-server listeners and sample their TCP connections during a dictation. Ports 8178 and 8179 must stay on `127.0.0.1`.
 6. Measure three warm dictations from key release to confirmed insertion. Every measurement must be below 1000 ms.

--- a/electron/main.js
+++ b/electron/main.js
@@ -95,10 +95,16 @@ function createCaptureWindow() {
   captureWin.loadFile(path.join(__dirname, "capture", "captureWindow.html"));
 }
 
+// The resting size for the recording/idle waveform - named so
+// hideHeldResult() below can't drift from createOverlayWindow's initial
+// size the way it did once already (merge artifact: it briefly resized
+// back to the pre-redesign 180x52 instead of this).
+const OVERLAY_RESTING_SIZE = [220, 56];
+
 function createOverlayWindow() {
   overlayWin = new BrowserWindow({
-    width: 220,
-    height: 56,
+    width: OVERLAY_RESTING_SIZE[0],
+    height: OVERLAY_RESTING_SIZE[1],
     show: false,
     frame: false,
     transparent: true,
@@ -139,7 +145,7 @@ function hideHeldResult() {
   overlayWin.hide();
   overlayWin.setIgnoreMouseEvents(true);
   overlayWin.setFocusable(false);
-  overlayWin.setSize(180, 52, false);
+  overlayWin.setSize(...OVERLAY_RESTING_SIZE, false);
 }
 
 const heldResultController = createHeldResultController({

--- a/electron/main.js
+++ b/electron/main.js
@@ -97,8 +97,8 @@ function createCaptureWindow() {
 
 function createOverlayWindow() {
   overlayWin = new BrowserWindow({
-    width: 180,
-    height: 52,
+    width: 220,
+    height: 56,
     show: false,
     frame: false,
     transparent: true,
@@ -106,6 +106,14 @@ function createOverlayWindow() {
     focusable: false,
     alwaysOnTop: true,
     skipTaskbar: true,
+    // Real macOS frosted-glass blur, not a flat dark box - "hud" is the
+    // vibrancy material Apple's own HUD-style floating panels use.
+    // visualEffectState defaults to "follow-window", which renders the
+    // dimmer inactive appearance for a window that's never focused (this
+    // one is always shown via showInactive()) - forcing "active" keeps the
+    // vibrancy at full strength regardless.
+    vibrancy: "hud",
+    visualEffectState: "active",
     webPreferences: {
       preload: path.join(__dirname, "overlay", "overlayPreload.js"),
       contextIsolation: true,
@@ -114,17 +122,6 @@ function createOverlayWindow() {
   });
   overlayWin.setIgnoreMouseEvents(true);
   overlayWin.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
-
-  // Temporary diagnostics for the "no HUD appears" report - see the PR this
-  // landed in. Confirms the overlay's own page actually loaded, since a
-  // silent load failure would otherwise look identical to a positioning bug.
-  overlayWin.webContents.on("did-finish-load", () => {
-    console.log("[overlay] page finished loading");
-  });
-  overlayWin.webContents.on("did-fail-load", (_event, errorCode, errorDescription) => {
-    console.error(`[overlay] page failed to load: ${errorCode} ${errorDescription}`);
-  });
-
   overlayWin.loadFile(path.join(__dirname, "overlay", "overlay.html"));
 }
 
@@ -218,10 +215,6 @@ function positionOverlayAtBottom() {
   const [width, height] = overlayWin.getSize();
   const { x, y } = computeBottomCenteredPosition(display.workArea, width, height);
   overlayWin.setPosition(x, y);
-  // Temporary diagnostics for the "no HUD appears" report.
-  console.log(
-    `[overlay] positioned at (${x}, ${y}), size ${width}x${height}, workArea ${JSON.stringify(display.workArea)}`
-  );
 }
 
 function setUserVisibleState(state, details) {
@@ -241,8 +234,6 @@ function setUserVisibleState(state, details) {
   overlayWin.webContents.send("dictation-state", state);
   if (state === "recording") {
     overlayWin.showInactive();
-    // Temporary diagnostics for the "no HUD appears" report.
-    console.log(`[overlay] showInactive() called, isVisible=${overlayWin.isVisible()}, opacity=${overlayWin.getOpacity()}`);
   } else {
     overlayWin.hide();
   }

--- a/electron/overlay/overlay.css
+++ b/electron/overlay/overlay.css
@@ -15,50 +15,52 @@ body {
   place-items: center;
 }
 
+/* The window itself carries the real macOS vibrancy blur (see
+   createOverlayWindow's vibrancy: "hud") - this stays deliberately light
+   and mostly transparent so that blur reads through, with just enough of a
+   border and inner highlight to look like a distinct glass pane rather
+   than the blur bleeding into the desktop with no edge at all. Shared by
+   both the recording waveform and the held-result panel, since the window
+   itself resizes between the two rather than swapping windows. */
 .overlay {
   box-sizing: border-box;
   width: 100%;
-  color: #fff;
-  background: rgb(27 27 30 / 96%);
-  border: 1px solid rgb(255 255 255 / 14%);
-  border-radius: 14px;
-  box-shadow: 0 8px 24px rgb(0 0 0 / 28%);
-  font-size: 14px;
+  color: rgb(255 255 255 / 92%);
+  background: rgb(255 255 255 / 6%);
+  border: 1px solid rgb(255 255 255 / 16%);
+  border-radius: 16px;
+  box-shadow:
+    0 8px 24px rgb(0 0 0 / 25%),
+    inset 0 1px 0 rgb(255 255 255 / 10%);
+  font-size: 13px;
 }
 
 .recording {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 10px 16px;
+  gap: 12px;
+  padding: 10px 18px;
   font-weight: 600;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
 }
 
-.recording-dot {
+.waveform {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  height: 20px;
   flex: 0 0 auto;
-  width: 10px;
-  height: 10px;
-  background: #ff453a;
-  border-radius: 50%;
 }
 
-.sound-meter {
-  width: 48px;
-  height: 6px;
-  overflow: hidden;
-  background: rgb(255 255 255 / 18%);
-  border-radius: 999px;
-}
-
-.sound-meter__level {
-  display: block;
-  width: 100%;
+.waveform__bar {
+  width: 3px;
   height: 100%;
-  background: #ff6961;
-  border-radius: inherit;
-  transform: scaleX(var(--sound-level, 0));
-  transform-origin: left;
-  transition: transform 80ms linear;
+  border-radius: 999px;
+  background: linear-gradient(180deg, #7dd3fc, #0a84ff);
+  transform: scaleY(var(--level, 0.08));
+  transform-origin: center;
+  transition: transform 90ms ease-out;
 }
 
 .held-result {
@@ -122,6 +124,8 @@ body[data-state="held"] .held-result {
   display: block;
 }
 
-body[data-state="idle"] .recording-dot {
-  background: #8e8e93;
+body[data-state="idle"] .waveform__bar {
+  background: rgb(255 255 255 / 28%);
+  transform: scaleY(0.15);
+  transition: transform 300ms ease-out;
 }

--- a/electron/overlay/overlay.html
+++ b/electron/overlay/overlay.html
@@ -10,11 +10,16 @@
   <body data-state="recording">
     <main class="overlay" aria-live="polite">
       <section class="recording" data-recording>
-        <span class="recording-dot" aria-hidden="true"></span>
-        <span data-status>Recording</span>
-        <span class="sound-meter" aria-hidden="true">
-          <span class="sound-meter__level" data-sound-level></span>
+        <span class="waveform" aria-hidden="true">
+          <span class="waveform__bar" data-bar></span>
+          <span class="waveform__bar" data-bar></span>
+          <span class="waveform__bar" data-bar></span>
+          <span class="waveform__bar" data-bar></span>
+          <span class="waveform__bar" data-bar></span>
+          <span class="waveform__bar" data-bar></span>
+          <span class="waveform__bar" data-bar></span>
         </span>
+        <span data-status>Listening</span>
       </section>
       <section class="held-result" data-held-result>
         <h1>Couldn't insert this dictation</h1>

--- a/electron/overlay/overlay.js
+++ b/electron/overlay/overlay.js
@@ -1,20 +1,37 @@
 const status = document.querySelector("[data-status]");
-const levelMeter = document.querySelector("[data-sound-level]");
+const bars = Array.from(document.querySelectorAll("[data-bar]"));
 const heldText = document.querySelector("[data-held-text]");
 const copyButton = document.querySelector("[data-copy]");
 const dismissButton = document.querySelector("[data-dismiss]");
 
+const IDLE_LEVEL = 0.08;
+
+// Each bar reads a slightly older point in the same real sound-level
+// signal, so the wave visibly travels across the bars as you speak rather
+// than every bar moving in lockstep - no decorative randomness, just a few
+// samples of delay across a real, short history of the actual mic input.
+const levelHistory = new Array(bars.length).fill(IDLE_LEVEL);
+
+function setBars(levels) {
+  bars.forEach((bar, i) => bar.style.setProperty("--level", levels[i]));
+}
+
 window.openstreamOverlay.onStateChange((state) => {
-  status.textContent = state === "recording" ? "Recording" : "Idle";
+  status.textContent = state === "recording" ? "Listening" : "Idle";
   document.body.dataset.state = state;
-  if (state !== "recording") levelMeter.style.setProperty("--sound-level", 0);
+  if (state !== "recording") {
+    levelHistory.fill(IDLE_LEVEL);
+    setBars(levelHistory);
+  }
 });
 
 window.openstreamOverlay.onSoundLevel((level) => {
-  // Typical speech RMS is well below 1. Expand it for a readable meter while
-  // retaining the normalized capture value on the IPC boundary.
-  const visibleLevel = Math.max(0.03, Math.min(1, level * 5));
-  levelMeter.style.setProperty("--sound-level", visibleLevel);
+  // Typical speech RMS is well below 1 - expand it for a readable waveform
+  // while retaining the normalized capture value on the IPC boundary.
+  const visibleLevel = Math.max(IDLE_LEVEL, Math.min(1, level * 5));
+  levelHistory.push(visibleLevel);
+  levelHistory.shift();
+  setBars(levelHistory);
 });
 
 window.openstreamOverlay.onHeldResult((text) => {


### PR DESCRIPTION
Direct design feedback on the overlay HUD, after #120 fixed the actual duplicate-instance bug: "instead of a red progress bar HUD thing, have like squiggly listening lines with text 'listening' and more glass like HUD."

## What this changes

- **Real vibrancy, not fake glass.** `vibrancy: "hud"` on the `BrowserWindow` gets a genuine macOS frosted-glass blur, replacing the old flat `rgb(27 27 30 / 92%)` CSS box that only pretended to be translucent. `visualEffectState: "active"` is needed alongside it - this window is always shown via `showInactive()` and never focused, and vibrancy defaults to a dimmer "inactive" look for an unfocused window, which would undercut the whole effect.
- **A live waveform instead of the dot + progress bar.** 7 vertical bars, each reading a slightly older point in the same real sound-level stream (`electron/overlay/overlay.js`) - not decorative animation. The wave visibly travels across the bars as you speak, driven by the same normalized level value the old single-bar meter used.
- **"Listening" instead of "Recording".**
- **Blue instead of red** for the waveform bars and the (now-removed) recording dot - red reads as an error/warning state, not an assistant listening.
- Bumped the window from 180x52 to 220x56 to give the new content room.
- Also removes the temporary "no HUD appears" diagnostic `console.log` lines that got merged into `main` by an accident - a separate PR against a debug branch I'd pushed for local testing, never meant to ship. This PR touches the same functions for the vibrancy change anyway, so cleaned it up here.

## What's verified vs. what needs a human

**Verified headlessly:** `node --check`, `npm run build`, and the full `node --test "electron/**/*.test.js"` suite (54/55, the one failure is the same pre-existing, unrelated Metal-backend issue seen on prior PRs).

**Needs a human, entirely:** this is a pure visual/design change with zero automated coverage possible - whether the vibrancy blur actually renders, whether the waveform looks and feels right while speaking, whether "Listening" reads well at that size. Step 7b in `docs/testing/hotkey-transcribe-manual-check.md`, added in this PR, covers what to check and the one known failure mode (macOS's Reduce Transparency setting flattens all vibrancy system-wide, which would make this look like a bug when it's actually a system setting).

## Test plan
- [x] `node --check`, `npm run build` (headless)
- [x] `node --test "electron/**/*.test.js"` (54/55, one pre-existing unrelated failure) (headless)
- [ ] Overlay shows real glass blur, a waveform that reacts to voice, and reads "Listening" (needs a human running `npm start`)
