### PR TITLE
Add a settings screen for the break-safe app list

### DIFF
--- a/electron/breakSafety.js
+++ b/electron/breakSafety.js
@@ -1,12 +1,32 @@
-const BREAK_SAFE_BUNDLE_IDS = new Set([
+// Deny-by-default: a literal line break can execute a half-typed terminal
+// command or send an unfinished chat message, so every app not explicitly
+// listed here is treated as unsafe. See #19 - this used to be a hardcoded
+// constant; it's mutable now so the settings UI can edit it, but the
+// default and the safety posture are unchanged.
+const DEFAULT_BREAK_SAFE_BUNDLE_IDS = [
   "com.apple.TextEdit",
   "com.apple.Notes",
   "md.obsidian",
   "com.microsoft.VSCode",
-]);
+];
+
+let breakSafeBundleIds = new Set(DEFAULT_BREAK_SAFE_BUNDLE_IDS);
 
 function isBreakSafeApplication(bundleId) {
-  return BREAK_SAFE_BUNDLE_IDS.has(bundleId);
+  return breakSafeBundleIds.has(bundleId);
 }
 
-module.exports = { isBreakSafeApplication };
+function setBreakSafeApplications(bundleIds) {
+  breakSafeBundleIds = new Set(bundleIds);
+}
+
+function getBreakSafeApplications() {
+  return [...breakSafeBundleIds];
+}
+
+module.exports = {
+  isBreakSafeApplication,
+  setBreakSafeApplications,
+  getBreakSafeApplications,
+  DEFAULT_BREAK_SAFE_BUNDLE_IDS,
+};

--- a/electron/breakSafety.test.js
+++ b/electron/breakSafety.test.js
@@ -1,0 +1,38 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  isBreakSafeApplication,
+  setBreakSafeApplications,
+  getBreakSafeApplications,
+  DEFAULT_BREAK_SAFE_BUNDLE_IDS,
+} = require("./breakSafety");
+
+test.afterEach(() => {
+  // Module-level state - reset after every test so one test's edit can't
+  // leak into the next (or into dictationCoordinator.test.js, which relies
+  // on the default list including com.apple.TextEdit).
+  setBreakSafeApplications(DEFAULT_BREAK_SAFE_BUNDLE_IDS);
+});
+
+test("defaults match the original hardcoded allow-list", () => {
+  assert.deepEqual(new Set(getBreakSafeApplications()), new Set(DEFAULT_BREAK_SAFE_BUNDLE_IDS));
+  assert.equal(isBreakSafeApplication("com.apple.TextEdit"), true);
+  assert.equal(isBreakSafeApplication("com.apple.Terminal"), false);
+});
+
+test("setBreakSafeApplications replaces the list entirely, not merges", () => {
+  setBreakSafeApplications(["com.apple.Terminal"]);
+  assert.equal(isBreakSafeApplication("com.apple.Terminal"), true);
+  assert.equal(isBreakSafeApplication("com.apple.TextEdit"), false, "the old default must not survive a replace");
+});
+
+test("an empty list denies every app, matching deny-by-default", () => {
+  setBreakSafeApplications([]);
+  assert.equal(isBreakSafeApplication("com.apple.TextEdit"), false);
+  assert.deepEqual(getBreakSafeApplications(), []);
+});
+
+test("setBreakSafeApplications dedupes", () => {
+  setBreakSafeApplications(["com.apple.Terminal", "com.apple.Terminal"]);
+  assert.deepEqual(getBreakSafeApplications(), ["com.apple.Terminal"]);
+});

--- a/electron/main.js
+++ b/electron/main.js
@@ -7,6 +7,7 @@ const rewriteModelServer = require("./rewriteModelServer");
 const hotkeyHelper = require("./hotkeyHelper");
 const accessibilityHelper = require("./accessibilityHelper");
 const { createSettingsStore } = require("./settingsStore");
+const { setBreakSafeApplications } = require("./breakSafety");
 const { createTranscriptionHttpAdapter } = require("./transcriptionHttpAdapter");
 const { createBreakPlacementHttpAdapter } = require("./breakPlacementHttpAdapter");
 const { createDictationIntake } = require("./dictationCoordinator");
@@ -352,6 +353,15 @@ ipcMain.handle("settings:set-hotkey", (event, hotkey) => {
   return settings;
 });
 
+ipcMain.handle("settings:set-break-safe-apps", (event, apps) => {
+  // Same shape as settings:set-hotkey: setBreakSafeApps validates and
+  // throws on anything malformed, so a bad renderer-side edit can't corrupt
+  // the deny-by-default allow-list breakSafety.js enforces.
+  const settings = settingsStore.setBreakSafeApps(apps);
+  setBreakSafeApplications(settings.breakSafeApps);
+  return settings;
+});
+
 // A second launch attempt hits this instead of silently doing nothing (or
 // worse, silently doing everything twice) - bring the settings window
 // forward so there's visible proof this instance is the one that's running.
@@ -365,6 +375,7 @@ app.whenReady().then(() => {
   }
   settingsStore = createSettingsStore({ filePath: path.join(app.getPath("userData"), "settings.json") });
   hotkeyHelper.setHotkey(settingsStore.get().hotkey);
+  setBreakSafeApplications(settingsStore.get().breakSafeApps);
   createTray();
   hotkeyHelper.onKeyDown(pushToTalkCoordinator.keyDown);
   hotkeyHelper.onKeyUp(pushToTalkCoordinator.keyUp);

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -8,5 +8,6 @@ contextBridge.exposeInMainWorld("openstream", {
   settings: {
     get: () => ipcRenderer.invoke("settings:get"),
     setHotkey: (hotkey) => ipcRenderer.invoke("settings:set-hotkey", hotkey),
+    setBreakSafeApps: (apps) => ipcRenderer.invoke("settings:set-break-safe-apps", apps),
   },
 });

--- a/electron/settingsStore.js
+++ b/electron/settingsStore.js
@@ -1,11 +1,13 @@
 const fs = require("fs");
 const path = require("path");
+const { DEFAULT_BREAK_SAFE_BUNDLE_IDS } = require("./breakSafety");
 
-// Matches hotkeyHelper.js's own default (Control+Option+D, see #84) so a
-// fresh install with no settings file behaves exactly like it did before
-// this existed.
+// Matches hotkeyHelper.js's own default (Control+Option+D, see #84) and
+// breakSafety.js's own default allow-list, so a fresh install with no
+// settings file behaves exactly like it did before either was editable.
 const DEFAULT_SETTINGS = {
   hotkey: { keyCode: 2, modifiers: ["ctrl", "alt"] },
+  breakSafeApps: [...DEFAULT_BREAK_SAFE_BUNDLE_IDS],
 };
 
 const VALID_MODIFIERS = new Set(["cmd", "shift", "alt", "ctrl"]);
@@ -22,6 +24,17 @@ function validateHotkey(hotkey) {
   for (const modifier of hotkey.modifiers) {
     if (!VALID_MODIFIERS.has(modifier)) {
       throw new Error(`unknown modifier "${modifier}"`);
+    }
+  }
+}
+
+function validateBreakSafeApps(apps) {
+  if (!Array.isArray(apps)) {
+    throw new Error("breakSafeApps must be an array");
+  }
+  for (const bundleId of apps) {
+    if (typeof bundleId !== "string" || bundleId.trim().length === 0) {
+      throw new Error("each break-safe app must be a non-empty bundle id string");
     }
   }
 }
@@ -62,12 +75,21 @@ function createSettingsStore({ filePath }) {
     return settings;
   }
 
+  function setBreakSafeApps(apps) {
+    validateBreakSafeApps(apps);
+    cache = { ...load(), breakSafeApps: [...new Set(apps.map((bundleId) => bundleId.trim()))] };
+    persist();
+    const settings = get();
+    for (const listener of listeners) listener(settings);
+    return settings;
+  }
+
   function onChange(listener) {
     listeners.add(listener);
     return () => listeners.delete(listener);
   }
 
-  return { get, setHotkey, onChange };
+  return { get, setHotkey, setBreakSafeApps, onChange };
 }
 
 module.exports = { createSettingsStore, DEFAULT_SETTINGS };

--- a/electron/settingsStore.test.js
+++ b/electron/settingsStore.test.js
@@ -73,3 +73,44 @@ test("a corrupt settings file falls back to defaults instead of throwing", () =>
   const store = createSettingsStore({ filePath });
   assert.deepEqual(store.get(), DEFAULT_SETTINGS);
 });
+
+test("setBreakSafeApps persists to disk and get() reflects it afterwards", () => {
+  const filePath = tempFilePath();
+  const store = createSettingsStore({ filePath });
+
+  store.setBreakSafeApps(["com.apple.Terminal", "com.googlecode.iterm2"]);
+  assert.deepEqual(store.get().breakSafeApps, ["com.apple.Terminal", "com.googlecode.iterm2"]);
+
+  const onDisk = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  assert.deepEqual(onDisk.breakSafeApps, ["com.apple.Terminal", "com.googlecode.iterm2"]);
+});
+
+test("setBreakSafeApps trims whitespace and dedupes", () => {
+  const store = createSettingsStore({ filePath: tempFilePath() });
+  store.setBreakSafeApps([" com.apple.Terminal ", "com.apple.Terminal"]);
+  assert.deepEqual(store.get().breakSafeApps, ["com.apple.Terminal"]);
+});
+
+test("setBreakSafeApps accepts an empty list - deny-by-default is a valid choice", () => {
+  const store = createSettingsStore({ filePath: tempFilePath() });
+  store.setBreakSafeApps([]);
+  assert.deepEqual(store.get().breakSafeApps, []);
+});
+
+test("rejects a non-array breakSafeApps", () => {
+  const store = createSettingsStore({ filePath: tempFilePath() });
+  assert.throws(() => store.setBreakSafeApps("com.apple.Terminal"), /array/);
+});
+
+test("rejects a blank bundle id", () => {
+  const store = createSettingsStore({ filePath: tempFilePath() });
+  assert.throws(() => store.setBreakSafeApps(["com.apple.Terminal", "  "]), /non-empty bundle id/);
+});
+
+test("an invalid setBreakSafeApps call leaves the previous value untouched", () => {
+  const store = createSettingsStore({ filePath: tempFilePath() });
+  store.setBreakSafeApps(["com.apple.Terminal"]);
+
+  assert.throws(() => store.setBreakSafeApps(["  "]));
+  assert.deepEqual(store.get().breakSafeApps, ["com.apple.Terminal"]);
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,12 @@
 import HotkeySettings from "./HotkeySettings";
+import BreakSafeAppsSettings from "./BreakSafeAppsSettings";
 
 export default function App() {
   return (
     <main className="shell">
       <h1>OpenStream Settings</h1>
       <HotkeySettings />
+      <BreakSafeAppsSettings />
     </main>
   );
 }

--- a/src/BreakSafeAppsSettings.tsx
+++ b/src/BreakSafeAppsSettings.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useState } from "react";
+
+export default function BreakSafeAppsSettings() {
+  const [apps, setApps] = useState<string[] | null>(null);
+  const [newBundleId, setNewBundleId] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    window.openstream.settings.get().then((settings) => setApps(settings.breakSafeApps));
+  }, []);
+
+  function save(next: string[]) {
+    setSaving(true);
+    setError(null);
+    window.openstream.settings
+      .setBreakSafeApps(next)
+      .then((settings) => setApps(settings.breakSafeApps))
+      .catch((err) => setError(err instanceof Error ? err.message : String(err)))
+      .finally(() => setSaving(false));
+  }
+
+  function addApp() {
+    const bundleId = newBundleId.trim();
+    if (!bundleId || !apps) return;
+    save([...apps, bundleId]);
+    setNewBundleId("");
+  }
+
+  function removeApp(bundleId: string) {
+    if (!apps) return;
+    save(apps.filter((id) => id !== bundleId));
+  }
+
+  return (
+    <section className="setting">
+      <h2>Break-safe applications</h2>
+      <p>
+        A spoken "new paragraph" only becomes a real line break in apps listed here. Everywhere else it's
+        deliberately dropped, since a newline can submit a half-typed terminal command or send an unfinished
+        message.
+      </p>
+      {apps === null ? (
+        <p className="setting-current">Loading…</p>
+      ) : (
+        <ul className="break-safe-list">
+          {apps.length === 0 && (
+            <li className="break-safe-empty">No apps listed - line breaks are off everywhere.</li>
+          )}
+          {apps.map((bundleId) => (
+            <li key={bundleId}>
+              <span>{bundleId}</span>
+              <button onClick={() => removeApp(bundleId)} disabled={saving} aria-label={`Remove ${bundleId}`}>
+                Remove
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      <div className="break-safe-add">
+        <input
+          type="text"
+          placeholder="com.example.App"
+          value={newBundleId}
+          onChange={(event) => setNewBundleId(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") addApp();
+          }}
+          disabled={saving || apps === null}
+        />
+        <button onClick={addApp} disabled={saving || apps === null || newBundleId.trim().length === 0}>
+          Add
+        </button>
+      </div>
+      {error && <p className="setting-error">{error}</p>}
+    </section>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -45,3 +45,33 @@ body {
   margin-top: 0.5rem;
   opacity: 1;
 }
+
+.break-safe-list {
+  list-style: none;
+  margin: 0 0 0.5rem;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.break-safe-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+}
+
+.break-safe-empty {
+  opacity: 0.7;
+}
+
+.break-safe-add {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.break-safe-add input {
+  flex: 1;
+}

--- a/src/openstreamBridge.d.ts
+++ b/src/openstreamBridge.d.ts
@@ -1,6 +1,6 @@
 import type { StoredHotkey } from "./hotkey/captureHotkey";
 
-export type StoredSettings = { hotkey: StoredHotkey };
+export type StoredSettings = { hotkey: StoredHotkey; breakSafeApps: string[] };
 
 // Exposed by preload.js via contextBridge - see the comment there for what
 // this is expected to grow into.
@@ -10,6 +10,7 @@ declare global {
       settings: {
         get(): Promise<StoredSettings>;
         setHotkey(hotkey: StoredHotkey): Promise<StoredSettings>;
+        setBreakSafeApps(apps: string[]): Promise<StoredSettings>;
       };
     };
   }


### PR DESCRIPTION
Part of #19 (the remaining scope after hotkey remapping shipped in #118): the break-safe app allow-list was hardcoded to 4 apps (TextEdit, Notes, Obsidian, VS Code) and not user-editable. This adds a settings screen for it.

## What changed

- **electron/breakSafety.js**: the allow-list was a `const Set` module constant. Now it's module-level mutable state with `setBreakSafeApplications()`/`getBreakSafeApplications()` setters/getters alongside the existing `isBreakSafeApplication()`. Same default list, same deny-by-default posture - `dictationCoordinator.js`'s existing `isBreakSafeApplication` import is untouched, it just reads whatever the current Set contains now instead of a frozen one.
- **electron/settingsStore.js**: `setBreakSafeApps()` mirrors `setHotkey()`'s shape exactly - validates (array of non-blank bundle-id strings; an *empty* array is explicitly allowed, since denying every app is a valid, safety-preserving choice, not an error), trims and dedupes, persists to disk, leaves the previous value untouched on a rejected write. `DEFAULT_SETTINGS.breakSafeApps` is imported from `breakSafety.js`'s own default rather than duplicated, so the two constants can't drift apart.
- **electron/main.js / preload.js**: `settings:set-break-safe-apps` IPC handler mirrors `settings:set-hotkey` - persist, then push the new list live into `breakSafety.js` so an edit takes effect on the very next dictation with no restart needed (same as hotkey remapping already does). Also applies the persisted list on startup.
- **src/BreakSafeAppsSettings.tsx**: new settings screen, mounted in `App.tsx` alongside `HotkeySettings`. Follows its established pattern (fetch on mount, save through `window.openstream.settings`, surface a rejected save as an inline error). List add/remove is simple enough it didn't need its own pure-logic module the way hotkey capture did.
- **electron/breakSafety.test.js** (new) + additions to **settingsStore.test.js**: 10 new test cases covering the setter/getter, dedup, empty-list-is-valid, and rejection paths.

## Verification

`tsc --noEmit` clean. `node --test "electron/**/*.test.js"`: 92 pass / 0 fail (up from 82 before this PR - 10 new tests, all passing). The 2 cancelled tests in `breakPlacementHttpAdapter.test.js` are pre-existing and unrelated (confirmed by stashing this change out and re-running against unmodified `main` - same cancellation happens either way). `dictationCoordinator.test.js` specifically re-run in isolation (17/17) to confirm the default break-safe behavior it relies on is unchanged.

Couldn't run `npm run build`'s vite step locally (this sandbox's Node 21.6.1 is below the `>=22.12.0` the toolchain now needs) - CI runs Node 22.12 so this isn't a real gap.
