### PR TITLE
Cancel superseded CI runs to reduce macOS concurrency-slot contention

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,17 @@ on:
   push:
     branches: [main]
 
+# macOS runners are capped at 5 concurrent jobs account-wide (a GitHub
+# limit, not something this repo controls) - with several people/agents
+# pushing to different branches at once, that cap gets exhausted fast and
+# leaves later runs stuck queued or failing outright. Cancelling a run's
+# own superseded predecessor when a new commit lands on the same
+# branch/PR - the group key pairs workflow name with ref - frees its slot
+# immediately instead of holding it for a result nobody will look at.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: macos-latest


### PR DESCRIPTION
Fixes the CI reliability problem several PRs hit today (startup_failure, runs stuck queued 15+ minutes).

## Diagnosis

This is a concurrency limit, not a billing/cost problem - checked before touching anything, since the ask was to keep this project completely free:

- The repo is already **public**, so GitHub Actions minutes are free and unlimited regardless of runner OS. No cost issue here at all.
- Per GitHub's own docs (billing/concepts/product-billing/github-actions, cross-referenced with the Actions usage-limits reference): **macOS runners are capped at 5 concurrent jobs account-wide**, and that cap is the same on Free, Pro, and Team plans - only Enterprise raises it (to 50). This is a hard platform limit, not something misconfigured in this repo.
- Checked the actual run history: every run succeeded cleanly for the entire session until a tight burst of 6 pushes landed within 25 minutes - multiple people/agents pushing to different branches at once, blowing past the 5-slot cap. Jobs that can't get a runner either queue indefinitely or fail outright with `startup_failure`, matching exactly what we saw.

## Fix

Adds a `concurrency` block so a new commit landing on the same branch/PR cancels its own previous still-running check instead of the two competing for one of the 5 macOS slots. This doesn't fix contention *between* different concurrent PRs (that's the real 5-slot ceiling, and GitHub Support can raise it on request if it keeps being a problem - a call for the account owner, not something I can do from here) - but it removes the self-inflicted waste of a branch holding a slot open for a run that's already obsolete. One of today's PRs literally did this to itself (an empty-commit CI retrigger held a slot for a superseded run).

## Verification

Validated the YAML (`ruby -ryaml -e "YAML.load_file(...)"`, since PyYAML isn't installed in this sandbox) - parses cleanly. This is a workflow-file-only change; nothing about what gets tested changes, so no code verification needed beyond that.
