### PR TITLE
Detect spoken bullet list cues and format as markdown lists

### DIFF
--- a/electron/cleanup/rules.js
+++ b/electron/cleanup/rules.js
@@ -26,6 +26,15 @@ const LEADING_FILLERS = [
 const SPOKEN_PUNCT = [
   [/\bnew paragraph\b/gi, "\n\n"],
   [/\bnew line\b/gi, "\n"],
+  // #124: scoped to explicit trigger phrases only, not the ordinal-word
+  // heuristic ("first," ... "second," ...) the issue leaves open - that
+  // heuristic risks misfiring on ordinary prose ("first, second, and
+  // third, I want to say thanks" is one flowing sentence, not a list), and
+  // an explicit command is unambiguous the same way #131's emoji triggers
+  // are. Also scoped to bullets only, not numbered lists - a "1. 2. 3."
+  // marker needs a running counter across matches, a different shape of
+  // transformation than this table's stateless single-token replace.
+  [/\b(bullet point|new bullet)\b/gi, "\n- "],
   [/\bfull stop\b/gi, "."],
   [/\bperiod\b/gi, "."],
   [/\bcomma\b/gi, ","],
@@ -107,14 +116,22 @@ function collapseRepeats(text) {
 
 function applySpokenPunct(text, { allowNewlines }) {
   for (const [pattern, replacement] of SPOKEN_PUNCT) {
-    // Deny-by-default (#45 §3): a spoken newline command only becomes a
-    // literal newline when the frontmost app is on the break-safe allow-list.
-    const isNewline = replacement === "\n" || replacement === "\n\n";
+    // Deny-by-default (#45 §3): a spoken newline command - including a
+    // bullet marker (#124), which is a newline too - only becomes literal
+    // when the frontmost app is on the break-safe allow-list. Same
+    // degrade-to-space fallback as new line/new paragraph: outside a
+    // break-safe app, "bullet point" just doesn't start a new line, rather
+    // than silently dropping the dash into the middle of a sentence.
+    const isNewline = replacement === "\n" || replacement === "\n\n" || replacement === "\n- ";
     text = text.replace(pattern, isNewline && !allowNewlines ? " " : replacement);
   }
   // Tidy the space the replaced word left behind: " ." -> "."
   text = text.replace(/\s+([.,!?;:)])/g, "$1");
-  text = text.replace(/([(/-])\s+/g, "$1");
+  // (?<!\n): a dash right after a newline is #124's list marker, which
+  // needs its trailing space ("- item") - unlike the hyphen use of "dash"
+  // (SPOKEN_PUNCT's own pattern for that already consumes its surrounding
+  // whitespace, so this tidy rule matching dash at all is redundant there).
+  text = text.replace(/(?<!\n)([(/-])\s+/g, "$1");
   // Same tidy for a newline a spoken "new line"/"new paragraph" just inserted.
   text = text.replace(/[ \t]+\n/g, "\n").replace(/\n[ \t]+/g, "\n");
   // whisper often already punctuated the sentence, so a spoken "period" can
@@ -205,7 +222,17 @@ function capitalise(text) {
   text = text.replace(/\bi\b/g, "I");
   text = text.replace(/\bi'(m|ve|ll|d)\b/g, (_match, suffix) => "I'" + suffix);
   const parts = text.split(SENT_BOUNDARY_SPLIT);
-  return parts.map((part) => (part && /[a-zA-Z]/.test(part[0]) ? part[0].toUpperCase() + part.slice(1) : part)).join("");
+  return parts
+    .map((part) => {
+      // A #124 bullet marker sits before the sentence-start letter, not on
+      // it - "- milk" should capitalise to "- Milk", not leave the marker's
+      // dash mistaken for the first character.
+      const marker = part.match(/^-\s+/);
+      const prefix = marker ? marker[0] : "";
+      const rest = part.slice(prefix.length);
+      return rest && /[a-zA-Z]/.test(rest[0]) ? prefix + rest[0].toUpperCase() + rest.slice(1) : part;
+    })
+    .join("");
 }
 
 function terminalPunct(text) {

--- a/electron/cleanup/rules.test.js
+++ b/electron/cleanup/rules.test.js
@@ -134,6 +134,31 @@ test("one-line box overrides break-safe: still no newline", () => {
   assert.ok(!out.includes("\n"));
 });
 
+test("bullet point / new bullet start a markdown list, break-safe only", () => {
+  const out = cleanup("shopping list bullet point milk bullet point eggs", { breakSafe: true });
+  assert.equal(out, "Shopping list\n- Milk\n- Eggs.");
+
+  const outAlt = cleanup("shopping list new bullet milk new bullet eggs", { breakSafe: true });
+  assert.equal(outAlt, "Shopping list\n- Milk\n- Eggs.");
+});
+
+test("bullet point outside a break-safe app degrades to flowing prose, no dash leaks in", () => {
+  const out = cleanup("shopping list bullet point milk bullet point eggs");
+  assert.equal(out, "Shopping list milk eggs.");
+  assert.ok(!out.includes("-"));
+  assert.ok(!out.includes("\n"));
+});
+
+test("bullet point in a one-line field also degrades, even if the app is break-safe", () => {
+  const out = cleanup("milk bullet point eggs", { breakSafe: true, oneLineBox: true });
+  assert.equal(out, "Milk eggs");
+});
+
+test("bullet marker doesn't break unrelated dash/paren tidy-up", () => {
+  assert.equal(cleanup("alpha dash beta"), "Alpha-beta.");
+  assert.equal(cleanup("call open paren now close paren"), "Call (now).");
+});
+
 test("segments long run-ons on conjunctions", () => {
   const out = cleanup(samples.find((s) => s.id === "sent-3").messy);
   assert.ok(out.includes(". "), "expected at least one inserted sentence break");


### PR DESCRIPTION
Closes #124.

## Scope decision

The issue leaves the trigger design open, so I made a call and want to be upfront about it: this is deliberately narrow.

- **Explicit trigger phrases only** ("bullet point", "new bullet"), not the ordinal-word heuristic ("first," ... "second," ...) the issue also raises. That heuristic risks misfiring on ordinary prose - the issue's own counter-example, "first, second, and third, I want to say thanks," is one flowing sentence, not a list. An explicit command is unambiguous the same way #131's emoji triggers are (every emoji trigger requires the literal word "emoji" for the same reason). The ordinal-word heuristic is left as a follow-up, to be measured against real dictation samples per #15's eval-set job rather than guessed at.
- **Bullets only, not numbered lists.** A "1. 2. 3." marker needs a running counter across matches - a materially different shape of transformation than this table's stateless single-token `.replace()` loop. The issue itself leaves numbered-vs-bullet rendering as an open question, so scoping it out rather than guessing.

This mirrors how #127 scoped itself (rules-only case now, ambiguous/harder case as a follow-up).

## What it does

"bullet point" / "new bullet" insert `\n- ` - same mechanism as the existing `new line`/`new paragraph` entries in `SPOKEN_PUNCT`, and gated by the same break-safe allow-list: a literal newline can submit a terminal command or send an unfinished message, so outside a break-safe app (or in a one-line field) "bullet point" degrades to a plain space instead of a newline, exactly like `new line` already does - never a bare dash dropped into the middle of a sentence.

```
"shopping list bullet point milk bullet point eggs" (break-safe)
  -> "Shopping list\n- Milk\n- Eggs."

"shopping list bullet point milk bullet point eggs" (not break-safe)
  -> "Shopping list milk eggs."
```

## Two things the new marker collided with

- The dash/paren whitespace tidy-up (`([(/-])\s+` -> strips the space after `(`, `/`, or `-`) was also stripping the space right after the list marker's dash, since dash-as-hyphen ("alpha dash beta") and the list marker share the same character. Added a negative lookbehind so a dash immediately after a newline (the list marker) is left alone; the hyphen case is unaffected since `SPOKEN_PUNCT`'s own "dash" pattern already consumes its surrounding whitespace before this tidy step even runs.
- `capitalise()` looked at each sentence-part's first character to decide what to uppercase. For `"- milk"` that first character is the dash, not the word, so it silently skipped capitalizing the actual content. It now looks past a leading `- ` marker before deciding what to capitalize.

## Verification

`electron/cleanup/rules.test.js`: 23/23 pass (4 new cases: bullet/new-bullet forming a list, degrading outside break-safe, degrading in a one-line field even when break-safe, and confirming the dash/paren fix didn't regress the existing "alpha dash beta" / "call open paren now close paren" cases). The existing latency-budget test (`< 5ms` ceiling, ~0.15ms measured) and the sweep-invariants test over the real sample set both still pass with the new rule added - no regression, no measurable cost. Full suite: 96/96 relevant pass (2 pre-existing unrelated cancellations in `breakPlacementHttpAdapter.test.js`, confirmed pre-existing in earlier PRs this session).
