### PR TITLE
feat: handle spoken self-correction ("scratch that", "delete that")

### DIFF
--- a/electron/cleanup/rules.js
+++ b/electron/cleanup/rules.js
@@ -83,6 +83,28 @@ const VOCAB = [
 const SENT_END = /(?<=[.!?])\s+/;
 const SENT_BOUNDARY_SPLIT = /(\n+|(?<=[.!?])\s+)/;
 
+// Self-correction (#127): "scratch that"/"delete that" means the clause
+// immediately before it should be discarded, not just the trigger phrase -
+// stripping only the phrase (as PHRASE_FILLERS would) leaves both versions
+// in the output ("buy milk buy oat milk"). The lookahead requires the
+// trigger to be followed by a pause (punctuation or end of input), not more
+// words in the same breath, so "delete that file"/"delete that branch" -
+// very plausible content in a dev-focused dictation tool - are left alone.
+//
+// Scope: only the clause in the same comma/sentence run as the trigger.
+// Reaching back across an already-finished earlier sentence ("no wait, I
+// meant the second one") isn't reliably regex-matchable; per #127 that's a
+// future #125-shaped follow-up (ask the rewrite model which sentence a
+// correction refers to). Until then, a trigger with nothing to delete in
+// its own run (e.g. it lands right after a full stop) is simply dropped as
+// a safe no-op rather than guessing which earlier sentence it means.
+const SELF_CORRECTION =
+  /(?:^|(?<=[.!?,]\s))[^.!?,]*?,?\s*\b(?:scratch|delete) that\b(?=[.,!?]|\s*$)[.,!?]?\s*/gi;
+
+function applySelfCorrection(text) {
+  return text.replace(SELF_CORRECTION, "");
+}
+
 function stripFillers(text) {
   for (const phrase of PHRASE_FILLERS) {
     text = text.replace(new RegExp(`\\b${phrase}\\b[,]?\\s*`, "gi"), "");
@@ -236,6 +258,7 @@ function cleanup(text, options = {}) {
   // something the speaker said, and must go before anything else runs.
   text = text.replace(/\s*\n\s*/g, " ");
 
+  text = applySelfCorrection(text);
   text = stripFillers(text);
   text = collapseRepeats(text);
   text = applySpokenPunct(text, { allowNewlines });
@@ -264,6 +287,8 @@ module.exports = {
   VOCAB,
   SENT_END,
   SENT_BOUNDARY_SPLIT,
+  SELF_CORRECTION,
+  applySelfCorrection,
   stripFillers,
   collapseRepeats,
   applySpokenPunct,

--- a/electron/cleanup/rules.test.js
+++ b/electron/cleanup/rules.test.js
@@ -99,6 +99,41 @@ test("applies technical vocabulary fixups", () => {
   }
 });
 
+test("handles spoken self-correction by discarding the preceding clause", () => {
+  const cases = [
+    ["buy milk, scratch that, buy oat milk", "Buy oat milk."],
+    ["call the doctor, delete that, call the dentist", "Call the dentist."],
+    ["scratch that, buy milk", "Buy milk."],
+    [
+      "get eggs, scratch that, get bacon, scratch that, get bread",
+      "Get bread.",
+    ],
+  ];
+
+  for (const [raw, expected] of cases) {
+    assert.equal(cleanup(raw), expected, raw);
+  }
+});
+
+test("does not treat 'delete that <noun>' as a correction command", () => {
+  // #127's design: the trigger only fires when followed by a pause, not
+  // more words in the same breath - "delete that file"/"delete that
+  // branch" are extremely plausible dictated content in a dev tool.
+  assert.equal(cleanup("please delete that file"), "Please delete that file.");
+  assert.equal(cleanup("delete that branch before you push"), "Delete that branch before you push.");
+});
+
+test("self-correction: a trigger right after a finished sentence is a known limitation", () => {
+  // Reaching back into an already-finished earlier sentence isn't
+  // regex-matchable (see #127's scoping note) - the trigger phrase itself
+  // is dropped as a safe no-op rather than guessing which sentence to
+  // delete, leaving the mistaken sentence in place.
+  assert.equal(
+    cleanup("Call the client today. Scratch that. Call them tomorrow instead."),
+    "Call the client today. Call them tomorrow instead."
+  );
+});
+
 test("capitalises sentence starts and bare i", () => {
   assert.equal(cleanup("i think i am ready"), "I think I am ready.");
 });


### PR DESCRIPTION
## Summary
- `scratch that` / `delete that` now discards the clause immediately before the trigger, not just the phrase itself - stripping only the phrase (as a plain filler would) left both the wrong and right versions in the output (`buy milk buy oat milk`)
- Gated behind a lookahead requiring a pause right after the trigger, so `delete that file` / `delete that branch` - plausible content in a dev-focused dictation tool - aren't caught by mistake
- Reaching back across an already-finished earlier sentence is out of scope for a regex-only rule per #127's own scoping note - left as a safe no-op (drops just the trigger, keeps the mistaken sentence) rather than guessing, flagged as future #125-shaped follow-up

Closes #127.

## Test plan
- [x] `node --test electron/cleanup/rules.test.js` - all 22 pass (3 new)
- [x] Full suite (`node --test "electron/**/*.test.js"`) - only pre-existing, environmental failures unrelated to this change (`breakPlacementHttpAdapter.test.js`, `rewriteModelServer.test.js` need a local `llama-server` binary/model not present here); confirmed by stashing and re-running against clean `main`