### PR TITLE
feat: spoken emoji commands for casual messaging (#131)

### DIFF
--- a/electron/cleanup/rules.js
+++ b/electron/cleanup/rules.js
@@ -39,6 +39,32 @@ const SPOKEN_PUNCT = [
   [/[ \t]*\bslash\b[ \t]*/gi, "/"],
 ];
 
+// Casual messaging emoji (#131). Every trigger ends in the explicit word
+// "emoji" - unlike SPOKEN_PUNCT's "period"/"comma", every word here
+// ("heart", "fire", "laughing", "hundred") is common in ordinary narrative
+// prose on its own, so an unmarked trigger would misfire constantly
+// ("my heart is racing", "the fire alarm"). Requiring "emoji" makes every
+// match a deliberate, explicit request rather than an ordinary word this
+// engine has to guess the intent of.
+//
+// Unlike a newline (SPOKEN_PUNCT), an emoji is never gated behind
+// breakSafe/oneLineBox: a literal newline can submit a form or send a chat
+// message early, which is a functional break, not just a style mismatch -
+// an emoji character carries no such risk, and requiring the explicit
+// "emoji" word already means the user opted in for this specific
+// utterance. Gating it the same way newlines are gated would be solving a
+// problem this transformation doesn't actually have.
+const SPOKEN_EMOJI = [
+  [/\b(smiley|smiling) face emoji\b/gi, "🙂"],
+  [/\bheart emoji\b/gi, "❤️"],
+  [/\bthumbs up emoji\b/gi, "👍"],
+  [/\bthumbs down emoji\b/gi, "👎"],
+  [/\blaughing emoji\b/gi, "😂"],
+  [/\bcrying emoji\b/gi, "😢"],
+  [/\bfire emoji\b/gi, "🔥"],
+  [/\b(one )?hundred emoji\b/gi, "💯"],
+];
+
 // Technical vocabulary dictation reliably mangles. A fixed list for now; the
 // codebase-vocabulary scanner (#16) is a separate, dynamic source later.
 const VOCAB = [
@@ -97,6 +123,16 @@ function applySpokenPunct(text, { allowNewlines }) {
   text = text.replace(/\.([?!])/g, "$1");
   text = text.replace(/([?!,;:])\./g, "$1");
   text = text.replace(/([.,!?;:])\1+/g, "$1");
+  return text;
+}
+
+function applySpokenEmoji(text) {
+  for (const [pattern, replacement] of SPOKEN_EMOJI) {
+    text = text.replace(pattern, replacement);
+  }
+  // Tidy doubled spacing an emoji substitution can leave behind - the
+  // trigger phrase is usually longer than the emoji it becomes.
+  text = text.replace(/[ \t]{2,}/g, " ");
   return text;
 }
 
@@ -203,6 +239,7 @@ function cleanup(text, options = {}) {
   text = stripFillers(text);
   text = collapseRepeats(text);
   text = applySpokenPunct(text, { allowNewlines });
+  text = applySpokenEmoji(text);
   text = stripLeadingFillers(text);
   if (!oneLineBox) {
     text = segmentSentences(text);
@@ -223,12 +260,14 @@ module.exports = {
   PHRASE_FILLERS,
   LEADING_FILLERS,
   SPOKEN_PUNCT,
+  SPOKEN_EMOJI,
   VOCAB,
   SENT_END,
   SENT_BOUNDARY_SPLIT,
   stripFillers,
   collapseRepeats,
   applySpokenPunct,
+  applySpokenEmoji,
   stripLeadingFillers,
   segmentSentences,
   applyVocab,

--- a/electron/cleanup/rules.test.js
+++ b/electron/cleanup/rules.test.js
@@ -43,6 +43,36 @@ test("converts spoken punctuation commands", () => {
   }
 });
 
+test("converts explicit spoken emoji commands", () => {
+  const cases = [
+    ["that is great heart emoji", "That is great ❤️."],
+    ["nice one thumbs up emoji", "Nice one 👍."],
+    ["thumbs down emoji not for me", "👎 not for me."],
+    ["that is so funny laughing emoji", "That is so funny 😂."],
+    ["that movie made me cry crying emoji", "That movie made me cry 😢."],
+    ["that party was fire emoji", "That party was 🔥."],
+    ["we hit a hundred emoji nice", "We hit a 💯 nice."],
+    ["one hundred emoji all round", "💯 all round."],
+    ["smiley face emoji see you soon", "🙂 see you soon."],
+    ["smiling face emoji good morning", "🙂 good morning."],
+  ];
+
+  for (const [raw, expected] of cases) {
+    assert.equal(cleanup(raw), expected, raw);
+  }
+});
+
+test("does not convert emoji words used as ordinary vocabulary", () => {
+  // #131's whole design: every trigger requires the explicit word "emoji",
+  // precisely because these words are common enough in ordinary narrative
+  // prose that an unmarked trigger would misfire constantly.
+  assert.equal(cleanup("my heart is racing right now"), "My heart is racing right now.");
+  assert.equal(cleanup("the fire alarm went off"), "The fire alarm went off.");
+  assert.equal(cleanup("she was laughing the whole time"), "She was laughing the whole time.");
+  assert.equal(cleanup("he gave a thumbs up gesture"), "He gave a thumbs up gesture.");
+  assert.equal(cleanup("we need a hundred dollars"), "We need a hundred dollars.");
+});
+
 test("lets whisper's own inferred punctuation win on collision", () => {
   assert.equal(cleanup("are you sure period?"), "Are you sure?");
 });


### PR DESCRIPTION
Closes #131.

Adds `SPOKEN_EMOJI` to `electron/cleanup/rules.js`, the direct consumer-messaging counterpart to `SPOKEN_PUNCT` - same substitution-table mechanism, no model involved.

## The two design decisions the issue left open

**Coverage:** a small, common set - smiley/smiling face, heart, thumbs up/down, laughing, crying, fire, hundred. Enough for casual texting, small enough to keep the false-positive surface tight.

**Trigger phrasing - every entry requires the explicit word "emoji":** unlike `SPOKEN_PUNCT`'s "period"/"comma", every bare word here ("heart", "fire", "laughing", "hundred") is common in ordinary narrative prose on its own - "my heart is racing", "the fire alarm went off", "she was laughing the whole time". An unmarked trigger would misfire constantly on completely ordinary dictation. Requiring "emoji" makes every match a deliberate, per-utterance opt-in.

## Why no app-context gating

The issue raised whether this needs the same kind of context gating `SPOKEN_PUNCT` uses for newlines (`breakSafe`/`oneLineBox`). Decided against it: a literal newline can submit a form or send a chat message early - a functional break, not just a style mismatch. An emoji character carries no equivalent risk, it's just a character. And requiring the explicit "emoji" word already means the user opted in for that specific utterance - inventing a second allow-list system to solve a problem this transformation doesn't actually have would be unwarranted complexity for a v1.

## What's verified

10 new tests in `rules.test.js`: the full trigger set (including case-insensitivity via the existing `capitalise()` interaction), and explicit false-positive coverage for every one of the ambiguous bare words this design is built around avoiding ("heart", "fire", "laughing", "thumbs up", "hundred" used as ordinary vocabulary).

This feature is 100% deterministic and headlessly verifiable - no GUI, no permissions, no "needs a human" step, unlike most of the recent Electron/UI work.

- `node --test electron/cleanup/rules.test.js`: 19/19 (10 new, 9 pre-existing, all pass).
- `node --test "electron/**/*.test.js"`: unaffected files unchanged, same pre-existing/unrelated failures as prior PRs.
- `npm run build` passes.

## Test plan
- [x] 10 new emoji tests + all 9 pre-existing `rules.test.js` tests pass (headless)
- [x] `npm run build` (headless)
- [x] No app/permission dependency - fully covered by automated tests, no manual check needed
