### PR TITLE
Convert spoken code-structure symbols for dictating into an editor

### DIFF
--- a/electron/cleanup/rules.js
+++ b/electron/cleanup/rules.js
@@ -26,6 +26,15 @@ const LEADING_FILLERS = [
 const SPOKEN_PUNCT = [
   [/\bnew paragraph\b/gi, "\n\n"],
   [/\bnew line\b/gi, "\n"],
+  // #124: scoped to explicit trigger phrases only, not the ordinal-word
+  // heuristic ("first," ... "second," ...) the issue leaves open - that
+  // heuristic risks misfiring on ordinary prose ("first, second, and
+  // third, I want to say thanks" is one flowing sentence, not a list), and
+  // an explicit command is unambiguous the same way #131's emoji triggers
+  // are. Also scoped to bullets only, not numbered lists - a "1. 2. 3."
+  // marker needs a running counter across matches, a different shape of
+  // transformation than this table's stateless single-token replace.
+  [/\b(bullet point|new bullet)\b/gi, "\n- "],
   [/\bfull stop\b/gi, "."],
   [/\bperiod\b/gi, "."],
   [/\bcomma\b/gi, ","],
@@ -107,14 +116,22 @@ function collapseRepeats(text) {
 
 function applySpokenPunct(text, { allowNewlines }) {
   for (const [pattern, replacement] of SPOKEN_PUNCT) {
-    // Deny-by-default (#45 §3): a spoken newline command only becomes a
-    // literal newline when the frontmost app is on the break-safe allow-list.
-    const isNewline = replacement === "\n" || replacement === "\n\n";
+    // Deny-by-default (#45 §3): a spoken newline command - including a
+    // bullet marker (#124), which is a newline too - only becomes literal
+    // when the frontmost app is on the break-safe allow-list. Same
+    // degrade-to-space fallback as new line/new paragraph: outside a
+    // break-safe app, "bullet point" just doesn't start a new line, rather
+    // than silently dropping the dash into the middle of a sentence.
+    const isNewline = replacement === "\n" || replacement === "\n\n" || replacement === "\n- ";
     text = text.replace(pattern, isNewline && !allowNewlines ? " " : replacement);
   }
   // Tidy the space the replaced word left behind: " ." -> "."
   text = text.replace(/\s+([.,!?;:)])/g, "$1");
-  text = text.replace(/([(/-])\s+/g, "$1");
+  // (?<!\n): a dash right after a newline is #124's list marker, which
+  // needs its trailing space ("- item") - unlike the hyphen use of "dash"
+  // (SPOKEN_PUNCT's own pattern for that already consumes its surrounding
+  // whitespace, so this tidy rule matching dash at all is redundant there).
+  text = text.replace(/(?<!\n)([(/-])\s+/g, "$1");
   // Same tidy for a newline a spoken "new line"/"new paragraph" just inserted.
   text = text.replace(/[ \t]+\n/g, "\n").replace(/\n[ \t]+/g, "\n");
   // whisper often already punctuated the sentence, so a spoken "period" can
@@ -205,7 +222,17 @@ function capitalise(text) {
   text = text.replace(/\bi\b/g, "I");
   text = text.replace(/\bi'(m|ve|ll|d)\b/g, (_match, suffix) => "I'" + suffix);
   const parts = text.split(SENT_BOUNDARY_SPLIT);
-  return parts.map((part) => (part && /[a-zA-Z]/.test(part[0]) ? part[0].toUpperCase() + part.slice(1) : part)).join("");
+  return parts
+    .map((part) => {
+      // A #124 bullet marker sits before the sentence-start letter, not on
+      // it - "- milk" should capitalise to "- Milk", not leave the marker's
+      // dash mistaken for the first character.
+      const marker = part.match(/^-\s+/);
+      const prefix = marker ? marker[0] : "";
+      const rest = part.slice(prefix.length);
+      return rest && /[a-zA-Z]/.test(rest[0]) ? prefix + rest[0].toUpperCase() + rest.slice(1) : part;
+    })
+    .join("");
 }
 
 function terminalPunct(text) {

--- a/electron/cleanup/rules.js
+++ b/electron/cleanup/rules.js
@@ -56,6 +56,24 @@ const SPOKEN_PUNCT = [
   [/\bdollar sign\b[ \t]*/gi, "$"],
   [/[ \t]*\bat sign\b[ \t]*/gi, "@"],
   [/\bhashtag\b[ \t]*/gi, "#"],
+  // #129: code-structure symbols, exact same shape as open/close paren
+  // above - the general-punctuation tidy-up below (applySpokenPunct)
+  // already handles the surrounding-whitespace trim for both bracket
+  // types, same as it does for parens.
+  //
+  // Deliberately does not implement "tab"/"indent" (whitespace-inserting,
+  // like a newline, so it would need breakSafe-style gating - but per the
+  // issue, a literal tab only makes sense in a *code editor*, a narrower
+  // set than the general breakSafeApps list Notes/TextEdit also sit on,
+  // and this repo has no such sub-list yet) or case conversion ("snake
+  // case get user name" -> get_user_name - a pattern-based rewrite closer
+  // to applyVocab's shape than this table's literal substitution, and the
+  // issue itself asks whether it belongs in this ticket or its own).
+  // Both left as follow-ups needing their own design decision.
+  [/\bopen brace\b/gi, "{"],
+  [/\bclose brace\b/gi, "}"],
+  [/\bopen bracket\b/gi, "["],
+  [/\bclose bracket\b/gi, "]"],
 ];
 
 // Casual messaging emoji (#131). Every trigger ends in the explicit word
@@ -135,13 +153,15 @@ function applySpokenPunct(text, { allowNewlines }) {
     const isNewline = replacement === "\n" || replacement === "\n\n" || replacement === "\n- ";
     text = text.replace(pattern, isNewline && !allowNewlines ? " " : replacement);
   }
-  // Tidy the space the replaced word left behind: " ." -> "."
-  text = text.replace(/\s+([.,!?;:)])/g, "$1");
+  // Tidy the space the replaced word left behind: " ." -> "." - ] and }
+  // (#129) get the same treatment as the ) they're modelled on.
+  text = text.replace(/\s+([.,!?;:)\]}])/g, "$1");
   // (?<!\n): a dash right after a newline is #124's list marker, which
   // needs its trailing space ("- item") - unlike the hyphen use of "dash"
   // (SPOKEN_PUNCT's own pattern for that already consumes its surrounding
   // whitespace, so this tidy rule matching dash at all is redundant there).
-  text = text.replace(/(?<!\n)([(/-])\s+/g, "$1");
+  // [ and { (#129) get the same leading-side trim as the ( they're modelled on.
+  text = text.replace(/(?<!\n)([(/\-[{])\s+/g, "$1");
   // Same tidy for a newline a spoken "new line"/"new paragraph" just inserted.
   text = text.replace(/[ \t]+\n/g, "\n").replace(/\n[ \t]+/g, "\n");
   // whisper often already punctuated the sentence, so a spoken "period" can

--- a/electron/cleanup/rules.js
+++ b/electron/cleanup/rules.js
@@ -46,6 +46,16 @@ const SPOKEN_PUNCT = [
   [/\bclose paren(thesis)?\b/gi, ")"],
   [/[ \t]*\bdash\b[ \t]*/gi, "-"],
   [/[ \t]*\bslash\b[ \t]*/gi, "/"],
+  // #128: symbols, same table shape as the punctuation above them. Each
+  // self-trims whitespace on whichever side it naturally attaches to in
+  // real usage, matching how open/close paren already do this
+  // asymmetrically rather than uniformly - "fifty percent" -> "50%" (no
+  // space before the mark), "dollar sign fifty" -> "$50" (none after),
+  // "at sign" attaches on both sides like dash does.
+  [/[ \t]*\bpercent\b/gi, "%"],
+  [/\bdollar sign\b[ \t]*/gi, "$"],
+  [/[ \t]*\bat sign\b[ \t]*/gi, "@"],
+  [/\bhashtag\b[ \t]*/gi, "#"],
 ];
 
 // Casual messaging emoji (#131). Every trigger ends in the explicit word
@@ -153,6 +163,24 @@ function applySpokenEmoji(text) {
   return text;
 }
 
+// #128: "quote ... end quote" wraps the spoken span in "...". Unlike a
+// newline, a quotation mark carries no functional risk in any app - it
+// can't submit a form or send a message - so this is never gated behind
+// breakSafe/oneLineBox, the same reasoning SPOKEN_EMOJI already uses.
+// Non-greedy + the g flag: "quote a end quote and quote b end quote"
+// matches each pair separately rather than spanning from the first
+// "quote" to the last "end quote".
+//
+// Scoped to quoting only, not "bold ... end bold" or similar markdown
+// emphasis - #128 itself flags that literal **markdown** characters are
+// meaningful in Slack or a markdown editor but wrong in a plain-text field
+// or code file, which needs its own app-context gate this repo doesn't
+// have yet (breakSafeApps governs newline safety, a different concern).
+// Left as a follow-up rather than guessing at that gate here.
+function applyQuoteMarkers(text) {
+  return text.replace(/\bquote\b\s+(.+?)\s+\bend quote\b/gi, (_match, inner) => `"${inner}"`);
+}
+
 function stripLeadingFillers(text) {
   const parts = text.split(SENT_BOUNDARY_SPLIT);
   const out = [];
@@ -224,11 +252,11 @@ function capitalise(text) {
   const parts = text.split(SENT_BOUNDARY_SPLIT);
   return parts
     .map((part) => {
-      // A #124 bullet marker sits before the sentence-start letter, not on
-      // it - "- milk" should capitalise to "- Milk", not leave the marker's
-      // dash mistaken for the first character.
-      const marker = part.match(/^-\s+/);
-      const prefix = marker ? marker[0] : "";
+      // A #124 bullet marker and/or a #128 opening quote can sit before the
+      // sentence-start letter without being it - "- milk" should capitalise
+      // to "- Milk", and a quote opening a sentence ("hello) to ("Hello,
+      // not leave the marker/quote mistaken for the first character.
+      const prefix = part.match(/^(-\s+)?"?/)[0];
       const rest = part.slice(prefix.length);
       return rest && /[a-zA-Z]/.test(rest[0]) ? prefix + rest[0].toUpperCase() + rest.slice(1) : part;
     })
@@ -267,6 +295,7 @@ function cleanup(text, options = {}) {
   text = collapseRepeats(text);
   text = applySpokenPunct(text, { allowNewlines });
   text = applySpokenEmoji(text);
+  text = applyQuoteMarkers(text);
   text = stripLeadingFillers(text);
   if (!oneLineBox) {
     text = segmentSentences(text);
@@ -295,6 +324,7 @@ module.exports = {
   collapseRepeats,
   applySpokenPunct,
   applySpokenEmoji,
+  applyQuoteMarkers,
   stripLeadingFillers,
   segmentSentences,
   applyVocab,

--- a/electron/cleanup/rules.test.js
+++ b/electron/cleanup/rules.test.js
@@ -166,6 +166,22 @@ test("converts spoken symbols", () => {
   }
 });
 
+test("converts spoken code-structure symbols", () => {
+  const cases = [
+    ["call open brace now close brace", "Call {now}."],
+    ["call open bracket now close bracket", "Call [now]."],
+  ];
+  for (const [raw, expected] of cases) {
+    assert.equal(cleanup(raw), expected, raw);
+  }
+});
+
+test("brace/bracket symbols don't regress paren, dash, or percent tidy-up", () => {
+  assert.equal(cleanup("call open paren now close paren"), "Call (now).");
+  assert.equal(cleanup("alpha dash beta"), "Alpha-beta.");
+  assert.equal(cleanup("fifty percent off"), "Fifty% off.");
+});
+
 test("quote ... end quote wraps the spoken span, unconditionally (no break-safe gating)", () => {
   assert.equal(cleanup("he said quote hello world end quote"), "He said \"hello world\".");
   // Not gated behind breakSafe, unlike a newline - a quote character carries

--- a/electron/cleanup/rules.test.js
+++ b/electron/cleanup/rules.test.js
@@ -154,6 +154,40 @@ test("bullet point in a one-line field also degrades, even if the app is break-s
   assert.equal(out, "Milk eggs");
 });
 
+test("converts spoken symbols", () => {
+  const cases = [
+    ["fifty percent off", "Fifty% off."],
+    ["dollar sign fifty", "$fifty."],
+    ["email me at john at sign gmail dot com", "Email me at john@gmail dot com."],
+    ["share hashtag opensource", "Share #opensource."],
+  ];
+  for (const [raw, expected] of cases) {
+    assert.equal(cleanup(raw), expected, raw);
+  }
+});
+
+test("quote ... end quote wraps the spoken span, unconditionally (no break-safe gating)", () => {
+  assert.equal(cleanup("he said quote hello world end quote"), "He said \"hello world\".");
+  // Not gated behind breakSafe, unlike a newline - a quote character carries
+  // no functional risk in any app.
+  assert.equal(
+    cleanup("he said quote hello world end quote", { breakSafe: false }),
+    "He said \"hello world\"."
+  );
+});
+
+test("quote markers handle multiple separate pairs in one dictation", () => {
+  assert.equal(cleanup("quote hello end quote and quote goodbye end quote"), "\"Hello\" and \"goodbye\".");
+});
+
+test("a quote opening a sentence still gets its content capitalised", () => {
+  assert.equal(cleanup("quote welcome end quote to the show"), "\"Welcome\" to the show.");
+});
+
+test("an unclosed quote (no matching end quote) is left untouched rather than guessed at", () => {
+  assert.equal(cleanup("he said quote hello"), "He said quote hello.");
+});
+
 test("bullet marker doesn't break unrelated dash/paren tidy-up", () => {
   assert.equal(cleanup("alpha dash beta"), "Alpha-beta.");
   assert.equal(cleanup("call open paren now close paren"), "Call (now).");

--- a/electron/cleanup/rules.test.js
+++ b/electron/cleanup/rules.test.js
@@ -134,6 +134,31 @@ test("one-line box overrides break-safe: still no newline", () => {
   assert.ok(!out.includes("\n"));
 });
 
+test("bullet point / new bullet start a markdown list, break-safe only", () => {
+  const out = cleanup("shopping list bullet point milk bullet point eggs", { breakSafe: true });
+  assert.equal(out, "Shopping list\n- Milk\n- Eggs.");
+
+  const outAlt = cleanup("shopping list new bullet milk new bullet eggs", { breakSafe: true });
+  assert.equal(outAlt, "Shopping list\n- Milk\n- Eggs.");
+});
+
+test("bullet point outside a break-safe app degrades to flowing prose, no dash leaks in", () => {
+  const out = cleanup("shopping list bullet point milk bullet point eggs");
+  assert.equal(out, "Shopping list milk eggs.");
+  assert.ok(!out.includes("-"));
+  assert.ok(!out.includes("\n"));
+});
+
+test("bullet point in a one-line field also degrades, even if the app is break-safe", () => {
+  const out = cleanup("milk bullet point eggs", { breakSafe: true, oneLineBox: true });
+  assert.equal(out, "Milk eggs");
+});
+
+test("bullet marker doesn't break unrelated dash/paren tidy-up", () => {
+  assert.equal(cleanup("alpha dash beta"), "Alpha-beta.");
+  assert.equal(cleanup("call open paren now close paren"), "Call (now).");
+});
+
 test("segments long run-ons on conjunctions", () => {
   const out = cleanup(samples.find((s) => s.id === "sent-3").messy);
   assert.ok(out.includes(". "), "expected at least one inserted sentence break");


### PR DESCRIPTION
Closes #129.

**Stacked on #164 (#128)**, which is stacked on #162 (#124) - all three touch `SPOKEN_PUNCT`/`applySpokenPunct` in the same file. Merge in order (#162 -> #164 -> this one) and each PR's diff shrinks to just its own change; happy to rebase instead if you'd rather review them independently.

**Heads up separately:** there's a branch named `feat/spoken-code-symbols-129` already checked out in the primary working directory (not this worktree) with no commits on it yet - I don't know if that's your own in-progress work or something else, so I didn't touch it and used a different branch name here (`feat/spoken-code-structure-symbols-129`) to stay out of its way. Worth checking what that branch actually is before it's forgotten.

## What it does

Open/close brace and open/close bracket, exact same shape as the existing open/close paren entries in `SPOKEN_PUNCT`:

- "call open brace now close brace" -> "Call {now}."
- "call open bracket now close bracket" -> "Call [now]."

Extended the two whitespace tidy-up regexes in `applySpokenPunct` to cover `}`/`]` alongside `)` on the closing side, and `{`/`[` alongside `(` on the opening side - otherwise the space around a brace/bracket would be left in ("Call { now }." instead of "Call {now}.").

## What I deliberately did not build

The issue names two more things, and both need a real design decision I didn't think was mine to make inside this PR:

- **"Tab"/"indent"** - these insert whitespace, same functional-risk class as a newline, so they'd need `breakSafe`-style gating. But per the issue, a literal tab only makes sense in a *code editor* specifically - it'd be wrong to insert in Notes or TextEdit even though both are on the general `breakSafeApps` list. That means the existing allow-list is the wrong gate for this; it needs its own narrower sub-list, which this repo doesn't have yet. Left as a follow-up.
- **Case conversion** ("snake case get user name" -> `get_user_name`, "camel case" -> `getUserName`) - the issue itself asks whether this belongs in this ticket or its own. It's a pattern-based rewrite (parse a spoken phrase, re-case it) closer in shape to `applyVocab` than to this table's literal single-token substitution, so it's a different kind of change, not a natural extension of this PR's scope.

Same scoping pattern #124 and #128 already used for their own open questions.

## Verification

`electron/cleanup/rules.test.js`: 30/30 pass (2 new cases: the brace/bracket conversions themselves, and a regression check confirming the extended tidy-up regexes didn't change paren/dash/percent behavior). Full suite: 103/106 (same 2 pre-existing unrelated cancellations and 1 pre-existing skip as the last two PRs this session).
