### PR TITLE
Build the codebase vocabulary scanner (UI hidden, deprioritised to post-v1.0)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -62,11 +62,11 @@ Owns: context awareness, prose cleanup rules, break safety.
 
 Same tracks, harder problems — this is where it gets genuinely complex.
 
-- **Track A:** codebase vocabulary scanner — extract identifiers/terms from the open git repo or editor buffer, feed them into whisper.cpp as an initial prompt / bias list
+- ~~**Track A:** codebase vocabulary scanner~~ - **moved to the After-v1.0 backlog.** Built and unit-tested (#16, PR #185: `git ls-files` a configured repo, extract/rank/cap identifiers, bias whisper's per-request prompt), but deprioritised - an MVP needs plain dictation working excellently first, and this is polish, not core. The Settings UI is unhooked, not deleted; the underlying scanning/caching/pipeline wiring stays in place, ready to pick back up
 - **Track B:** `llama-server` plumbing - fetch the binary and an **Apache 2.0 / MIT, ungated** GGUF (SmolLM2-1.7B-Instruct provisionally; acquisition policy open in #52), start it, confirm a local HTTP round trip (moved here from Phase 2 by #24 and #32)
 - **Track B:** voice-driven editing — select existing text anywhere, speak a command ("make this a bullet list", "snake_case that"), send it to the **rewrite model server** to rewrite the selection in place. **Correction from #45:** that server is now **resident**, started at app launch alongside the transcription model server, because it also decides break placement during ordinary dictation. The lazy-then-idle-released lifecycle #29 chose assumed it served voice edits only
 
-**Definition of done:** dictation that's measurably more accurate on your own codebase's vocabulary, plus voice-editing of existing text. Tag `v0.3`.
+**Definition of done:** voice-editing of existing text, working reliably. Tag `v0.3`.
 
 ---
 
@@ -86,3 +86,5 @@ Same tracks, harder problems — this is where it gets genuinely complex.
 ## After v1.0
 
 Open to outside contributors. Backlog candidates: Linux/Windows ports, per-project config files, custom wake-word-free modes, team-shared vocabulary packs. Not scoped yet — revisit after launch feedback.
+
+- **Codebase vocabulary scanner** ([#16](https://github.com/Nabzx/openstream/issues/16)) - moved here from Phase 3. Built, not shipped: the scanning/caching/pipeline wiring exists and is tested (PR #185), the Settings UI is unhooked. Before re-enabling: confirm a live dictation with a configured project path actually gets the biased prompt end to end (a `vocabulary.promptLength` diagnostic exists for exactly this check and hasn't been read back yet).

--- a/electron/dictationCoordinator.js
+++ b/electron/dictationCoordinator.js
@@ -8,6 +8,11 @@ function createDictationIntake(options) {
     contextDetection,
     breakPlacement,
     delivery,
+    // #16: optional on purpose - most callers (and all of history before
+    // #16) have no project vocabulary configured at all. Defaults to a
+    // no-op that biases nothing, rather than forcing every caller/test to
+    // know about vocabulary scanning.
+    vocabulary = { getPrompt: () => "" },
     onDiagnostic = () => {},
   } = options;
 
@@ -15,6 +20,7 @@ function createDictationIntake(options) {
   assertAdapter("contextDetection", contextDetection, "getFocusContext");
   assertAdapter("breakPlacement", breakPlacement, "placeParagraphBreaks");
   assertAdapter("delivery", delivery, "deliver");
+  assertAdapter("vocabulary", vocabulary, "getPrompt");
 
   let queue = Promise.resolve();
 
@@ -33,7 +39,7 @@ function createDictationIntake(options) {
 
     let rawText;
     try {
-      const transcript = await transcription.transcribe(wavBuffer);
+      const transcript = await transcription.transcribe(wavBuffer, vocabulary.getPrompt());
       if (typeof transcript !== "string") {
         throw new Error("transcription adapter returned a non-string transcript");
       }

--- a/electron/dictationCoordinator.js
+++ b/electron/dictationCoordinator.js
@@ -39,7 +39,9 @@ function createDictationIntake(options) {
 
     let rawText;
     try {
-      const transcript = await transcription.transcribe(wavBuffer, vocabulary.getPrompt());
+      const vocabularyPrompt = vocabulary.getPrompt();
+      emitDiagnostic("vocabulary.promptLength", vocabularyPrompt.length);
+      const transcript = await transcription.transcribe(wavBuffer, vocabularyPrompt);
       if (typeof transcript !== "string") {
         throw new Error("transcription adapter returned a non-string transcript");
       }

--- a/electron/dictationCoordinator.test.js
+++ b/electron/dictationCoordinator.test.js
@@ -217,6 +217,7 @@ test("repairs malformed break indices without retrying and records format and re
     text: "First sentence. Second sentence.\n\nThird sentence. Fourth sentence.",
   });
   assert.deepEqual(harness.diagnostics, [
+    ["vocabulary.promptLength", 0],
     ["paragraphBreaks.formatValid", false],
     ["paragraphBreaks.repairUsed", true],
   ]);

--- a/electron/dictationCoordinator.test.js
+++ b/electron/dictationCoordinator.test.js
@@ -17,6 +17,7 @@ function createIntake({
   getFocusContext,
   placeParagraphBreaks,
   deliver,
+  vocabulary,
   onDiagnostic,
 } = {}) {
   const diagnostics = [];
@@ -42,6 +43,7 @@ function createIntake({
         return { kind: "inserted" };
       }),
     },
+    vocabulary,
     onDiagnostic: onDiagnostic || ((name, value) => diagnostics.push([name, value])),
   });
 
@@ -75,6 +77,35 @@ test("completed recording is transcribed, cleaned, and delivered once", async ()
   assert.deepEqual(transcriptionCalls, [completedWav]);
   assert.equal(contextCalls.length, 1);
   assert.deepEqual(harness.delivered, ["GitHub\nJavaScript."]);
+});
+
+test("#16: the vocabulary adapter's prompt is passed to transcribe", async () => {
+  const transcriptionCalls = [];
+  const harness = createIntake({
+    transcribe: async (wavBuffer, prompt) => {
+      transcriptionCalls.push(prompt);
+      return "hello world";
+    },
+    vocabulary: { getPrompt: () => "useEffect, useState" },
+  });
+
+  await harness.intake.complete(completedWav);
+
+  assert.deepEqual(transcriptionCalls, ["useEffect, useState"]);
+});
+
+test("#16: with no vocabulary adapter configured, transcribe gets an empty prompt", async () => {
+  const transcriptionCalls = [];
+  const harness = createIntake({
+    transcribe: async (wavBuffer, prompt) => {
+      transcriptionCalls.push(prompt);
+      return "hello world";
+    },
+  });
+
+  await harness.intake.complete(completedWav);
+
+  assert.deepEqual(transcriptionCalls, [""]);
 });
 
 test("a known unsafe application never receives spoken line breaks", async () => {

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,4 +1,4 @@
-const { app, Tray, Menu, BrowserWindow, clipboard, ipcMain, nativeImage, screen } = require("electron");
+const { app, Tray, Menu, BrowserWindow, clipboard, dialog, ipcMain, nativeImage, screen } = require("electron");
 const path = require("path");
 const { performance } = require("node:perf_hooks");
 const { computeBottomCenteredPosition } = require("./overlayPosition");
@@ -11,6 +11,7 @@ const { setBreakSafeApplications } = require("./breakSafety");
 const { createTranscriptionHttpAdapter } = require("./transcriptionHttpAdapter");
 const { createBreakPlacementHttpAdapter } = require("./breakPlacementHttpAdapter");
 const { createDictationIntake } = require("./dictationCoordinator");
+const { createVocabularyCache } = require("./vocabularyCache");
 const { createHeldResultController } = require("./heldResultController");
 const { createPushToTalkCoordinator } = require("./pushToTalkCoordinator");
 
@@ -46,6 +47,7 @@ const transcription = createTranscriptionHttpAdapter({ inferenceUrl: whisperServ
 const breakPlacement = createBreakPlacementHttpAdapter({
   chatCompletionsUrl: rewriteModelServer.chatCompletionsUrl,
 });
+const vocabulary = createVocabularyCache();
 
 function recordDictationDiagnostic(name, value) {
   console.log(`[dictation] ${name}: ${JSON.stringify(value)}`);
@@ -56,6 +58,7 @@ const dictationIntake = createDictationIntake({
   contextDetection: accessibilityHelper,
   breakPlacement,
   delivery: accessibilityHelper,
+  vocabulary,
   onDiagnostic: recordDictationDiagnostic,
 });
 
@@ -362,6 +365,31 @@ ipcMain.handle("settings:set-break-safe-apps", (event, apps) => {
   return settings;
 });
 
+// #16: setting the path persists it and triggers a rescan in the same
+// round trip, so the settings window can show the resulting status (or
+// error) without a second call. A failed scan (bad path, not a git repo)
+// rejects the promise and leaves both the persisted path and the previous
+// cache as they were - see vocabularyCache.js.
+ipcMain.handle("settings:set-vocabulary-path", async (event, projectPath) => {
+  const settings = settingsStore.setVocabularyProjectPath(projectPath);
+  await vocabulary.rescan(settings.vocabularyProjectPath);
+  return { settings, status: vocabulary.getStatus() };
+});
+
+ipcMain.handle("vocabulary:rescan", async () => {
+  await vocabulary.rescan(settingsStore.get().vocabularyProjectPath);
+  return vocabulary.getStatus();
+});
+
+ipcMain.handle("vocabulary:get-status", () => vocabulary.getStatus());
+
+ipcMain.handle("vocabulary:choose-folder", async () => {
+  if (!win) return null;
+  const result = await dialog.showOpenDialog(win, { properties: ["openDirectory"] });
+  if (result.canceled || result.filePaths.length === 0) return null;
+  return result.filePaths[0];
+});
+
 // A second launch attempt hits this instead of silently doing nothing (or
 // worse, silently doing everything twice) - bring the settings window
 // forward so there's visible proof this instance is the one that's running.
@@ -376,6 +404,15 @@ app.whenReady().then(() => {
   settingsStore = createSettingsStore({ filePath: path.join(app.getPath("userData"), "settings.json") });
   hotkeyHelper.setHotkey(settingsStore.get().hotkey);
   setBreakSafeApplications(settingsStore.get().breakSafeApps);
+  // Fire-and-forget: a scan failing here (bad/moved path since last run)
+  // must not block startup. It just means vocabulary biasing stays off
+  // until the user opens Settings and fixes or re-picks the path.
+  const configuredProjectPath = settingsStore.get().vocabularyProjectPath;
+  if (configuredProjectPath) {
+    vocabulary.rescan(configuredProjectPath).catch((error) => {
+      console.error("[vocabulary] initial scan failed:", error.message);
+    });
+  }
   createTray();
   hotkeyHelper.onKeyDown(pushToTalkCoordinator.keyDown);
   hotkeyHelper.onKeyUp(pushToTalkCoordinator.keyUp);

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -9,5 +9,11 @@ contextBridge.exposeInMainWorld("openstream", {
     get: () => ipcRenderer.invoke("settings:get"),
     setHotkey: (hotkey) => ipcRenderer.invoke("settings:set-hotkey", hotkey),
     setBreakSafeApps: (apps) => ipcRenderer.invoke("settings:set-break-safe-apps", apps),
+    setVocabularyProjectPath: (projectPath) => ipcRenderer.invoke("settings:set-vocabulary-path", projectPath),
+  },
+  vocabulary: {
+    rescan: () => ipcRenderer.invoke("vocabulary:rescan"),
+    getStatus: () => ipcRenderer.invoke("vocabulary:get-status"),
+    chooseFolder: () => ipcRenderer.invoke("vocabulary:choose-folder"),
   },
 });

--- a/electron/settingsStore.js
+++ b/electron/settingsStore.js
@@ -8,6 +8,9 @@ const { DEFAULT_BREAK_SAFE_BUNDLE_IDS } = require("./breakSafety");
 const DEFAULT_SETTINGS = {
   hotkey: { keyCode: 2, modifiers: ["ctrl", "alt"] },
   breakSafeApps: [...DEFAULT_BREAK_SAFE_BUNDLE_IDS],
+  // #16: null means no project configured - vocabulary biasing is opt-in,
+  // not a default every fresh install has to notice and turn off.
+  vocabularyProjectPath: null,
 };
 
 const VALID_MODIFIERS = new Set(["cmd", "shift", "alt", "ctrl"]);
@@ -25,6 +28,13 @@ function validateHotkey(hotkey) {
     if (!VALID_MODIFIERS.has(modifier)) {
       throw new Error(`unknown modifier "${modifier}"`);
     }
+  }
+}
+
+function validateVocabularyProjectPath(projectPath) {
+  if (projectPath === null) return;
+  if (typeof projectPath !== "string" || projectPath.trim().length === 0) {
+    throw new Error("vocabularyProjectPath must be null or a non-empty string");
   }
 }
 
@@ -84,12 +94,21 @@ function createSettingsStore({ filePath }) {
     return settings;
   }
 
+  function setVocabularyProjectPath(projectPath) {
+    validateVocabularyProjectPath(projectPath);
+    cache = { ...load(), vocabularyProjectPath: projectPath === null ? null : projectPath.trim() };
+    persist();
+    const settings = get();
+    for (const listener of listeners) listener(settings);
+    return settings;
+  }
+
   function onChange(listener) {
     listeners.add(listener);
     return () => listeners.delete(listener);
   }
 
-  return { get, setHotkey, setBreakSafeApps, onChange };
+  return { get, setHotkey, setBreakSafeApps, setVocabularyProjectPath, onChange };
 }
 
 module.exports = { createSettingsStore, DEFAULT_SETTINGS };

--- a/electron/settingsStore.test.js
+++ b/electron/settingsStore.test.js
@@ -114,3 +114,36 @@ test("an invalid setBreakSafeApps call leaves the previous value untouched", () 
   assert.throws(() => store.setBreakSafeApps(["  "]));
   assert.deepEqual(store.get().breakSafeApps, ["com.apple.Terminal"]);
 });
+
+test("vocabularyProjectPath defaults to null", () => {
+  const store = createSettingsStore({ filePath: tempFilePath() });
+  assert.equal(store.get().vocabularyProjectPath, null);
+});
+
+test("setVocabularyProjectPath persists a trimmed path and get() reflects it afterwards", () => {
+  const filePath = tempFilePath();
+  const store = createSettingsStore({ filePath });
+
+  store.setVocabularyProjectPath("  /Users/me/code/myapp  ");
+  assert.equal(store.get().vocabularyProjectPath, "/Users/me/code/myapp");
+
+  const onDisk = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  assert.equal(onDisk.vocabularyProjectPath, "/Users/me/code/myapp");
+});
+
+test("setVocabularyProjectPath(null) clears a previously-set path", () => {
+  const store = createSettingsStore({ filePath: tempFilePath() });
+  store.setVocabularyProjectPath("/Users/me/code/myapp");
+  store.setVocabularyProjectPath(null);
+  assert.equal(store.get().vocabularyProjectPath, null);
+});
+
+test("rejects an empty-string vocabularyProjectPath", () => {
+  const store = createSettingsStore({ filePath: tempFilePath() });
+  assert.throws(() => store.setVocabularyProjectPath("   "), /non-empty string/);
+});
+
+test("rejects a non-string, non-null vocabularyProjectPath", () => {
+  const store = createSettingsStore({ filePath: tempFilePath() });
+  assert.throws(() => store.setVocabularyProjectPath(42), /non-empty string/);
+});

--- a/electron/transcriptionHttpAdapter.js
+++ b/electron/transcriptionHttpAdapter.js
@@ -4,10 +4,15 @@ function createTranscriptionHttpAdapter(options) {
     throw new Error("Transcription HTTP adapter requires an inferenceUrl function");
   }
 
-  async function transcribe(wavBuffer) {
+  // prompt is optional - #16's vocabulary scanner builds it from project
+  // identifiers, but plenty of dictations happen with no project configured
+  // at all, and whisper-server treats a missing/empty prompt exactly like
+  // it always has.
+  async function transcribe(wavBuffer, prompt) {
     const formData = new FormData();
     formData.append("file", new Blob([wavBuffer], { type: "audio/wav" }), "dictation.wav");
     formData.append("response_format", "json");
+    if (prompt) formData.append("prompt", prompt);
 
     const res = await fetchImpl(inferenceUrl(), { method: "POST", body: formData });
     if (!res.ok) throw new Error(`transcription model server returned ${res.status}`);

--- a/electron/transcriptionHttpAdapter.test.js
+++ b/electron/transcriptionHttpAdapter.test.js
@@ -24,6 +24,36 @@ test("posts a completed WAV recording to the local transcription contract", asyn
   assert.equal(file.type, "audio/wav");
 });
 
+test("sends the vocabulary prompt as a form field when given one", async () => {
+  const calls = [];
+  const adapter = createTranscriptionHttpAdapter({
+    inferenceUrl: () => "http://127.0.0.1:8178/inference",
+    fetchImpl: async (url, options) => {
+      calls.push({ url, options });
+      return { ok: true, json: async () => ({ text: "hello" }) };
+    },
+  });
+
+  await adapter.transcribe(Buffer.from("RIFF wav bytes"), "useEffect, useState");
+
+  assert.equal(calls[0].options.body.get("prompt"), "useEffect, useState");
+});
+
+test("omits the prompt field entirely when none is given", async () => {
+  const calls = [];
+  const adapter = createTranscriptionHttpAdapter({
+    inferenceUrl: () => "http://127.0.0.1:8178/inference",
+    fetchImpl: async (url, options) => {
+      calls.push({ url, options });
+      return { ok: true, json: async () => ({ text: "hello" }) };
+    },
+  });
+
+  await adapter.transcribe(Buffer.from("RIFF wav bytes"));
+
+  assert.equal(calls[0].options.body.get("prompt"), null);
+});
+
 test("fails clearly when the transcription model server rejects a recording", async () => {
   const adapter = createTranscriptionHttpAdapter({
     inferenceUrl: () => "http://127.0.0.1:8178/inference",

--- a/electron/vocabularyCache.js
+++ b/electron/vocabularyCache.js
@@ -1,0 +1,44 @@
+// #16: holds the last scan's result in memory and serves it as the
+// vocabulary adapter createDictationIntake expects (getPrompt()). Scanning
+// a repo touches the filesystem and can take real time on a large project,
+// so it happens once - on rescan, not on every dictation - and every
+// dictation just reads whatever's cached.
+const { scanRepository, buildPrompt } = require("./vocabularyScanner");
+
+function createVocabularyCache({ scan = scanRepository, buildPromptFn = buildPrompt, now = () => new Date() } = {}) {
+  let state = null; // { path, terms, prompt, filesRead, scannedAt } | null
+
+  async function rescan(repoPath) {
+    if (!repoPath) {
+      state = null;
+      return getStatus();
+    }
+    const result = await scan(repoPath);
+    state = {
+      path: result.path,
+      terms: result.terms,
+      prompt: buildPromptFn(result.terms),
+      filesRead: result.filesRead,
+      scannedAt: now(),
+    };
+    return getStatus();
+  }
+
+  function getPrompt() {
+    return state ? state.prompt : "";
+  }
+
+  function getStatus() {
+    if (!state) return { path: null, termCount: 0, filesRead: 0, scannedAt: null };
+    return {
+      path: state.path,
+      termCount: state.terms.length,
+      filesRead: state.filesRead,
+      scannedAt: state.scannedAt,
+    };
+  }
+
+  return { rescan, getPrompt, getStatus };
+}
+
+module.exports = { createVocabularyCache };

--- a/electron/vocabularyCache.test.js
+++ b/electron/vocabularyCache.test.js
@@ -1,0 +1,70 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { createVocabularyCache } = require("./vocabularyCache");
+
+test("getPrompt is empty and status is null before any scan", () => {
+  const cache = createVocabularyCache();
+  assert.equal(cache.getPrompt(), "");
+  assert.deepEqual(cache.getStatus(), { path: null, termCount: 0, filesRead: 0, scannedAt: null });
+});
+
+test("rescan populates the prompt and status from the scanner", async () => {
+  const scanCalls = [];
+  const cache = createVocabularyCache({
+    scan: async (repoPath) => {
+      scanCalls.push(repoPath);
+      return { path: repoPath, filesRead: 3, terms: ["getUserById", "userId"] };
+    },
+    buildPromptFn: (terms) => terms.join(", "),
+    now: () => new Date("2026-01-01T00:00:00Z"),
+  });
+
+  const status = await cache.rescan("/repo");
+
+  assert.deepEqual(scanCalls, ["/repo"]);
+  assert.equal(cache.getPrompt(), "getUserById, userId");
+  assert.deepEqual(status, {
+    path: "/repo",
+    termCount: 2,
+    filesRead: 3,
+    scannedAt: new Date("2026-01-01T00:00:00Z"),
+  });
+  assert.deepEqual(cache.getStatus(), status);
+});
+
+test("rescan with an empty/falsy path clears the cache without scanning", async () => {
+  let scanned = false;
+  const cache = createVocabularyCache({
+    scan: async () => {
+      scanned = true;
+      return { path: "/repo", filesRead: 1, terms: ["term"] };
+    },
+  });
+  await cache.rescan("/repo");
+  assert.equal(cache.getPrompt(), "term");
+
+  scanned = false;
+  const status = await cache.rescan(null);
+
+  assert.equal(scanned, false, "should not call the scanner for a null path");
+  assert.equal(cache.getPrompt(), "");
+  assert.deepEqual(status, { path: null, termCount: 0, filesRead: 0, scannedAt: null });
+});
+
+test("a failed rescan propagates the error and leaves the previous cache untouched", async () => {
+  let shouldFail = false;
+  const cache = createVocabularyCache({
+    scan: async () => {
+      if (shouldFail) throw new Error("not a git repository");
+      return { path: "/repo", filesRead: 1, terms: ["goodTerm"] };
+    },
+    buildPromptFn: (terms) => terms.join(", "),
+  });
+
+  await cache.rescan("/repo");
+  assert.equal(cache.getPrompt(), "goodTerm");
+
+  shouldFail = true;
+  await assert.rejects(() => cache.rescan("/bad-repo"), /not a git repository/);
+  assert.equal(cache.getPrompt(), "goodTerm", "cache should be unchanged after a failed rescan");
+});

--- a/electron/vocabularyScanner.js
+++ b/electron/vocabularyScanner.js
@@ -1,0 +1,129 @@
+// #16: scan a git repo for project-specific identifiers and turn them into
+// a prompt whisper.cpp can be biased with. Whisper's per-request "prompt"
+// form field on /inference genuinely changes output - verified directly
+// against the pinned whisper-server binary, not assumed from docs: given
+// the prompt "useEffect, useState, React", a dictation of "the react
+// component uses use effect and use state" transcribed useState with the
+// prompt's exact casing, where it came out UseState without one.
+const path = require("path");
+const { execFile } = require("child_process");
+const { promisify } = require("util");
+const fs = require("fs/promises");
+
+const execFileAsync = promisify(execFile);
+
+// Extensions worth reading for identifiers. Deliberately source-code only -
+// lockfiles, generated output, and binary assets have no spoken vocabulary
+// in them and would just cost scan time.
+const SOURCE_EXTENSIONS = new Set([
+  ".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs",
+  ".py", ".rb", ".go", ".rs", ".java", ".kt", ".swift",
+  ".c", ".h", ".cpp", ".hpp", ".cc", ".cs", ".php",
+  ".m", ".mm",
+]);
+
+// Language keywords common enough to dominate a frequency-ranked list
+// without being project-specific vocabulary at all - whisper already
+// transcribes these correctly, so including them just wastes prompt budget
+// that should go to identifiers whisper hasn't seen. Not exhaustive, not
+// trying to be a real lexer - just enough to stop the obvious flood.
+const KEYWORD_DENYLIST = new Set([
+  "const", "let", "var", "function", "return", "import", "export", "default",
+  "class", "interface", "type", "enum", "extends", "implements", "public",
+  "private", "protected", "static", "readonly", "async", "await", "true",
+  "false", "null", "undefined", "void", "this", "self", "super", "new",
+  "delete", "typeof", "instanceof", "in", "of", "if", "else", "for", "while",
+  "do", "switch", "case", "break", "continue", "try", "catch", "finally",
+  "throw", "yield", "from", "with", "as", "def", "elif", "pass", "lambda",
+  "none", "true", "false", "and", "or", "not", "is", "print", "func",
+  "struct", "impl", "trait", "mod", "use", "pub", "fn", "let", "mut",
+  "package", "namespace", "template", "using", "include", "define",
+]);
+
+const MIN_TERM_LENGTH = 3;
+const MAX_FILE_CHARS = 256 * 1024; // skip pathologically large generated files
+const MAX_FILES_READ = 2000;
+const DEFAULT_MAX_TERMS = 150;
+const DEFAULT_PROMPT_CHAR_BUDGET = 800;
+
+const IDENTIFIER_PATTERN = /\b[A-Za-z_][A-Za-z0-9_]{2,}\b/g;
+
+function isSourceFile(filePath) {
+  return SOURCE_EXTENSIONS.has(path.extname(filePath).toLowerCase());
+}
+
+function extractIdentifiers(text, counts) {
+  const matches = text.match(IDENTIFIER_PATTERN);
+  if (!matches) return;
+  for (const term of matches) {
+    if (term.length < MIN_TERM_LENGTH) continue;
+    const lower = term.toLowerCase();
+    if (KEYWORD_DENYLIST.has(lower)) continue;
+    // Pure numbers-with-underscores (e.g. a token that's all digits once
+    // the leading letter/underscore requirement is satisfied) aren't real
+    // vocabulary either.
+    if (/^_*\d+_*$/.test(term)) continue;
+    counts.set(term, (counts.get(term) || 0) + 1);
+  }
+}
+
+// tools is injected so this is testable against a fake repo without a real
+// git checkout or real filesystem - same DI shape as scripts/model-artifacts.mjs.
+async function scanRepository(repoPath, options = {}) {
+  const {
+    maxTerms = DEFAULT_MAX_TERMS,
+    tools = { listFiles: gitListFiles, readFile: (p) => fs.readFile(p, "utf8") },
+  } = options;
+
+  const files = (await tools.listFiles(repoPath)).filter(isSourceFile).slice(0, MAX_FILES_READ);
+  const counts = new Map();
+  let filesRead = 0;
+
+  for (const relativePath of files) {
+    const absolutePath = path.join(repoPath, relativePath);
+    let text;
+    try {
+      text = await tools.readFile(absolutePath);
+    } catch {
+      continue; // race: tracked but deleted/moved since ls-files ran, or unreadable
+    }
+    if (text.length > MAX_FILE_CHARS) continue; // pathologically large generated file
+    extractIdentifiers(text, counts);
+    filesRead += 1;
+  }
+
+  const terms = [...counts.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, maxTerms)
+    .map(([term]) => term);
+
+  return { path: repoPath, filesRead, terms };
+}
+
+async function gitListFiles(repoPath) {
+  const { stdout } = await execFileAsync("git", ["-C", repoPath, "ls-files"], {
+    maxBuffer: 1024 * 1024 * 10,
+  });
+  return stdout.split("\n").filter(Boolean);
+}
+
+// Whisper's initial prompt is context for the decoder, not a hard
+// dictionary - past some length the marginal terms stop earning their
+// tokens and just crowd out the ones that matter most (already frequency-
+// ranked, so the crowd-out is the least-frequent terms, not random).
+function buildPrompt(terms, options = {}) {
+  const { charBudget = DEFAULT_PROMPT_CHAR_BUDGET } = options;
+  if (terms.length === 0) return "";
+
+  const kept = [];
+  let length = 0;
+  for (const term of terms) {
+    const addedLength = kept.length === 0 ? term.length : term.length + 2; // ", "
+    if (length + addedLength > charBudget) break;
+    kept.push(term);
+    length += addedLength;
+  }
+  return kept.join(", ");
+}
+
+module.exports = { scanRepository, buildPrompt, gitListFiles, SOURCE_EXTENSIONS, KEYWORD_DENYLIST };

--- a/electron/vocabularyScanner.test.js
+++ b/electron/vocabularyScanner.test.js
@@ -1,0 +1,104 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const { scanRepository, buildPrompt } = require("./vocabularyScanner");
+
+function fakeTools(files) {
+  return {
+    listFiles: async () => Object.keys(files),
+    readFile: async (absolutePath) => {
+      const relative = path.relative("/repo", absolutePath);
+      if (!(relative in files)) throw new Error(`no such file: ${absolutePath}`);
+      return files[relative];
+    },
+  };
+}
+
+test("extracts identifiers and ranks them by frequency", async () => {
+  const tools = fakeTools({
+    "src/getUserById.js": "function getUserById(userId) { return getUserById(userId); }",
+  });
+  const result = await scanRepository("/repo", { tools });
+
+  assert.equal(result.filesRead, 1);
+  assert.ok(result.terms.includes("getUserById"), "getUserById should be extracted");
+  assert.ok(result.terms.includes("userId"), "userId should be extracted");
+  // getUserById appears 3x (definition + 2 uses), userId 2x - frequency order.
+  assert.ok(result.terms.indexOf("getUserById") < result.terms.indexOf("userId"));
+});
+
+test("filters out language keywords", async () => {
+  const tools = fakeTools({
+    "src/x.js": "const function return import export class if else for while",
+  });
+  const result = await scanRepository("/repo", { tools });
+  assert.deepEqual(result.terms, []);
+});
+
+test("filters terms shorter than the minimum length", async () => {
+  const tools = fakeTools({ "src/x.js": "id id id ab longEnoughTerm" });
+  const result = await scanRepository("/repo", { tools });
+  assert.ok(!result.terms.includes("id"));
+  assert.ok(!result.terms.includes("ab"));
+  assert.ok(result.terms.includes("longEnoughTerm"));
+});
+
+test("filters non-source files by extension", async () => {
+  const tools = fakeTools({
+    "package-lock.json": "someIdentifierThatShouldBeIgnored",
+    "src/real.py": "someRealIdentifier",
+  });
+  const result = await scanRepository("/repo", { tools });
+  assert.equal(result.filesRead, 1);
+  assert.ok(result.terms.includes("someRealIdentifier"));
+  assert.ok(!result.terms.includes("someIdentifierThatShouldBeIgnored"));
+});
+
+test("skips a file it cannot read rather than failing the whole scan", async () => {
+  const tools = {
+    listFiles: async () => ["src/broken.js", "src/fine.js"],
+    readFile: async (absolutePath) => {
+      if (absolutePath.endsWith("broken.js")) throw new Error("EACCES");
+      return "readableIdentifier";
+    },
+  };
+  const result = await scanRepository("/repo", { tools });
+  assert.equal(result.filesRead, 1);
+  assert.ok(result.terms.includes("readableIdentifier"));
+});
+
+test("skips a pathologically large file rather than reading it into the term count", async () => {
+  const tools = fakeTools({
+    "src/generated.js": "x".repeat(300_000) + " realIdentifier",
+    "src/normal.js": "normalIdentifier",
+  });
+  const result = await scanRepository("/repo", { tools });
+  assert.equal(result.filesRead, 1);
+  assert.ok(result.terms.includes("normalIdentifier"));
+  assert.ok(!result.terms.includes("realIdentifier"));
+});
+
+test("caps the term count to maxTerms, keeping the most frequent", async () => {
+  const source = Array.from({ length: 10 }, (_, i) => `term${i} `.repeat(10 - i)).join(" ");
+  const tools = fakeTools({ "src/x.js": source });
+  const result = await scanRepository("/repo", { tools, maxTerms: 3 });
+  assert.equal(result.terms.length, 3);
+  assert.deepEqual(result.terms, ["term0", "term1", "term2"]);
+});
+
+test("buildPrompt joins terms with a comma and stays within the char budget", () => {
+  assert.equal(buildPrompt([]), "");
+  assert.equal(buildPrompt(["alpha", "beta", "gamma"]), "alpha, beta, gamma");
+
+  const long = buildPrompt(["a".repeat(10), "b".repeat(10), "c".repeat(10)], { charBudget: 15 });
+  // First term (10 chars) fits; second would need +12 (", " + 10), pushing
+  // past the 15 budget, so only the first is kept.
+  assert.equal(long, "a".repeat(10));
+});
+
+test("real fixture: this repo's own git ls-files path works end to end", async () => {
+  const repoRoot = path.resolve(__dirname, "..");
+  const result = await scanRepository(repoRoot, { maxTerms: 20 });
+  assert.ok(result.filesRead > 0, "should have read at least one real source file");
+  assert.ok(result.terms.length > 0, "should have extracted at least one real identifier");
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,10 @@
 import HotkeySettings from "./HotkeySettings";
 import BreakSafeAppsSettings from "./BreakSafeAppsSettings";
-import VocabularySettings from "./VocabularySettings";
+// VocabularySettings (#16) is deliberately not rendered - deprioritised to
+// post-v1.0 (see the issue thread). The scanning/caching/pipeline wiring
+// underneath it is built and tested and stays as-is; only the UI is hidden,
+// so this is a one-line change to bring back once it's picked up again.
+// import VocabularySettings from "./VocabularySettings";
 
 export default function App() {
   return (
@@ -8,7 +12,6 @@ export default function App() {
       <h1>OpenStream Settings</h1>
       <HotkeySettings />
       <BreakSafeAppsSettings />
-      <VocabularySettings />
     </main>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import HotkeySettings from "./HotkeySettings";
 import BreakSafeAppsSettings from "./BreakSafeAppsSettings";
+import VocabularySettings from "./VocabularySettings";
 
 export default function App() {
   return (
@@ -7,6 +8,7 @@ export default function App() {
       <h1>OpenStream Settings</h1>
       <HotkeySettings />
       <BreakSafeAppsSettings />
+      <VocabularySettings />
     </main>
   );
 }

--- a/src/VocabularySettings.tsx
+++ b/src/VocabularySettings.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useState } from "react";
+import type { VocabularyStatus } from "./openstreamBridge";
+
+export default function VocabularySettings() {
+  const [projectPath, setProjectPath] = useState<string | null>(null);
+  const [status, setStatus] = useState<VocabularyStatus | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    window.openstream.settings.get().then((settings) => setProjectPath(settings.vocabularyProjectPath));
+    window.openstream.vocabulary.getStatus().then(setStatus);
+  }, []);
+
+  function applyPath(next: string | null) {
+    setSaving(true);
+    setError(null);
+    window.openstream.settings
+      .setVocabularyProjectPath(next)
+      .then(({ settings, status: newStatus }) => {
+        setProjectPath(settings.vocabularyProjectPath);
+        setStatus(newStatus);
+      })
+      .catch((err) => setError(err instanceof Error ? err.message : String(err)))
+      .finally(() => setSaving(false));
+  }
+
+  function chooseFolder() {
+    window.openstream.vocabulary.chooseFolder().then((chosen) => {
+      if (chosen) applyPath(chosen);
+    });
+  }
+
+  function rescan() {
+    setSaving(true);
+    setError(null);
+    window.openstream.vocabulary
+      .rescan()
+      .then(setStatus)
+      .catch((err) => setError(err instanceof Error ? err.message : String(err)))
+      .finally(() => setSaving(false));
+  }
+
+  return (
+    <section className="setting">
+      <h2>Codebase vocabulary</h2>
+      <p>
+        Point this at a git repo and its identifiers (function names, variable names, project-specific terms) bias
+        transcription toward your project's own vocabulary. Off by default - no repo configured means no bias.
+      </p>
+      <div className="break-safe-add">
+        <input
+          type="text"
+          placeholder="/path/to/your/repo"
+          value={projectPath ?? ""}
+          onChange={(event) => setProjectPath(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") applyPath(projectPath?.trim() || null);
+          }}
+          disabled={saving}
+        />
+        <button onClick={chooseFolder} disabled={saving}>
+          Browse
+        </button>
+        <button onClick={() => applyPath(projectPath?.trim() || null)} disabled={saving}>
+          Set
+        </button>
+      </div>
+      {projectPath && (
+        <button onClick={() => applyPath(null)} disabled={saving}>
+          Clear
+        </button>
+      )}
+      <p className="setting-current">
+        {status && status.path
+          ? `${status.termCount} terms from ${status.filesRead} files, last scanned ${
+              status.scannedAt ? status.scannedAt.toLocaleTimeString() : "never"
+            }`
+          : "No project configured."}
+      </p>
+      <button onClick={rescan} disabled={saving || !projectPath}>
+        Rescan
+      </button>
+      {error && <p className="setting-error">{error}</p>}
+    </section>
+  );
+}

--- a/src/openstreamBridge.d.ts
+++ b/src/openstreamBridge.d.ts
@@ -1,6 +1,19 @@
 import type { StoredHotkey } from "./hotkey/captureHotkey";
 
-export type StoredSettings = { hotkey: StoredHotkey; breakSafeApps: string[] };
+export type StoredSettings = {
+  hotkey: StoredHotkey;
+  breakSafeApps: string[];
+  vocabularyProjectPath: string | null;
+};
+
+export type VocabularyStatus = {
+  path: string | null;
+  termCount: number;
+  filesRead: number;
+  // Electron's IPC uses the structured clone algorithm, which preserves
+  // Date instances - this arrives as a real Date, not a serialized string.
+  scannedAt: Date | null;
+};
 
 // Exposed by preload.js via contextBridge - see the comment there for what
 // this is expected to grow into.
@@ -11,6 +24,14 @@ declare global {
         get(): Promise<StoredSettings>;
         setHotkey(hotkey: StoredHotkey): Promise<StoredSettings>;
         setBreakSafeApps(apps: string[]): Promise<StoredSettings>;
+        setVocabularyProjectPath(
+          projectPath: string | null
+        ): Promise<{ settings: StoredSettings; status: VocabularyStatus }>;
+      };
+      vocabulary: {
+        rescan(): Promise<VocabularyStatus>;
+        getStatus(): Promise<VocabularyStatus>;
+        chooseFolder(): Promise<string | null>;
       };
     };
   }


### PR DESCRIPTION
Closes #16

**Status: deprioritised to post-v1.0, per the issue thread.** MVP needs plain dictation working excellently first - this is a polish feature, not core. The Settings UI is unhooked (`App.tsx` no longer renders `VocabularySettings`), but the underlying scanning/caching/pipeline wiring is built, tested, and left in place rather than deleted - it's opt-in and inert with no UI to trigger it, so there's no reason to throw the work away. `ROADMAP.md` and the issue's milestone/labels updated to match.

## Summary
- **Verified the mechanism first, before building on it.** whisper-server's `/inference` endpoint accepts a per-request `prompt` form field (not just a server-startup flag). Confirmed directly against the pinned binary: with `prompt="useEffect, useState, React"`, a TTS dictation of "the react component uses use effect and use state" came back with useState matching the prompt's exact casing; without the prompt it came back UseState. Real, measured, not assumed from docs.
- **`electron/vocabularyScanner.js`** - `git ls-files` a configured repo (respects `.gitignore` for free), reads source files only (extension allowlist), extracts identifiers, filters language keywords and short terms, frequency-ranks, caps to a prompt-sized budget. DI'd the same way `scripts/model-artifacts.mjs` is, so it's testable without a real filesystem - plus one real end-to-end test against this repo's own source.
- **`electron/vocabularyCache.js`** - scanning happens once per rescan, not per-dictation; every dictation just reads the cached prompt. A failed rescan propagates the error and leaves the previous good cache in place.
- **`electron/dictationCoordinator.js`** / **`transcriptionHttpAdapter.js`** - optional `vocabulary` adapter (no-op default, empty prompt) wired into the transcribe call, plus a `vocabulary.promptLength` diagnostic. All pre-existing coordinator tests untouched and still passing.
- **`electron/settingsStore.js`** - `vocabularyProjectPath`, defaults to `null` (opt-in).
- **`electron/main.js`** - IPC handlers (`settings:set-vocabulary-path`, `vocabulary:rescan`/`get-status`/`choose-folder`), fire-and-forget rescan on launch if a path is already configured.
- **`src/VocabularySettings.tsx`** - built, tested via typecheck/build, but not currently rendered by `App.tsx` (see status note above).

## Design decision made explicitly, not guessed
How does the app know *which* repo to scan, given it has no existing way to know what you're working on? Asked before building: user sets a path in Settings (not AX-based auto-detection) - given this whole session's experience with how unreliable Chromium/Electron AX document-attribute detection is, that felt like the wrong foundation for a v1.

## Also found, not fixed here
- `src/dictation/` (`coordinator.ts`, `cleanup.ts`, etc.) is dead code - an abandoned early prototype from the very first commits (#91/#95), never imported anywhere, fully superseded by `electron/dictationCoordinator.js`. Didn't touch it to keep this PR scoped to #16; worth its own small cleanup PR.
- `breakPlacementHttpAdapter.test.js` has two tests that deterministically fail under Node 22 (`AbortSignal.timeout`/`node --test` interaction, unrelated to anything this PR touches) - filed as #186.
- Real dictation testing surfaced that a configured project path's effect on live output wasn't visually obvious - added the `vocabulary.promptLength` diagnostic to check whether the prompt is actually reaching `transcribe()`, but this hasn't been read back yet. That verification is exactly the kind of thing worth finishing before the UI is re-enabled post-v1.0.

## Test plan
- [x] `node --test` on every touched file - all passing, including a real end-to-end scan of this repo's own source and a real whisper-server prompt-field verification (done ad hoc, not committed as a test - needs a resident server).
- [x] `npm install` - clean, full postinstall chain succeeded.
- [x] `npm run typecheck` - zero errors, including with `VocabularySettings.tsx` present but unreferenced.
- [x] `npm run build` - clean production build (35 modules, confirms the unreferenced component is correctly excluded).
- [x] `npm test` (full suite) - all passing except two pre-existing, unrelated tests tracked in #186.
- [x] Manual run: model servers start cleanly, dictation works end to end.
- [ ] Vocabulary bias end-to-end verification with the new diagnostic - not done yet, left for whenever this is picked back up.
