### PR TITLE
Convert spoken currency amounts to digit form

### DIFF
--- a/electron/cleanup/rules.js
+++ b/electron/cleanup/rules.js
@@ -56,6 +56,24 @@ const SPOKEN_PUNCT = [
   [/\bdollar sign\b[ \t]*/gi, "$"],
   [/[ \t]*\bat sign\b[ \t]*/gi, "@"],
   [/\bhashtag\b[ \t]*/gi, "#"],
+  // #129: code-structure symbols, exact same shape as open/close paren
+  // above - the general-punctuation tidy-up below (applySpokenPunct)
+  // already handles the surrounding-whitespace trim for both bracket
+  // types, same as it does for parens.
+  //
+  // Deliberately does not implement "tab"/"indent" (whitespace-inserting,
+  // like a newline, so it would need breakSafe-style gating - but per the
+  // issue, a literal tab only makes sense in a *code editor*, a narrower
+  // set than the general breakSafeApps list Notes/TextEdit also sit on,
+  // and this repo has no such sub-list yet) or case conversion ("snake
+  // case get user name" -> get_user_name - a pattern-based rewrite closer
+  // to applyVocab's shape than this table's literal substitution, and the
+  // issue itself asks whether it belongs in this ticket or its own).
+  // Both left as follow-ups needing their own design decision.
+  [/\bopen brace\b/gi, "{"],
+  [/\bclose brace\b/gi, "}"],
+  [/\bopen bracket\b/gi, "["],
+  [/\bclose bracket\b/gi, "]"],
 ];
 
 // Casual messaging emoji (#131). Every trigger ends in the explicit word
@@ -135,13 +153,15 @@ function applySpokenPunct(text, { allowNewlines }) {
     const isNewline = replacement === "\n" || replacement === "\n\n" || replacement === "\n- ";
     text = text.replace(pattern, isNewline && !allowNewlines ? " " : replacement);
   }
-  // Tidy the space the replaced word left behind: " ." -> "."
-  text = text.replace(/\s+([.,!?;:)])/g, "$1");
+  // Tidy the space the replaced word left behind: " ." -> "." - ] and }
+  // (#129) get the same treatment as the ) they're modelled on.
+  text = text.replace(/\s+([.,!?;:)\]}])/g, "$1");
   // (?<!\n): a dash right after a newline is #124's list marker, which
   // needs its trailing space ("- item") - unlike the hyphen use of "dash"
   // (SPOKEN_PUNCT's own pattern for that already consumes its surrounding
   // whitespace, so this tidy rule matching dash at all is redundant there).
-  text = text.replace(/(?<!\n)([(/-])\s+/g, "$1");
+  // [ and { (#129) get the same leading-side trim as the ( they're modelled on.
+  text = text.replace(/(?<!\n)([(/\-[{])\s+/g, "$1");
   // Same tidy for a newline a spoken "new line"/"new paragraph" just inserted.
   text = text.replace(/[ \t]+\n/g, "\n").replace(/\n[ \t]+/g, "\n");
   // whisper often already punctuated the sentence, so a spoken "period" can

--- a/electron/cleanup/rules.js
+++ b/electron/cleanup/rules.js
@@ -46,6 +46,16 @@ const SPOKEN_PUNCT = [
   [/\bclose paren(thesis)?\b/gi, ")"],
   [/[ \t]*\bdash\b[ \t]*/gi, "-"],
   [/[ \t]*\bslash\b[ \t]*/gi, "/"],
+  // #128: symbols, same table shape as the punctuation above them. Each
+  // self-trims whitespace on whichever side it naturally attaches to in
+  // real usage, matching how open/close paren already do this
+  // asymmetrically rather than uniformly - "fifty percent" -> "50%" (no
+  // space before the mark), "dollar sign fifty" -> "$50" (none after),
+  // "at sign" attaches on both sides like dash does.
+  [/[ \t]*\bpercent\b/gi, "%"],
+  [/\bdollar sign\b[ \t]*/gi, "$"],
+  [/[ \t]*\bat sign\b[ \t]*/gi, "@"],
+  [/\bhashtag\b[ \t]*/gi, "#"],
 ];
 
 // Casual messaging emoji (#131). Every trigger ends in the explicit word
@@ -153,6 +163,24 @@ function applySpokenEmoji(text) {
   return text;
 }
 
+// #128: "quote ... end quote" wraps the spoken span in "...". Unlike a
+// newline, a quotation mark carries no functional risk in any app - it
+// can't submit a form or send a message - so this is never gated behind
+// breakSafe/oneLineBox, the same reasoning SPOKEN_EMOJI already uses.
+// Non-greedy + the g flag: "quote a end quote and quote b end quote"
+// matches each pair separately rather than spanning from the first
+// "quote" to the last "end quote".
+//
+// Scoped to quoting only, not "bold ... end bold" or similar markdown
+// emphasis - #128 itself flags that literal **markdown** characters are
+// meaningful in Slack or a markdown editor but wrong in a plain-text field
+// or code file, which needs its own app-context gate this repo doesn't
+// have yet (breakSafeApps governs newline safety, a different concern).
+// Left as a follow-up rather than guessing at that gate here.
+function applyQuoteMarkers(text) {
+  return text.replace(/\bquote\b\s+(.+?)\s+\bend quote\b/gi, (_match, inner) => `"${inner}"`);
+}
+
 function stripLeadingFillers(text) {
   const parts = text.split(SENT_BOUNDARY_SPLIT);
   const out = [];
@@ -224,11 +252,11 @@ function capitalise(text) {
   const parts = text.split(SENT_BOUNDARY_SPLIT);
   return parts
     .map((part) => {
-      // A #124 bullet marker sits before the sentence-start letter, not on
-      // it - "- milk" should capitalise to "- Milk", not leave the marker's
-      // dash mistaken for the first character.
-      const marker = part.match(/^-\s+/);
-      const prefix = marker ? marker[0] : "";
+      // A #124 bullet marker and/or a #128 opening quote can sit before the
+      // sentence-start letter without being it - "- milk" should capitalise
+      // to "- Milk", and a quote opening a sentence ("hello) to ("Hello,
+      // not leave the marker/quote mistaken for the first character.
+      const prefix = part.match(/^(-\s+)?"?/)[0];
       const rest = part.slice(prefix.length);
       return rest && /[a-zA-Z]/.test(rest[0]) ? prefix + rest[0].toUpperCase() + rest.slice(1) : part;
     })
@@ -267,6 +295,7 @@ function cleanup(text, options = {}) {
   text = collapseRepeats(text);
   text = applySpokenPunct(text, { allowNewlines });
   text = applySpokenEmoji(text);
+  text = applyQuoteMarkers(text);
   text = stripLeadingFillers(text);
   if (!oneLineBox) {
     text = segmentSentences(text);
@@ -295,6 +324,7 @@ module.exports = {
   collapseRepeats,
   applySpokenPunct,
   applySpokenEmoji,
+  applyQuoteMarkers,
   stripLeadingFillers,
   segmentSentences,
   applyVocab,

--- a/electron/cleanup/rules.js
+++ b/electron/cleanup/rules.js
@@ -201,6 +201,81 @@ function applyQuoteMarkers(text) {
   return text.replace(/\bquote\b\s+(.+?)\s+\bend quote\b/gi, (_match, inner) => `"${inner}"`);
 }
 
+// #130: numeric entities. Scoped to currency only - the one category the
+// issue treats as relatively clear-cut ("unit-anchored patterns"). Phone
+// numbers/confirmation codes and dates/times are deliberately not
+// implemented here: the issue's own methodology is to measure what whisper
+// already renders correctly on real dictation samples before assuming a
+// gap exists (whisper often already emits digit sequences, not words), and
+// for dates it explicitly flags "leave it as prose, don't guess" as a
+// likely-correct outcome rather than a gap to fill. Neither of those is
+// something this change can verify without real audio samples, so both
+// are left as follow-ups rather than guessed at.
+const NUMBER_WORDS = {
+  // "a"/"an" as a number word only ever means one - "a hundred dollars",
+  // "a dollar" - the same idiom that already lets English speakers say
+  // "a hundred" instead of "one hundred".
+  a: 1, an: 1,
+  zero: 0, one: 1, two: 2, three: 3, four: 4, five: 5, six: 6, seven: 7, eight: 8, nine: 9,
+  ten: 10, eleven: 11, twelve: 12, thirteen: 13, fourteen: 14, fifteen: 15,
+  sixteen: 16, seventeen: 17, eighteen: 18, nineteen: 19,
+  twenty: 20, thirty: 30, forty: 40, fifty: 50, sixty: 60, seventy: 70, eighty: 80, ninety: 90,
+};
+
+// Parses a run of spoken number words (up to the thousands) into an
+// integer, standard English number-word grammar. Returns null on anything
+// unrecognised rather than guessing - a caller only substitutes the digit
+// form when this parses cleanly.
+function parseNumberWords(phrase) {
+  const words = phrase.toLowerCase().split(/[\s-]+/).filter((word) => word && word !== "and");
+  if (words.length === 0) return null;
+
+  let total = 0;
+  let current = 0;
+  for (const word of words) {
+    if (word in NUMBER_WORDS) {
+      current += NUMBER_WORDS[word];
+    } else if (word === "hundred") {
+      current = (current || 1) * 100;
+    } else if (word === "thousand") {
+      total += (current || 1) * 1000;
+      current = 0;
+    } else {
+      return null;
+    }
+  }
+  return total + current;
+}
+
+const NUMBER_WORD_PATTERN =
+  "(?:a|an|zero|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|thirteen|fourteen|fifteen|" +
+  "sixteen|seventeen|eighteen|nineteen|twenty|thirty|forty|fifty|sixty|seventy|eighty|ninety|hundred|" +
+  "thousand|and)";
+const NUMBER_PHRASE_PATTERN = `${NUMBER_WORD_PATTERN}(?:[\\s-]+${NUMBER_WORD_PATTERN})*`;
+
+function applyCurrency(text) {
+  // Combined form first, so a standalone "cents" pass below can't run on a
+  // span this pass already consumed.
+  text = text.replace(
+    new RegExp(`\\b(${NUMBER_PHRASE_PATTERN})\\s+dollars?\\s+and\\s+(${NUMBER_PHRASE_PATTERN})\\s+cents?\\b`, "gi"),
+    (match, dollarsWords, centsWords) => {
+      const dollars = parseNumberWords(dollarsWords);
+      const cents = parseNumberWords(centsWords);
+      if (dollars === null || cents === null || cents > 99) return match;
+      return `$${dollars}.${String(cents).padStart(2, "0")}`;
+    }
+  );
+  text = text.replace(new RegExp(`\\b(${NUMBER_PHRASE_PATTERN})\\s+dollars?\\b`, "gi"), (match, words) => {
+    const dollars = parseNumberWords(words);
+    return dollars === null ? match : `$${dollars}`;
+  });
+  text = text.replace(new RegExp(`\\b(${NUMBER_PHRASE_PATTERN})\\s+cents?\\b`, "gi"), (match, words) => {
+    const cents = parseNumberWords(words);
+    return cents === null || cents > 99 ? match : `$0.${String(cents).padStart(2, "0")}`;
+  });
+  return text;
+}
+
 function stripLeadingFillers(text) {
   const parts = text.split(SENT_BOUNDARY_SPLIT);
   const out = [];
@@ -316,6 +391,7 @@ function cleanup(text, options = {}) {
   text = applySpokenPunct(text, { allowNewlines });
   text = applySpokenEmoji(text);
   text = applyQuoteMarkers(text);
+  text = applyCurrency(text);
   text = stripLeadingFillers(text);
   if (!oneLineBox) {
     text = segmentSentences(text);
@@ -345,6 +421,8 @@ module.exports = {
   applySpokenPunct,
   applySpokenEmoji,
   applyQuoteMarkers,
+  parseNumberWords,
+  applyCurrency,
   stripLeadingFillers,
   segmentSentences,
   applyVocab,

--- a/electron/cleanup/rules.test.js
+++ b/electron/cleanup/rules.test.js
@@ -166,6 +166,22 @@ test("converts spoken symbols", () => {
   }
 });
 
+test("converts spoken code-structure symbols", () => {
+  const cases = [
+    ["call open brace now close brace", "Call {now}."],
+    ["call open bracket now close bracket", "Call [now]."],
+  ];
+  for (const [raw, expected] of cases) {
+    assert.equal(cleanup(raw), expected, raw);
+  }
+});
+
+test("brace/bracket symbols don't regress paren, dash, or percent tidy-up", () => {
+  assert.equal(cleanup("call open paren now close paren"), "Call (now).");
+  assert.equal(cleanup("alpha dash beta"), "Alpha-beta.");
+  assert.equal(cleanup("fifty percent off"), "Fifty% off.");
+});
+
 test("quote ... end quote wraps the spoken span, unconditionally (no break-safe gating)", () => {
   assert.equal(cleanup("he said quote hello world end quote"), "He said \"hello world\".");
   // Not gated behind breakSafe, unlike a newline - a quote character carries

--- a/electron/cleanup/rules.test.js
+++ b/electron/cleanup/rules.test.js
@@ -154,6 +154,40 @@ test("bullet point in a one-line field also degrades, even if the app is break-s
   assert.equal(out, "Milk eggs");
 });
 
+test("converts spoken symbols", () => {
+  const cases = [
+    ["fifty percent off", "Fifty% off."],
+    ["dollar sign fifty", "$fifty."],
+    ["email me at john at sign gmail dot com", "Email me at john@gmail dot com."],
+    ["share hashtag opensource", "Share #opensource."],
+  ];
+  for (const [raw, expected] of cases) {
+    assert.equal(cleanup(raw), expected, raw);
+  }
+});
+
+test("quote ... end quote wraps the spoken span, unconditionally (no break-safe gating)", () => {
+  assert.equal(cleanup("he said quote hello world end quote"), "He said \"hello world\".");
+  // Not gated behind breakSafe, unlike a newline - a quote character carries
+  // no functional risk in any app.
+  assert.equal(
+    cleanup("he said quote hello world end quote", { breakSafe: false }),
+    "He said \"hello world\"."
+  );
+});
+
+test("quote markers handle multiple separate pairs in one dictation", () => {
+  assert.equal(cleanup("quote hello end quote and quote goodbye end quote"), "\"Hello\" and \"goodbye\".");
+});
+
+test("a quote opening a sentence still gets its content capitalised", () => {
+  assert.equal(cleanup("quote welcome end quote to the show"), "\"Welcome\" to the show.");
+});
+
+test("an unclosed quote (no matching end quote) is left untouched rather than guessed at", () => {
+  assert.equal(cleanup("he said quote hello"), "He said quote hello.");
+});
+
 test("bullet marker doesn't break unrelated dash/paren tidy-up", () => {
   assert.equal(cleanup("alpha dash beta"), "Alpha-beta.");
   assert.equal(cleanup("call open paren now close paren"), "Call (now).");

--- a/electron/cleanup/rules.test.js
+++ b/electron/cleanup/rules.test.js
@@ -1,6 +1,6 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
-const { cleanup } = require("./rules");
+const { cleanup, parseNumberWords } = require("./rules");
 const samples = require("../../spike/llm-cleanup-latency/samples.json");
 
 test("removes standalone and phrase fillers", () => {
@@ -70,7 +70,11 @@ test("does not convert emoji words used as ordinary vocabulary", () => {
   assert.equal(cleanup("the fire alarm went off"), "The fire alarm went off.");
   assert.equal(cleanup("she was laughing the whole time"), "She was laughing the whole time.");
   assert.equal(cleanup("he gave a thumbs up gesture"), "He gave a thumbs up gesture.");
-  assert.equal(cleanup("we need a hundred dollars"), "We need a hundred dollars.");
+  // "a hundred dollars" is correctly converted to "$100" by #130's currency
+  // rule - a separate, later feature. That's the right behavior now, not a
+  // regression: this test's job is only to confirm "hundred" alone never
+  // becomes 💯 without the explicit word "emoji".
+  assert.equal(cleanup("we need a hundred dollars"), "We need $100.");
 });
 
 test("lets whisper's own inferred punctuation win on collision", () => {
@@ -180,6 +184,37 @@ test("brace/bracket symbols don't regress paren, dash, or percent tidy-up", () =
   assert.equal(cleanup("call open paren now close paren"), "Call (now).");
   assert.equal(cleanup("alpha dash beta"), "Alpha-beta.");
   assert.equal(cleanup("fifty percent off"), "Fifty% off.");
+});
+
+test("parseNumberWords: standard English number-word grammar up to the thousands", () => {
+  assert.equal(parseNumberWords("twenty"), 20);
+  assert.equal(parseNumberWords("one hundred and fifty"), 150);
+  assert.equal(parseNumberWords("two thousand five hundred"), 2500);
+  assert.equal(parseNumberWords("nineteen"), 19);
+  assert.equal(parseNumberWords("not a number"), null, "unrecognised words must not be guessed at");
+});
+
+test("converts spoken currency (#130): dollars, cents, and combined amounts", () => {
+  const cases = [
+    ["it costs twenty dollars", "It costs $20."],
+    ["it costs one hundred and fifty dollars", "It costs $150."],
+    ["it costs two thousand five hundred dollars", "It costs $2500."],
+    ["it costs twenty dollars and fifty cents", "It costs $20.50."],
+    ["that will be fifty cents", "That will be $0.50."],
+  ];
+  for (const [raw, expected] of cases) {
+    assert.equal(cleanup(raw), expected, raw);
+  }
+});
+
+test("currency conversion doesn't misfire on ordinary number words without a currency anchor", () => {
+  assert.equal(cleanup("i have twenty of them"), "I have twenty of them.");
+  assert.equal(cleanup("i need a bit more time"), "I need a bit more time.");
+});
+
+test("\"a\"/\"an\" as a number word means one, the same idiom as ordinary English", () => {
+  assert.equal(cleanup("i only have a dollar to my name"), "I only have $1 to my name.");
+  assert.equal(cleanup("that will cost a dollar and fifty cents"), "That will cost $1.50.");
 });
 
 test("quote ... end quote wraps the spoken span, unconditionally (no break-safe gating)", () => {


### PR DESCRIPTION
Closes #130.

**Stacked on #165 (#129) -> #164 (#128) -> #162 (#124)**, same file chain. Merge in order and each PR's diff shrinks to just its own change; happy to rebase instead if you'd rather review independently.

## Scope decision

The issue names four categories: phone numbers/confirmation codes, currency, dates/times, measurements. I only implemented currency, deliberately.

The issue's own methodology is measure-first: whisper often already renders digit sequences correctly on its own (its own decoding frequently emits digits, not words), so the first step is checking what's *actually* still wrong against real dictation samples, not assuming every category has a gap. For dates specifically, the issue goes further and flags "leave it as prose, don't guess" as a likely-*correct* outcome, not a gap to fill - date format is genuinely ambiguous from speech alone ("march third" could be 03/03 or the 3rd of March). I don't have real audio dictation samples to measure phone-number/date behavior against, so I didn't guess at either - both stay open as follow-ups. Currency is the one category the issue itself treats as clear-cut ("unit-anchored patterns"), so that's what this PR does.

## What it does

`parseNumberWords()` implements standard English number-word grammar up to the thousands (ones, teens, tens, hundred/thousand scaling, "and" connectors), returning `null` on anything unrecognised rather than guessing. `applyCurrency()` only substitutes the digit form when a dollars/cents-anchored phrase parses cleanly:

```
"it costs twenty dollars"                    -> "It costs $20."
"it costs one hundred and fifty dollars"     -> "It costs $150."
"it costs two thousand five hundred dollars" -> "It costs $2500."
"it costs twenty dollars and fifty cents"    -> "It costs $20.50."
"that will be fifty cents"                   -> "That will be $0.50."
```

"a"/"an" count as one - the same idiom that already lets English speakers say "a hundred" instead of "one hundred". Without this, "a hundred dollars" would convert to the grammatically awkward "a $100" instead of "$100"; with it, "a dollar and fifty cents" correctly becomes "$1.50".

Not gated behind `breakSafe`/`oneLineBox` - a currency symbol carries no functional risk in any app, same reasoning #128's quote markers and #131's `SPOKEN_EMOJI` already use.

## A pre-existing test this correctly changed the outcome of

`we need a hundred dollars` was one of #131's fixture phrases, used there purely to confirm "hundred" alone never becomes 💯 without the explicit word "emoji" - that test never cared about currency. This PR's `applyCurrency` now correctly converts that same phrase to `We need $100.`, which is the *right* result for #130, not a regression in what #131's test actually verifies. Updated the expected value and left a comment explaining why, rather than silently changing it.

## Verification

`electron/cleanup/rules.test.js`: 34/34 pass (7 new cases: the parser unit tests, five currency conversions, a false-positive check on ordinary number words with no currency anchor immediately following, and the "a"/"an" idiom). Latency-budget test and the real-sample sweep both still pass. Full suite: 107/110 (same 2 pre-existing unrelated cancellations and 1 pre-existing skip as the last three PRs this session).
