### PR TITLE
Add a spell-that-out letter-by-letter mode

### DIFF
--- a/electron/cleanup/rules.js
+++ b/electron/cleanup/rules.js
@@ -276,6 +276,38 @@ function applyCurrency(text) {
   return text;
 }
 
+// #132: "spell:" / "spell that:" starts a fresh letter-by-letter capture -
+// scoped to that forward-starting form only, not the alternative the issue
+// also raises (retroactively correcting the immediately preceding word).
+// The forward form is self-contained: it can only ever touch the letters
+// that follow the trigger, never risk consuming or discarding earlier
+// content it didn't mean to. Requires 2+ single-letter tokens, so a lone
+// "spell" in ordinary speech ("I can't spell that word") never misfires -
+// there's nothing after it shaped like a spelled-out sequence.
+//
+// Scoped to whisper's "clean" transcription case only - individual letters
+// coming through as single-character tokens ("j o h n"). Not implemented:
+// letter-name disambiguation ("Jay Oh Aitch Enn" instead of "J O H N"),
+// which the issue itself flags as needing its own word-to-letter table
+// this repo doesn't have yet. Also not implemented: distinguishing a
+// spelled proper noun ("John", capitalise) from a spelled confirmation
+// code ("AB3459", stays uppercase) - the issue explicitly says there's no
+// spoken signal that tells them apart, so this always capitalises as a
+// proper noun, the "almost always" case per the issue's own framing.
+// Both left as follow-ups rather than guessed at.
+function applySpellOut(text) {
+  // The separator lives inside the repeated group, not after it, so a
+  // separator can only ever be consumed when it's actually followed by
+  // another letter - otherwise a trailing "spell a b three four five nine"
+  // (mixed letters and number words, out of scope - see the comment above)
+  // would consume the space after "b" regardless, gluing what's left onto
+  // the assembled word ("Abthree...") instead of leaving it be ("Ab three...").
+  return text.replace(/\bspell(?: that)?:?\s+([a-z]\b(?:[\s-]+[a-z]\b)+)/gi, (_match, letters) => {
+    const word = letters.trim().split(/[\s-]+/).join("");
+    return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+  });
+}
+
 function stripLeadingFillers(text) {
   const parts = text.split(SENT_BOUNDARY_SPLIT);
   const out = [];
@@ -386,6 +418,11 @@ function cleanup(text, options = {}) {
   // something the speaker said, and must go before anything else runs.
   text = text.replace(/\s*\n\s*/g, " ");
 
+  // #132: must run before collapseRepeats - a spelled word with a doubled
+  // letter ("b o o k") would otherwise have its repeated "o o" tokens
+  // collapsed before the letters are ever assembled into one word,
+  // corrupting "book" into "bok".
+  text = applySpellOut(text);
   text = stripFillers(text);
   text = collapseRepeats(text);
   text = applySpokenPunct(text, { allowNewlines });
@@ -423,6 +460,7 @@ module.exports = {
   applyQuoteMarkers,
   parseNumberWords,
   applyCurrency,
+  applySpellOut,
   stripLeadingFillers,
   segmentSentences,
   applyVocab,

--- a/electron/cleanup/rules.test.js
+++ b/electron/cleanup/rules.test.js
@@ -217,6 +217,31 @@ test("\"a\"/\"an\" as a number word means one, the same idiom as ordinary Englis
   assert.equal(cleanup("that will cost a dollar and fifty cents"), "That will cost $1.50.");
 });
 
+test("spell:/spell that: assembles single-letter tokens into one capitalised word (#132)", () => {
+  assert.equal(cleanup("my name is spell that j o h n"), "My name is John.");
+  assert.equal(cleanup("spell: b o o k"), "Book.");
+});
+
+test("spell out preserves a doubled letter instead of collapsing it as a repeat", () => {
+  // Must run before collapseRepeats, or "o o" in a spelled "book" gets
+  // merged into a single "o" the same way an ordinary stutter would.
+  assert.equal(cleanup("spell: l e t t e r"), "Letter.");
+});
+
+test("a lone 'spell'/'spell that' with no letter sequence after it is left alone", () => {
+  assert.equal(cleanup("i cannot spell that word"), "I cannot spell that word.");
+  assert.equal(cleanup("spell a"), "Spell a.");
+});
+
+test("spell out stops cleanly at the first non-letter token instead of gluing text onto it", () => {
+  // Mixed letters and spoken digits (e.g. a confirmation code like
+  // "AB3459") isn't implemented - see the comment in applySpellOut - but
+  // it must degrade to leaving the unhandled part alone with its spacing
+  // intact, not corrupt it.
+  const out = cleanup("the code is spell a b three four five nine");
+  assert.equal(out, "The code is Ab three four five nine.");
+});
+
 test("quote ... end quote wraps the spoken span, unconditionally (no break-safe gating)", () => {
   assert.equal(cleanup("he said quote hello world end quote"), "He said \"hello world\".");
   // Not gated behind breakSafe, unlike a newline - a quote character carries


### PR DESCRIPTION
Closes #132.

**Stacked on #167 (#130) -> #165 (#129) -> #164 (#128) -> #162 (#124)**, same file chain. Merge in order and each PR's diff shrinks to just its own change; happy to rebase instead if you'd rather review independently.

## Scope decision

The issue leaves three separate things open. I resolved two of them with a scope call, and left the third as a real, documented gap:

1. **Trigger form: forward-starting only.** The issue asks whether "spell that" should retroactively correct the immediately preceding word, or whether "spell:"/"spell that:" should start a fresh capture going forward. I built the forward form only - it's self-contained, it can only ever touch the letters that come after the trigger, and can never risk consuming or discarding earlier content it didn't mean to. The retroactive form needs deciding "how far back does it reach," which felt like its own design question, not something to guess at here. Requires 2+ single-letter tokens, so a lone "spell" in ordinary speech ("I can't spell that word") never misfires.

2. **Letter-word disambiguation: not implemented.** Whisper may transcribe spelled letters as themselves ("J O H N") or as similar-sounding words ("Jay Oh Aitch Enn"). This only handles the clean case - the issue itself flags the letter-name case as needing its own word-to-letter table, which I didn't want to guess at without real transcripts to validate against.

3. **Output casing: always capitalises as a proper noun.** The issue explicitly says there's no spoken signal that distinguishes a name ("John", capitalise) from a confirmation code ("AB3459", stays uppercase) - so it always does the "almost always" case per the issue's own framing, rather than guessing which one applies.

## A real bug I found and fixed along the way

Two, actually:

- **Ordering with `collapseRepeats`.** A spelled word with a doubled letter ("b o o k") would have its repeated "o o" tokens collapsed the same way an ordinary stutter is, *before* the letters are ever assembled into one word - corrupting "book" into "bok". `applySpellOut` now runs at the very front of the pipeline, before `collapseRepeats` ever sees the text.
- **Garbled output on a partial match.** While testing the out-of-scope mixed letters-and-numbers case (a code like "AB3459" spoken as "a b three four five nine"), my first regex draft consumed a trailing separator even when nothing after it continued the letter run, gluing whatever came next onto the assembled word: `"the code is spell a b three four five nine"` came out as `"The code is Abthree four five nine."` - wrong word, and the space before "three" gone entirely. Restructured the regex so the separator lives inside the repeated group rather than after it, so it's only ever consumed when actually followed by another letter. Same input now correctly degrades to `"The code is Ab three four five nine."` - "Ab" assembled, everything after left alone with its spacing intact, rather than corrupted.

## Verification

`electron/cleanup/rules.test.js`: 38/38 pass (6 new cases: basic spell-out via both "spell that:" and "spell:", a doubled-letter case proving the `collapseRepeats` ordering fix, two "must not misfire" cases, and the degrade-gracefully case proving the regex-structure fix). Latency-budget test and the real-sample sweep both still pass. Full suite: 111/114 (same 2 pre-existing unrelated cancellations and 1 pre-existing skip as the rest of this session's PRs).
