### PR TITLE
Fix push-to-talk hotkey silently doing nothing after a lost keyUp

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -213,6 +213,14 @@ const pushToTalkCoordinator = createPushToTalkCoordinator({
     captureWin.webContents.send("stop-recording", timing);
   },
   setUserVisibleState,
+  onStuckRecording() {
+    // See #140/pushToTalkCoordinator.js: this fires only when keyUp never
+    // arrived for a whole recording. Previously that left `recording` stuck
+    // true forever with no signal at all - every press after it silently
+    // did nothing. Logging it is the diagnostic #140 needs to confirm
+    // whether this is what's actually happening in the field.
+    console.error("[dictation] keyUp never arrived - force-stopped after the safety timeout (see #140)");
+  },
 });
 
 function loadTrayIcons() {

--- a/electron/pushToTalkCoordinator.js
+++ b/electron/pushToTalkCoordinator.js
@@ -1,5 +1,32 @@
-function createPushToTalkCoordinator({ startCapture, stopCapture, setUserVisibleState, now = performance.now.bind(performance) }) {
+// #140: recording was a plain latch with no recovery if a keyUp was ever
+// lost - the native tap disabled at the wrong moment, a dropped IPC line,
+// anything. Once stuck true, keyDown's own guard would silently swallow
+// every future press, forever, with no error - indistinguishable from "the
+// hotkey stopped working" until the app restarted and reset the flag.
+const DEFAULT_MAX_RECORDING_MS = 60_000;
+
+function createPushToTalkCoordinator({
+  startCapture,
+  stopCapture,
+  setUserVisibleState,
+  now = performance.now.bind(performance),
+  setSafetyTimer = setTimeout,
+  clearSafetyTimer = clearTimeout,
+  maxRecordingMs = DEFAULT_MAX_RECORDING_MS,
+  onStuckRecording = () => {},
+}) {
   let recording = false;
+  let safetyTimer = null;
+
+  function finishRecording() {
+    recording = false;
+    if (safetyTimer) {
+      clearSafetyTimer(safetyTimer);
+      safetyTimer = null;
+    }
+    stopCapture({ releasedAtMs: now() });
+    setUserVisibleState("transcribing");
+  }
 
   return {
     keyDown() {
@@ -7,13 +34,20 @@ function createPushToTalkCoordinator({ startCapture, stopCapture, setUserVisible
       recording = true;
       startCapture();
       setUserVisibleState("recording");
+      // No real dictation runs this long. If maxRecordingMs elapses without
+      // a matching keyUp, force a stop rather than leave `recording` stuck
+      // true - that's the difference between one bad dictation and every
+      // press after it silently doing nothing.
+      safetyTimer = setSafetyTimer(() => {
+        safetyTimer = null;
+        finishRecording();
+        onStuckRecording();
+      }, maxRecordingMs);
     },
 
     keyUp() {
       if (!recording) return;
-      recording = false;
-      stopCapture({ releasedAtMs: now() });
-      setUserVisibleState("transcribing");
+      finishRecording();
     },
   };
 }

--- a/electron/pushToTalkCoordinator.test.js
+++ b/electron/pushToTalkCoordinator.test.js
@@ -38,3 +38,80 @@ test("repeated or unmatched key events do not create extra recordings", () => {
 
   assert.deepEqual(captureCommands, ["start", "stop"]);
 });
+
+// Fake timer that lets a test fire the callback deterministically instead
+// of waiting on a real clock, matching the injected-timer pattern used
+// elsewhere in this codebase (e.g. hotkeyHelper.js's restart timer).
+function createFakeTimers() {
+  let scheduled = null;
+  return {
+    setSafetyTimer: (callback, delay) => {
+      scheduled = { callback, delay };
+      return scheduled;
+    },
+    clearSafetyTimer: (handle) => {
+      if (handle === scheduled) scheduled = null;
+    },
+    fire: () => {
+      const pending = scheduled;
+      scheduled = null;
+      pending.callback();
+    },
+    isPending: () => scheduled !== null,
+  };
+}
+
+// #140: a keyUp that never arrives (a lost/dropped event, for whatever
+// reason) must not leave `recording` stuck true forever - that would make
+// every subsequent keyDown a silent no-op, indistinguishable from "the
+// hotkey stopped working".
+test("a keyUp that never arrives is force-stopped by the safety timeout, and the next keyDown works again", () => {
+  const captureCommands = [];
+  const states = [];
+  const stuckEvents = [];
+  const timers = createFakeTimers();
+  const coordinator = createPushToTalkCoordinator({
+    startCapture: () => captureCommands.push("start"),
+    stopCapture: () => captureCommands.push("stop"),
+    setUserVisibleState: (state) => states.push(state),
+    setSafetyTimer: timers.setSafetyTimer,
+    clearSafetyTimer: timers.clearSafetyTimer,
+    maxRecordingMs: 60_000,
+    onStuckRecording: () => stuckEvents.push(true),
+  });
+
+  coordinator.keyDown();
+  assert.equal(timers.isPending(), true);
+
+  // keyUp never comes.
+  timers.fire();
+
+  assert.deepEqual(captureCommands, ["start", "stop"]);
+  assert.deepEqual(states, ["recording", "transcribing"]);
+  assert.equal(stuckEvents.length, 1);
+
+  // The whole point: recording must not be stuck - a fresh press works.
+  coordinator.keyDown();
+  assert.deepEqual(captureCommands, ["start", "stop", "start"]);
+});
+
+test("a normal keyUp cancels the safety timeout instead of double-stopping later", () => {
+  const captureCommands = [];
+  const stuckEvents = [];
+  const timers = createFakeTimers();
+  const coordinator = createPushToTalkCoordinator({
+    startCapture: () => captureCommands.push("start"),
+    stopCapture: () => captureCommands.push("stop"),
+    setUserVisibleState: () => {},
+    setSafetyTimer: timers.setSafetyTimer,
+    clearSafetyTimer: timers.clearSafetyTimer,
+    onStuckRecording: () => stuckEvents.push(true),
+  });
+
+  coordinator.keyDown();
+  coordinator.keyUp();
+
+  assert.equal(timers.isPending(), false);
+  assert.deepEqual(captureCommands, ["start", "stop"]);
+  assert.equal(stuckEvents.length, 0);
+});


### PR DESCRIPTION
Closes #140 (as a defensive fix - see the caveat at the end on what this does and doesn't prove).

## What I found

pushToTalkCoordinator's `recording` flag was a plain boolean latch with no recovery path:

```js
keyDown() {
  if (recording) return;
  recording = true;
  ...
},
keyUp() {
  if (!recording) return;
  recording = false;
  ...
},
```

`keyDown()` silently no-ops whenever `recording` is already `true`, and the only way to clear it back to `false` was a matching `keyUp()`. If a `keyUp` is ever lost for any reason - the native tap getting disabled by macOS mid-release and only recovering on the next event, a dropped IPC line, a process hiccup, anything - `recording` stays stuck `true` permanently. From that point on, every subsequent hotkey press silently does nothing: `keyDown()`'s own guard swallows it, with zero logging anywhere in the chain. That's indistinguishable from "the hotkey stopped working" until the app restarts and the in-memory flag resets - which fits #140's report of a press being "sometimes dropped."

I want to be upfront about what this is and isn't: I couldn't reproduce the report directly (#140 itself says it needs its own repro), so I can't claim this is *the* cause with certainty. What I can say is it's a real, previously-untested gap - `pushToTalkCoordinator.test.js` had a test for "repeated keyDown doesn't double-start" but nothing for "a keyUp that never arrives," and once you look for it, the failure mode it produces (silent, permanent, until restart) matches the report closely enough that it's worth fixing regardless of whether it's the whole story.

## Fix

`keyDown()` now starts a safety timer (default 60s - far beyond any real dictation) that force-stops the recording if `keyUp` never arrives, via a new injected `setSafetyTimer`/`clearSafetyTimer` pair (matching the existing DI pattern in this file and in `hotkeyHelper.js`'s own restart timer) and a `maxRecordingMs` option. A normal `keyUp` cancels the timer, so nothing changes for the working path. Wired a new `onStuckRecording` callback in `main.js` to `console.error` - this was completely silent before, so if this safety net ever actually fires in real use, there's now a log line confirming it, rather than needing to guess from a user's memory of what happened.

## Tests

Two new cases in `pushToTalkCoordinator.test.js`, using a fake injected timer (no real clock, no flakiness):
- a `keyUp` that never arrives gets force-stopped by the safety timeout, `onStuckRecording` fires once, and - the actual point - a fresh `keyDown()` afterward works again instead of staying stuck.
- a normal `keyUp` cancels the pending safety timer (no double-stop later).

Existing two tests untouched and still pass.

## Verification

`node --test "electron/**/*.test.js"`: 82 pass / 0 fail (2 cancelled tests in `breakPlacementHttpAdapter.test.js` are pre-existing - confirmed by stashing this change out and re-running, same cancellation happens on `main` unmodified, unrelated to this PR). `tsc --noEmit` clean. Couldn't run `npm run build`'s vite step in this sandbox (Node 21.6.1 here vs. the `>=22.12.0` engines requirement vite/rolldown now need) - CI runs Node 22.12 so this isn't a real gap, just a local sandbox limitation; my change doesn't touch anything Vite-bundled anyway (plain CommonJS in the Electron main process).
