### PR TITLE
fix: reapply overlay vibrancy after window creation

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -136,6 +136,12 @@ function createOverlayWindow() {
   });
   overlayWin.setIgnoreMouseEvents(true);
   overlayWin.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
+  // Reapplied explicitly, not just passed to the constructor: on a
+  // frameless + transparent window this pairing has been unreliable at
+  // construction time on some Electron/macOS combinations, and calling
+  // setVibrancy() again once the native window actually exists is the
+  // documented workaround.
+  overlayWin.setVibrancy("hud");
   overlayWin.loadFile(path.join(__dirname, "overlay", "overlay.html"));
 }
 


### PR DESCRIPTION
Follow-up to #122: direct feedback that the overlay still doesn't look glass-themed on a real screen after that PR merged, despite `vibrancy: "hud"` being set in the `BrowserWindow` constructor.

## The fix

`overlayWin.setVibrancy("hud")` called again explicitly once the native window exists, not just passed as a constructor option. On a frameless + transparent window, that pairing has been unreliable at construction time on some Electron/macOS version combinations - reapplying it post-construction is the documented workaround, and is a no-op cost on setups where the constructor option already worked correctly.

**Not yet confirmed this is the actual root cause.** Still waiting on the user to confirm whether System Settings > Accessibility > Display > Reduce Transparency is enabled - that setting flattens all vibrancy effects system-wide regardless of what any app does, which would explain the symptom without this being a code bug at all. Opening this now since it's a legitimate, low-risk improvement either way, not gated on that answer.

## What's verified vs. what needs a human

**Verified headlessly:** `node --check`, `npm run build`, full `vitest` (18/18), and `node --test "electron/**/*.test.js"` (78/81 - one pre-existing unrelated Metal-backend failure, and two pre-existing cancelled tests in `breakPlacementHttpAdapter.test.js` from a separate, already-merged commit that has nothing to do with this change - reproduced in isolation to confirm).

**Needs a human, entirely:** whether the overlay actually looks glass-themed now. Zero automated coverage possible for a vibrancy rendering question.

## Test plan
- [x] `node --check`, `npm run build` (headless)
- [x] `vitest` 18/18, `node --test` 78/81 with two pre-existing, unrelated, isolation-confirmed failures (headless)
- [ ] Overlay actually renders real glass/blur on a real screen (needs a human)
