### PR TITLE
Voice-edit fidelity spike: SmolLM2-1.7B verdict is no (#222)

### DIFF
--- a/prototypes/voice-edit-fidelity-222/README.md
+++ b/prototypes/voice-edit-fidelity-222/README.md
@@ -1,0 +1,23 @@
+# prototypes/voice-edit-fidelity-222
+
+Throwaway spike for [issue #222](https://github.com/Nabzx/openstream/issues/222):
+can a prompted local rewrite model follow a spoken edit command faithfully enough
+to ship voice editing ([#17](https://github.com/Nabzx/openstream/issues/17))?
+
+**Answer: no, not with SmolLM2-1.7B.** See `RESULTS.md`.
+
+## Files
+
+| | |
+| --- | --- |
+| `corpus.json` | 15 selection + spoken-command cases: tested-core, preservation (the #24 meaning-drift risk), adversarial (over-reach, questions, no-ops). |
+| `prompts.mjs` | Three prompt variants — `zero-shot`, `strict`, `one-shot`. |
+| `guards.mjs` | The deterministic guards from #17's decision (empty / >3× length / chatter-prefix). |
+| `run.mjs` | `node run.mjs --url <chat-completions-url>` → runs every variant × case, writes `results.json`. Does not start a server. |
+| `review.mjs` | `node review.mjs > review.html` → static page for hand-judging faithfulness. |
+| `results.json`, `review.html` | The 2026-08-28 run. |
+
+## Re-running against another model
+
+`run.mjs` only needs a URL, so pointing it at a different rewrite model server
+(Qwen3-1.7B, Granite-3.3-2B, … per #192) is a one-command re-test.

--- a/prototypes/voice-edit-fidelity-222/RESULTS.md
+++ b/prototypes/voice-edit-fidelity-222/RESULTS.md
@@ -1,0 +1,92 @@
+# Results — voice-edit fidelity spike (#222)
+
+Run 2026-08-28 on the driving machine (macOS 26.2, Apple Silicon), against the
+repo's own pinned `resources/bin/llama/llama-server` + `smollm2-1.7b-instruct-q4_k_m.gguf`
+at a 2048-token context — the rewrite model server exactly as production configures it.
+15 cases × 3 prompt variants. Faithfulness judged by hand from `review.html`; the
+raw data is in `results.json`.
+
+## Verdict: **No.** Prompting SmolLM2-1.7B does not clear the bar for voice editing.
+
+The model handles deterministic string transforms and is safely conservative on
+vague/adversarial commands, but it **will not reliably perform the two commands the
+feature is pitched on** — "make this a bullet list" and "make this shorter" — under
+any of the three prompts tried. It either silently returns the text unchanged or,
+when pushed with an example, does the wrong transform and adds artefacts.
+
+## Latency — not a concern
+
+Warm, single request: **min 266ms, median ~900ms, max 2.5s** across all variants.
+Comfortably inside the "multi-second is acceptable but must be visible" bar from #17.
+Model load (cold start) was ~1.3s with the file warm in disk cache.
+
+## Faithfulness by variant
+
+Hand-judged; "acceptable" = applied the instruction and only the instruction.
+
+### zero-shot (plain contract prompt)
+
+| Bucket | Acceptable | Notes |
+| --- | --- | --- |
+| tested-core (8) | **3–4 / 8** | `snake_case`, `camelCase`, numbered list: clean. `capitalise`: missed "for", changed "macos"→"MacOS". `fix grammar`: partial (tense shift, "Me and him" left). "shorter": deleted one word only. **both bullet-list cases returned unchanged.** |
+| preservation (2) | 1 / 2 | hedge kept ✓. "shorter" silently dropped "Tuesday". |
+| adversarial (5) | 4 / 5 | correctly left vague/question/leave-alone cases untouched. Translated to (wrong) French when asked. |
+
+### strict (zero-shot + "you MUST carry out the instruction, don't add bullets unless asked")
+
+**No improvement.** 7/15 returned unchanged — one *more* than zero-shot. The
+bullet-list cases still came back verbatim; "make this shorter" got *worse* (fully
+unchanged where zero-shot at least trimmed a word). Telling it harder does not make
+it able.
+
+### one-shot (one worked bullet-list example)
+
+**Worse.** The single example contaminates every case: spurious `-` markers added to
+plain sentences (`adv-make-better`, `adv-leave-alone`, `preserve-hedge`), "make this
+shorter" turned into a bullet list, "make this a numbered list" rendered as dashes,
+`camelCase` broke to `snake_case`, and `preserve-number-name` was reduced to
+"- Latency dropped by 43 milliseconds" — Priya, Tuesday and the deployment context
+all gone. Same pattern #67 measured for break placement: the example doesn't remove
+the bias, it *is* the bias.
+
+## The #17 guards don't catch the real failure modes
+
+**0 / 45 guard rejections** across all runs. The guards (empty / >3× length /
+chatter-prefix) are designed for a model that rambles — but SmolLM2 fails by
+*doing nothing* or *doing the wrong transform cleanly*. Neither is deterministically
+detectable:
+
+- An "returned unchanged" check would catch the zero-shot no-ops (6–7 per run) —
+  worth adding to #17's contract — but that just converts a silent no-op into an
+  error message, it doesn't make the edit happen.
+- Nothing deterministic catches "did a bullet list when asked to shorten" or
+  "dropped a proper noun".
+
+## What this means for #17
+
+The design in #17's decision comment is sound; the model in the role is not. Options,
+in order of preference:
+
+1. **Narrow #17's launch surface to what actually works**: identifier case
+   conversions and list *numbering/bulleting of already-delimited items*, shipped as
+   a small fixed set with the "returned unchanged → tell the user" guard. Drop the
+   open natural-language surface until the model improves. This is a much smaller
+   feature than the pitch.
+2. **Wait for a better model in the rewrite role** — re-run this exact spike against
+   the #192 candidates (Qwen3-1.7B, Granite-3.3-2B, OLMo-2-1B). `run.mjs` takes
+   `--url`, so this is a one-command re-test once another server is available.
+3. **Defer voice editing past v0.3.**
+
+Recommend option 1 for scope-setting and option 2 as the parallel research task
+(add a child ticket to re-run this against Qwen3 / Granite).
+
+## Reproducing
+
+```
+# start the rewrite model server on any port
+resources/bin/llama/llama-server --model resources/models/smollm2-1.7b-instruct-q4_k_m.gguf \
+  --host 127.0.0.1 --port 8199 --ctx-size 2048
+# run the corpus
+node prototypes/voice-edit-fidelity-222/run.mjs --url http://127.0.0.1:8199/v1/chat/completions
+node prototypes/voice-edit-fidelity-222/review.mjs > prototypes/voice-edit-fidelity-222/review.html
+```

--- a/prototypes/voice-edit-fidelity-222/corpus.json
+++ b/prototypes/voice-edit-fidelity-222/corpus.json
@@ -1,0 +1,125 @@
+{
+  "note": "Selection + spoken-command pairs for issue #222. `expect` is a short human-readable description of the only acceptable change; `category` groups the case; `check` names the specific failure this case is probing for.",
+  "cases": [
+    {
+      "id": "core-bullets-commalist",
+      "category": "tested-core",
+      "instruction": "make this a bullet list",
+      "selection": "Buy milk, eggs, bread and coffee. Also pick up a birthday card.",
+      "expect": "Same items, one per line, each with a bullet marker. No items added or dropped.",
+      "check": "applies a structural transform at all"
+    },
+    {
+      "id": "core-bullets-sentences",
+      "category": "tested-core",
+      "instruction": "turn this into a bullet list",
+      "selection": "The build compiles the two engines from pinned commits. It downloads both models from pinned revisions. Every file is SHA-256 verified.",
+      "expect": "Three bullets, one per sentence, wording preserved.",
+      "check": "one bullet per idea, no rewording"
+    },
+    {
+      "id": "core-shorter",
+      "category": "tested-core",
+      "instruction": "make this shorter",
+      "selection": "I just wanted to quickly follow up on the thing we were talking about earlier today, because I think it might actually be quite important for us to sort out before the end of the week if at all possible.",
+      "expect": "Noticeably shorter, same core ask (follow up, important, sort out before end of week).",
+      "check": "shortens without losing the ask"
+    },
+    {
+      "id": "core-fix-grammar",
+      "category": "tested-core",
+      "instruction": "fix the grammar",
+      "selection": "Me and him was going to the shops but we dont has enough time.",
+      "expect": "Grammatical version, same meaning: 'He and I were going to the shops but we don't have enough time.'",
+      "check": "corrects errors only"
+    },
+    {
+      "id": "core-snake-case",
+      "category": "tested-core",
+      "instruction": "snake case that",
+      "selection": "getUserProfileData",
+      "expect": "get_user_profile_data",
+      "check": "exact identifier transform"
+    },
+    {
+      "id": "core-camel-case",
+      "category": "tested-core",
+      "instruction": "make this camel case",
+      "selection": "user profile display name",
+      "expect": "userProfileDisplayName",
+      "check": "exact identifier transform"
+    },
+    {
+      "id": "core-numbered-list",
+      "category": "tested-core",
+      "instruction": "make this a numbered list",
+      "selection": "First open the settings window. Then pick a new shortcut. Finally relaunch the app.",
+      "expect": "Three numbered steps, wording preserved.",
+      "check": "numbered structure, no rewording"
+    },
+    {
+      "id": "core-capitalise",
+      "category": "tested-core",
+      "instruction": "capitalise the first letter of each word",
+      "selection": "local first voice dictation for macos",
+      "expect": "Local First Voice Dictation For Macos",
+      "check": "casing only"
+    },
+    {
+      "id": "preserve-hedge",
+      "category": "preservation",
+      "instruction": "fix the grammar",
+      "selection": "I think this approach are the best one, but we should probaly check.",
+      "expect": "Grammar fixed; 'I think' and the tentativeness kept: 'I think this approach is the best one, but we should probably check.'",
+      "check": "does not drop the hedge (the #24 failure)"
+    },
+    {
+      "id": "preserve-number-name",
+      "category": "preservation",
+      "instruction": "make this shorter",
+      "selection": "According to the report that Priya sent over on Tuesday, the latency dropped by 43 milliseconds after the change was deployed to the fleet.",
+      "expect": "Shorter; keeps 'Priya', 'Tuesday', '43 milliseconds'.",
+      "check": "keeps specific facts"
+    },
+    {
+      "id": "adv-make-better",
+      "category": "adversarial",
+      "instruction": "make this better",
+      "selection": "The meeting is at 3pm in room 2.",
+      "expect": "A vague instruction on an already-clear sentence - minimal or no change is the faithful answer.",
+      "check": "does not over-rewrite on a vague command"
+    },
+    {
+      "id": "adv-question",
+      "category": "adversarial",
+      "instruction": "what does this mean",
+      "selection": "The settle guard refuses to trust a target until the frontmost app has been stable for 400ms.",
+      "expect": "This is a question, not an edit - the right behaviour is to return the text unchanged or signal that it is not an edit, NOT to answer the question.",
+      "check": "does not answer a question in place of editing"
+    },
+    {
+      "id": "adv-improve-comment",
+      "category": "adversarial",
+      "instruction": "improve this",
+      "selection": "// loop over the items and add each one to the set",
+      "expect": "Vague command on a fine comment - minimal change; must stay a comment, must not become code or prose.",
+      "check": "stays in-kind, minimal change"
+    },
+    {
+      "id": "adv-leave-alone",
+      "category": "adversarial",
+      "instruction": "leave this exactly as it is",
+      "selection": "Nothing about this sentence needs to change.",
+      "expect": "Returned verbatim.",
+      "check": "does not rewrite when told not to"
+    },
+    {
+      "id": "adv-out-of-scope",
+      "category": "adversarial",
+      "instruction": "translate this to French",
+      "selection": "The window remembers its size and position.",
+      "expect": "Out of the intended command surface. Either complies (documented) or returns unchanged - but must not add commentary about it.",
+      "check": "handles an off-surface command without chatter"
+    }
+  ]
+}

--- a/prototypes/voice-edit-fidelity-222/guards.mjs
+++ b/prototypes/voice-edit-fidelity-222/guards.mjs
@@ -1,0 +1,40 @@
+// The deterministic guards from #17's decision comment. They can only
+// reject an obviously-broken edit - they cannot judge faithfulness, which
+// is what the human review page is for. Returns { ok, reason, cleaned }.
+
+const CHATTER_PREFIXES = [
+  /^here('?s| is)\b/i,
+  /^sure[,!.]/i,
+  /^(the )?(edited|revised|updated|corrected|shortened) (text|version)\b/i,
+  /^okay[,!.]/i,
+  /^certainly[,!.]/i,
+];
+
+function stripWrappers(text) {
+  let t = text.trim();
+  // one layer of code fence
+  const fence = t.match(/^```[^\n]*\n([\s\S]*?)\n```$/);
+  if (fence) t = fence[1].trim();
+  // matching surrounding quotes
+  if ((t.startsWith('"') && t.endsWith('"')) || (t.startsWith("'") && t.endsWith("'"))) {
+    t = t.slice(1, -1);
+  }
+  return t;
+}
+
+export function applyGuards(rawOutput, selection) {
+  const cleaned = stripWrappers(rawOutput);
+
+  if (cleaned.length === 0) {
+    return { ok: false, reason: "empty", cleaned };
+  }
+  if (cleaned.length > selection.length * 3 + 40) {
+    return { ok: false, reason: "far longer than the selection", cleaned };
+  }
+  for (const pattern of CHATTER_PREFIXES) {
+    if (pattern.test(cleaned)) {
+      return { ok: false, reason: "starts with model chatter", cleaned };
+    }
+  }
+  return { ok: true, reason: null, cleaned };
+}

--- a/prototypes/voice-edit-fidelity-222/prompts.mjs
+++ b/prototypes/voice-edit-fidelity-222/prompts.mjs
@@ -1,0 +1,50 @@
+// Prompt variants for the voice-edit fidelity spike (#222). Each takes a
+// case ({ instruction, selection }) and returns a messages array. #67
+// found that a worked example moves the model's behaviour, so we test
+// zero-shot and one-shot.
+
+const RULES =
+  "You apply a single editing instruction to a piece of text the user has selected. " +
+  "Return ONLY the edited text: no preamble, no explanation, no surrounding quotes, no code fences. " +
+  "Change only what the instruction asks for. Preserve everything else - wording, meaning, names, numbers, and any hedges like \"I think\". " +
+  "If the instruction is a question rather than an edit, return the text unchanged.";
+
+function userTurn({ instruction, selection }) {
+  return `Instruction: ${instruction}\n\nSelected text:\n${selection}`;
+}
+
+export const PROMPTS = {
+  "zero-shot": (testCase) => [
+    { role: "system", content: RULES },
+    { role: "user", content: userTurn(testCase) },
+  ],
+
+  "strict": (testCase) => [
+    {
+      role: "system",
+      content:
+        RULES +
+        " You MUST carry out the instruction - do not return the text unchanged unless the instruction is a question or explicitly says to leave it alone. " +
+        "Do not add bullet points, numbering, or list formatting unless the instruction asks for a list.",
+    },
+    { role: "user", content: userTurn(testCase) },
+  ],
+
+  "one-shot": (testCase) => [
+    { role: "system", content: RULES },
+    {
+      role: "user",
+      content: userTurn({
+        instruction: "make this a bullet list",
+        selection: "We need to book the venue, send the invites and order the cake.",
+      }),
+    },
+    {
+      role: "assistant",
+      content: "- We need to book the venue\n- Send the invites\n- Order the cake",
+    },
+    { role: "user", content: userTurn(testCase) },
+  ],
+};
+
+export const SAMPLING = { temperature: 0, n_predict: 512, stream: false };

--- a/prototypes/voice-edit-fidelity-222/results.json
+++ b/prototypes/voice-edit-fidelity-222/results.json
@@ -1,0 +1,1073 @@
+{
+  "ranAt": "2026-08-28T15:58:48.073Z",
+  "url": "http://127.0.0.1:8199/v1/chat/completions",
+  "summary": {
+    "zero-shot": {
+      "cases": 15,
+      "guardRejected": 0,
+      "returnedUnchanged": 6,
+      "latencyMs": {
+        "min": 370,
+        "median": 861,
+        "max": 2269
+      }
+    },
+    "strict": {
+      "cases": 15,
+      "guardRejected": 0,
+      "returnedUnchanged": 7,
+      "latencyMs": {
+        "min": 266,
+        "median": 1018,
+        "max": 2539
+      }
+    },
+    "one-shot": {
+      "cases": 15,
+      "guardRejected": 0,
+      "returnedUnchanged": 1,
+      "latencyMs": {
+        "min": 456,
+        "median": 926,
+        "max": 2802
+      }
+    }
+  },
+  "runs": [
+    {
+      "variant": "zero-shot",
+      "id": "core-bullets-commalist",
+      "category": "tested-core",
+      "instruction": "make this a bullet list",
+      "selection": "Buy milk, eggs, bread and coffee. Also pick up a birthday card.",
+      "expect": "Same items, one per line, each with a bullet marker. No items added or dropped.",
+      "check": "applies a structural transform at all",
+      "rawOutput": "Buy milk, eggs, bread and coffee. Also pick up a birthday card.",
+      "cleanedOutput": "Buy milk, eggs, bread and coffee. Also pick up a birthday card.",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": true,
+      "latencyMs": 861,
+      "usage": {
+        "completion_tokens": 17,
+        "prompt_tokens": 125,
+        "total_tokens": 142,
+        "prompt_tokens_details": {
+          "cached_tokens": 124
+        }
+      }
+    },
+    {
+      "variant": "zero-shot",
+      "id": "core-bullets-sentences",
+      "category": "tested-core",
+      "instruction": "turn this into a bullet list",
+      "selection": "The build compiles the two engines from pinned commits. It downloads both models from pinned revisions. Every file is SHA-256 verified.",
+      "expect": "Three bullets, one per sentence, wording preserved.",
+      "check": "one bullet per idea, no rewording",
+      "rawOutput": "The build compiles the two engines from pinned commits. It downloads both models from pinned revisions. Every file is SHA-256 verified.",
+      "cleanedOutput": "The build compiles the two engines from pinned commits. It downloads both models from pinned revisions. Every file is SHA-256 verified.",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": true,
+      "latencyMs": 1867,
+      "usage": {
+        "completion_tokens": 32,
+        "prompt_tokens": 141,
+        "total_tokens": 173,
+        "prompt_tokens_details": {
+          "cached_tokens": 140
+        }
+      }
+    },
+    {
+      "variant": "zero-shot",
+      "id": "core-shorter",
+      "category": "tested-core",
+      "instruction": "make this shorter",
+      "selection": "I just wanted to quickly follow up on the thing we were talking about earlier today, because I think it might actually be quite important for us to sort out before the end of the week if at all possible.",
+      "expect": "Noticeably shorter, same core ask (follow up, important, sort out before end of week).",
+      "check": "shortens without losing the ask",
+      "rawOutput": "I just wanted to follow up on the thing we were talking about earlier today, because I think it might actually be quite important for us to sort out before the end of the week if at all possible.",
+      "cleanedOutput": "I just wanted to follow up on the thing we were talking about earlier today, because I think it might actually be quite important for us to sort out before the end of the week if at all possible.",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": false,
+      "latencyMs": 2269,
+      "usage": {
+        "completion_tokens": 42,
+        "prompt_tokens": 149,
+        "total_tokens": 191,
+        "prompt_tokens_details": {
+          "cached_tokens": 148
+        }
+      }
+    },
+    {
+      "variant": "zero-shot",
+      "id": "core-fix-grammar",
+      "category": "tested-core",
+      "instruction": "fix the grammar",
+      "selection": "Me and him was going to the shops but we dont has enough time.",
+      "expect": "Grammatical version, same meaning: 'He and I were going to the shops but we don't have enough time.'",
+      "check": "corrects errors only",
+      "rawOutput": "Me and him were going to the shops, but we didn't have enough time.",
+      "cleanedOutput": "Me and him were going to the shops, but we didn't have enough time.",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": false,
+      "latencyMs": 1072,
+      "usage": {
+        "completion_tokens": 18,
+        "prompt_tokens": 122,
+        "total_tokens": 140,
+        "prompt_tokens_details": {
+          "cached_tokens": 121
+        }
+      }
+    },
+    {
+      "variant": "zero-shot",
+      "id": "core-snake-case",
+      "category": "tested-core",
+      "instruction": "snake case that",
+      "selection": "getUserProfileData",
+      "expect": "get_user_profile_data",
+      "check": "exact identifier transform",
+      "rawOutput": "get_user_profile_data",
+      "cleanedOutput": "get_user_profile_data",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": false,
+      "latencyMs": 397,
+      "usage": {
+        "completion_tokens": 8,
+        "prompt_tokens": 111,
+        "total_tokens": 119,
+        "prompt_tokens_details": {
+          "cached_tokens": 110
+        }
+      }
+    },
+    {
+      "variant": "zero-shot",
+      "id": "core-camel-case",
+      "category": "tested-core",
+      "instruction": "make this camel case",
+      "selection": "user profile display name",
+      "expect": "userProfileDisplayName",
+      "check": "exact identifier transform",
+      "rawOutput": "userProfileDisplayName",
+      "cleanedOutput": "userProfileDisplayName",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": false,
+      "latencyMs": 370,
+      "usage": {
+        "completion_tokens": 5,
+        "prompt_tokens": 112,
+        "total_tokens": 117,
+        "prompt_tokens_details": {
+          "cached_tokens": 111
+        }
+      }
+    },
+    {
+      "variant": "zero-shot",
+      "id": "core-numbered-list",
+      "category": "tested-core",
+      "instruction": "make this a numbered list",
+      "selection": "First open the settings window. Then pick a new shortcut. Finally relaunch the app.",
+      "expect": "Three numbered steps, wording preserved.",
+      "check": "numbered structure, no rewording",
+      "rawOutput": "1. First open the settings window.\n2. Then pick a new shortcut.\n3. Finally relaunch the app.",
+      "cleanedOutput": "1. First open the settings window.\n2. Then pick a new shortcut.\n3. Finally relaunch the app.",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": false,
+      "latencyMs": 1520,
+      "usage": {
+        "completion_tokens": 28,
+        "prompt_tokens": 128,
+        "total_tokens": 156,
+        "prompt_tokens_details": {
+          "cached_tokens": 127
+        }
+      }
+    },
+    {
+      "variant": "zero-shot",
+      "id": "core-capitalise",
+      "category": "tested-core",
+      "instruction": "capitalise the first letter of each word",
+      "selection": "local first voice dictation for macos",
+      "expect": "Local First Voice Dictation For Macos",
+      "check": "casing only",
+      "rawOutput": "Local First Voice Dictation for MacOS",
+      "cleanedOutput": "Local First Voice Dictation for MacOS",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": false,
+      "latencyMs": 459,
+      "usage": {
+        "completion_tokens": 9,
+        "prompt_tokens": 120,
+        "total_tokens": 129,
+        "prompt_tokens_details": {
+          "cached_tokens": 119
+        }
+      }
+    },
+    {
+      "variant": "zero-shot",
+      "id": "preserve-hedge",
+      "category": "preservation",
+      "instruction": "fix the grammar",
+      "selection": "I think this approach are the best one, but we should probaly check.",
+      "expect": "Grammar fixed; 'I think' and the tentativeness kept: 'I think this approach is the best one, but we should probably check.'",
+      "check": "does not drop the hedge (the #24 failure)",
+      "rawOutput": "I think this approach is the best one, but we should probably check.",
+      "cleanedOutput": "I think this approach is the best one, but we should probably check.",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": false,
+      "latencyMs": 846,
+      "usage": {
+        "completion_tokens": 16,
+        "prompt_tokens": 123,
+        "total_tokens": 139,
+        "prompt_tokens_details": {
+          "cached_tokens": 122
+        }
+      }
+    },
+    {
+      "variant": "zero-shot",
+      "id": "preserve-number-name",
+      "category": "preservation",
+      "instruction": "make this shorter",
+      "selection": "According to the report that Priya sent over on Tuesday, the latency dropped by 43 milliseconds after the change was deployed to the fleet.",
+      "expect": "Shorter; keeps 'Priya', 'Tuesday', '43 milliseconds'.",
+      "check": "keeps specific facts",
+      "rawOutput": "According to Priya's report, the latency dropped by 43 milliseconds after the change was deployed.",
+      "cleanedOutput": "According to Priya's report, the latency dropped by 43 milliseconds after the change was deployed.",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": false,
+      "latencyMs": 1154,
+      "usage": {
+        "completion_tokens": 22,
+        "prompt_tokens": 136,
+        "total_tokens": 158,
+        "prompt_tokens_details": {
+          "cached_tokens": 135
+        }
+      }
+    },
+    {
+      "variant": "zero-shot",
+      "id": "adv-make-better",
+      "category": "adversarial",
+      "instruction": "make this better",
+      "selection": "The meeting is at 3pm in room 2.",
+      "expect": "A vague instruction on an already-clear sentence - minimal or no change is the faithful answer.",
+      "check": "does not over-rewrite on a vague command",
+      "rawOutput": "The meeting is at 3pm in room 2.",
+      "cleanedOutput": "The meeting is at 3pm in room 2.",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": true,
+      "latencyMs": 699,
+      "usage": {
+        "completion_tokens": 13,
+        "prompt_tokens": 119,
+        "total_tokens": 132,
+        "prompt_tokens_details": {
+          "cached_tokens": 118
+        }
+      }
+    },
+    {
+      "variant": "zero-shot",
+      "id": "adv-question",
+      "category": "adversarial",
+      "instruction": "what does this mean",
+      "selection": "The settle guard refuses to trust a target until the frontmost app has been stable for 400ms.",
+      "expect": "This is a question, not an edit - the right behaviour is to return the text unchanged or signal that it is not an edit, NOT to answer the question.",
+      "check": "does not answer a question in place of editing",
+      "rawOutput": "The settle guard refuses to trust a target until the frontmost app has been stable for 400ms.",
+      "cleanedOutput": "The settle guard refuses to trust a target until the frontmost app has been stable for 400ms.",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": true,
+      "latencyMs": 1296,
+      "usage": {
+        "completion_tokens": 24,
+        "prompt_tokens": 131,
+        "total_tokens": 155,
+        "prompt_tokens_details": {
+          "cached_tokens": 130
+        }
+      }
+    },
+    {
+      "variant": "zero-shot",
+      "id": "adv-improve-comment",
+      "category": "adversarial",
+      "instruction": "improve this",
+      "selection": "// loop over the items and add each one to the set",
+      "expect": "Vague command on a fine comment - minimal change; must stay a comment, must not become code or prose.",
+      "check": "stays in-kind, minimal change",
+      "rawOutput": "// loop over the items and add each one to the set",
+      "cleanedOutput": "// loop over the items and add each one to the set",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": true,
+      "latencyMs": 677,
+      "usage": {
+        "completion_tokens": 13,
+        "prompt_tokens": 118,
+        "total_tokens": 131,
+        "prompt_tokens_details": {
+          "cached_tokens": 117
+        }
+      }
+    },
+    {
+      "variant": "zero-shot",
+      "id": "adv-leave-alone",
+      "category": "adversarial",
+      "instruction": "leave this exactly as it is",
+      "selection": "Nothing about this sentence needs to change.",
+      "expect": "Returned verbatim.",
+      "check": "does not rewrite when told not to",
+      "rawOutput": "Nothing about this sentence needs to change.",
+      "cleanedOutput": "Nothing about this sentence needs to change.",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": true,
+      "latencyMs": 477,
+      "usage": {
+        "completion_tokens": 9,
+        "prompt_tokens": 118,
+        "total_tokens": 127,
+        "prompt_tokens_details": {
+          "cached_tokens": 117
+        }
+      }
+    },
+    {
+      "variant": "zero-shot",
+      "id": "adv-out-of-scope",
+      "category": "adversarial",
+      "instruction": "translate this to French",
+      "selection": "The window remembers its size and position.",
+      "expect": "Out of the intended command surface. Either complies (documented) or returns unchanged - but must not add commentary about it.",
+      "check": "handles an off-surface command without chatter",
+      "rawOutput": "La fenêtre réfère à sa taille et à sa position.",
+      "cleanedOutput": "La fenêtre réfère à sa taille et à sa position.",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": false,
+      "latencyMs": 910,
+      "usage": {
+        "completion_tokens": 18,
+        "prompt_tokens": 116,
+        "total_tokens": 134,
+        "prompt_tokens_details": {
+          "cached_tokens": 115
+        }
+      }
+    },
+    {
+      "variant": "strict",
+      "id": "core-bullets-commalist",
+      "category": "tested-core",
+      "instruction": "make this a bullet list",
+      "selection": "Buy milk, eggs, bread and coffee. Also pick up a birthday card.",
+      "expect": "Same items, one per line, each with a bullet marker. No items added or dropped.",
+      "check": "applies a structural transform at all",
+      "rawOutput": "Buy milk, eggs, bread and coffee. Also pick up a birthday card.",
+      "cleanedOutput": "Buy milk, eggs, bread and coffee. Also pick up a birthday card.",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": true,
+      "latencyMs": 851,
+      "usage": {
+        "completion_tokens": 17,
+        "prompt_tokens": 171,
+        "total_tokens": 188,
+        "prompt_tokens_details": {
+          "cached_tokens": 170
+        }
+      }
+    },
+    {
+      "variant": "strict",
+      "id": "core-bullets-sentences",
+      "category": "tested-core",
+      "instruction": "turn this into a bullet list",
+      "selection": "The build compiles the two engines from pinned commits. It downloads both models from pinned revisions. Every file is SHA-256 verified.",
+      "expect": "Three bullets, one per sentence, wording preserved.",
+      "check": "one bullet per idea, no rewording",
+      "rawOutput": "The build compiles the two engines from pinned commits. It downloads both models from pinned revisions. Every file is SHA-256 verified.",
+      "cleanedOutput": "The build compiles the two engines from pinned commits. It downloads both models from pinned revisions. Every file is SHA-256 verified.",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": true,
+      "latencyMs": 1753,
+      "usage": {
+        "completion_tokens": 32,
+        "prompt_tokens": 187,
+        "total_tokens": 219,
+        "prompt_tokens_details": {
+          "cached_tokens": 186
+        }
+      }
+    },
+    {
+      "variant": "strict",
+      "id": "core-shorter",
+      "category": "tested-core",
+      "instruction": "make this shorter",
+      "selection": "I just wanted to quickly follow up on the thing we were talking about earlier today, because I think it might actually be quite important for us to sort out before the end of the week if at all possible.",
+      "expect": "Noticeably shorter, same core ask (follow up, important, sort out before end of week).",
+      "check": "shortens without losing the ask",
+      "rawOutput": "I just wanted to quickly follow up on the thing we were talking about earlier today, because I think it might actually be quite important for us to sort out before the end of the week if at all possible.",
+      "cleanedOutput": "I just wanted to quickly follow up on the thing we were talking about earlier today, because I think it might actually be quite important for us to sort out before the end of the week if at all possible.",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": true,
+      "latencyMs": 2539,
+      "usage": {
+        "completion_tokens": 43,
+        "prompt_tokens": 195,
+        "total_tokens": 238,
+        "prompt_tokens_details": {
+          "cached_tokens": 194
+        }
+      }
+    },
+    {
+      "variant": "strict",
+      "id": "core-fix-grammar",
+      "category": "tested-core",
+      "instruction": "fix the grammar",
+      "selection": "Me and him was going to the shops but we dont has enough time.",
+      "expect": "Grammatical version, same meaning: 'He and I were going to the shops but we don't have enough time.'",
+      "check": "corrects errors only",
+      "rawOutput": "Me and him were going to the shops, but we didn't have enough time.",
+      "cleanedOutput": "Me and him were going to the shops, but we didn't have enough time.",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": false,
+      "latencyMs": 1172,
+      "usage": {
+        "completion_tokens": 18,
+        "prompt_tokens": 168,
+        "total_tokens": 186,
+        "prompt_tokens_details": {
+          "cached_tokens": 167
+        }
+      }
+    },
+    {
+      "variant": "strict",
+      "id": "core-snake-case",
+      "category": "tested-core",
+      "instruction": "snake case that",
+      "selection": "getUserProfileData",
+      "expect": "get_user_profile_data",
+      "check": "exact identifier transform",
+      "rawOutput": "get_user_profile_data",
+      "cleanedOutput": "get_user_profile_data",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": false,
+      "latencyMs": 426,
+      "usage": {
+        "completion_tokens": 8,
+        "prompt_tokens": 157,
+        "total_tokens": 165,
+        "prompt_tokens_details": {
+          "cached_tokens": 156
+        }
+      }
+    },
+    {
+      "variant": "strict",
+      "id": "core-camel-case",
+      "category": "tested-core",
+      "instruction": "make this camel case",
+      "selection": "user profile display name",
+      "expect": "userProfileDisplayName",
+      "check": "exact identifier transform",
+      "rawOutput": "userProfileDisplayName",
+      "cleanedOutput": "userProfileDisplayName",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": false,
+      "latencyMs": 266,
+      "usage": {
+        "completion_tokens": 5,
+        "prompt_tokens": 158,
+        "total_tokens": 163,
+        "prompt_tokens_details": {
+          "cached_tokens": 157
+        }
+      }
+    },
+    {
+      "variant": "strict",
+      "id": "core-numbered-list",
+      "category": "tested-core",
+      "instruction": "make this a numbered list",
+      "selection": "First open the settings window. Then pick a new shortcut. Finally relaunch the app.",
+      "expect": "Three numbered steps, wording preserved.",
+      "check": "numbered structure, no rewording",
+      "rawOutput": "1. First open the settings window.\n2. Then pick a new shortcut.\n3. Finally relaunch the app.",
+      "cleanedOutput": "1. First open the settings window.\n2. Then pick a new shortcut.\n3. Finally relaunch the app.",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": false,
+      "latencyMs": 1545,
+      "usage": {
+        "completion_tokens": 28,
+        "prompt_tokens": 174,
+        "total_tokens": 202,
+        "prompt_tokens_details": {
+          "cached_tokens": 173
+        }
+      }
+    },
+    {
+      "variant": "strict",
+      "id": "core-capitalise",
+      "category": "tested-core",
+      "instruction": "capitalise the first letter of each word",
+      "selection": "local first voice dictation for macos",
+      "expect": "Local First Voice Dictation For Macos",
+      "check": "casing only",
+      "rawOutput": "Local First Voice Dictation for MacOS",
+      "cleanedOutput": "Local First Voice Dictation for MacOS",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": false,
+      "latencyMs": 447,
+      "usage": {
+        "completion_tokens": 9,
+        "prompt_tokens": 166,
+        "total_tokens": 175,
+        "prompt_tokens_details": {
+          "cached_tokens": 165
+        }
+      }
+    },
+    {
+      "variant": "strict",
+      "id": "preserve-hedge",
+      "category": "preservation",
+      "instruction": "fix the grammar",
+      "selection": "I think this approach are the best one, but we should probaly check.",
+      "expect": "Grammar fixed; 'I think' and the tentativeness kept: 'I think this approach is the best one, but we should probably check.'",
+      "check": "does not drop the hedge (the #24 failure)",
+      "rawOutput": "I think this approach is the best one, but we should probably check.",
+      "cleanedOutput": "I think this approach is the best one, but we should probably check.",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": false,
+      "latencyMs": 859,
+      "usage": {
+        "completion_tokens": 16,
+        "prompt_tokens": 169,
+        "total_tokens": 185,
+        "prompt_tokens_details": {
+          "cached_tokens": 168
+        }
+      }
+    },
+    {
+      "variant": "strict",
+      "id": "preserve-number-name",
+      "category": "preservation",
+      "instruction": "make this shorter",
+      "selection": "According to the report that Priya sent over on Tuesday, the latency dropped by 43 milliseconds after the change was deployed to the fleet.",
+      "expect": "Shorter; keeps 'Priya', 'Tuesday', '43 milliseconds'.",
+      "check": "keeps specific facts",
+      "rawOutput": "According to Priya's report, the latency dropped by 43 milliseconds after the change was deployed.",
+      "cleanedOutput": "According to Priya's report, the latency dropped by 43 milliseconds after the change was deployed.",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": false,
+      "latencyMs": 1145,
+      "usage": {
+        "completion_tokens": 22,
+        "prompt_tokens": 182,
+        "total_tokens": 204,
+        "prompt_tokens_details": {
+          "cached_tokens": 181
+        }
+      }
+    },
+    {
+      "variant": "strict",
+      "id": "adv-make-better",
+      "category": "adversarial",
+      "instruction": "make this better",
+      "selection": "The meeting is at 3pm in room 2.",
+      "expect": "A vague instruction on an already-clear sentence - minimal or no change is the faithful answer.",
+      "check": "does not over-rewrite on a vague command",
+      "rawOutput": "The meeting is at 3pm in room 2.",
+      "cleanedOutput": "The meeting is at 3pm in room 2.",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": true,
+      "latencyMs": 674,
+      "usage": {
+        "completion_tokens": 13,
+        "prompt_tokens": 165,
+        "total_tokens": 178,
+        "prompt_tokens_details": {
+          "cached_tokens": 164
+        }
+      }
+    },
+    {
+      "variant": "strict",
+      "id": "adv-question",
+      "category": "adversarial",
+      "instruction": "what does this mean",
+      "selection": "The settle guard refuses to trust a target until the frontmost app has been stable for 400ms.",
+      "expect": "This is a question, not an edit - the right behaviour is to return the text unchanged or signal that it is not an edit, NOT to answer the question.",
+      "check": "does not answer a question in place of editing",
+      "rawOutput": "The settle guard refuses to trust a target until the frontmost app has been stable for 400ms.",
+      "cleanedOutput": "The settle guard refuses to trust a target until the frontmost app has been stable for 400ms.",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": true,
+      "latencyMs": 1636,
+      "usage": {
+        "completion_tokens": 24,
+        "prompt_tokens": 177,
+        "total_tokens": 201,
+        "prompt_tokens_details": {
+          "cached_tokens": 176
+        }
+      }
+    },
+    {
+      "variant": "strict",
+      "id": "adv-improve-comment",
+      "category": "adversarial",
+      "instruction": "improve this",
+      "selection": "// loop over the items and add each one to the set",
+      "expect": "Vague command on a fine comment - minimal change; must stay a comment, must not become code or prose.",
+      "check": "stays in-kind, minimal change",
+      "rawOutput": "// loop over the items and add each one to the set",
+      "cleanedOutput": "// loop over the items and add each one to the set",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": true,
+      "latencyMs": 1018,
+      "usage": {
+        "completion_tokens": 13,
+        "prompt_tokens": 164,
+        "total_tokens": 177,
+        "prompt_tokens_details": {
+          "cached_tokens": 163
+        }
+      }
+    },
+    {
+      "variant": "strict",
+      "id": "adv-leave-alone",
+      "category": "adversarial",
+      "instruction": "leave this exactly as it is",
+      "selection": "Nothing about this sentence needs to change.",
+      "expect": "Returned verbatim.",
+      "check": "does not rewrite when told not to",
+      "rawOutput": "Nothing about this sentence needs to change.",
+      "cleanedOutput": "Nothing about this sentence needs to change.",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": true,
+      "latencyMs": 639,
+      "usage": {
+        "completion_tokens": 9,
+        "prompt_tokens": 164,
+        "total_tokens": 173,
+        "prompt_tokens_details": {
+          "cached_tokens": 163
+        }
+      }
+    },
+    {
+      "variant": "strict",
+      "id": "adv-out-of-scope",
+      "category": "adversarial",
+      "instruction": "translate this to French",
+      "selection": "The window remembers its size and position.",
+      "expect": "Out of the intended command surface. Either complies (documented) or returns unchanged - but must not add commentary about it.",
+      "check": "handles an off-surface command without chatter",
+      "rawOutput": "La fenêtre réfère à sa taille et à sa position.",
+      "cleanedOutput": "La fenêtre réfère à sa taille et à sa position.",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": false,
+      "latencyMs": 1134,
+      "usage": {
+        "completion_tokens": 18,
+        "prompt_tokens": 162,
+        "total_tokens": 180,
+        "prompt_tokens_details": {
+          "cached_tokens": 161
+        }
+      }
+    },
+    {
+      "variant": "one-shot",
+      "id": "core-bullets-commalist",
+      "category": "tested-core",
+      "instruction": "make this a bullet list",
+      "selection": "Buy milk, eggs, bread and coffee. Also pick up a birthday card.",
+      "expect": "Same items, one per line, each with a bullet marker. No items added or dropped.",
+      "check": "applies a structural transform at all",
+      "rawOutput": "- Buy milk\n- Eggs\n- Bread\n- Coffee\n- Pick up a birthday card",
+      "cleanedOutput": "- Buy milk\n- Eggs\n- Bread\n- Coffee\n- Pick up a birthday card",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": false,
+      "latencyMs": 1786,
+      "usage": {
+        "completion_tokens": 20,
+        "prompt_tokens": 181,
+        "total_tokens": 201,
+        "prompt_tokens_details": {
+          "cached_tokens": 180
+        }
+      }
+    },
+    {
+      "variant": "one-shot",
+      "id": "core-bullets-sentences",
+      "category": "tested-core",
+      "instruction": "turn this into a bullet list",
+      "selection": "The build compiles the two engines from pinned commits. It downloads both models from pinned revisions. Every file is SHA-256 verified.",
+      "expect": "Three bullets, one per sentence, wording preserved.",
+      "check": "one bullet per idea, no rewording",
+      "rawOutput": "- Build compiles the two engines from pinned commits\n- Downloads both models from pinned revisions\n- Every file is SHA-256 verified",
+      "cleanedOutput": "- Build compiles the two engines from pinned commits\n- Downloads both models from pinned revisions\n- Every file is SHA-256 verified",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": false,
+      "latencyMs": 2802,
+      "usage": {
+        "completion_tokens": 33,
+        "prompt_tokens": 197,
+        "total_tokens": 230,
+        "prompt_tokens_details": {
+          "cached_tokens": 196
+        }
+      }
+    },
+    {
+      "variant": "one-shot",
+      "id": "core-shorter",
+      "category": "tested-core",
+      "instruction": "make this shorter",
+      "selection": "I just wanted to quickly follow up on the thing we were talking about earlier today, because I think it might actually be quite important for us to sort out before the end of the week if at all possible.",
+      "expect": "Noticeably shorter, same core ask (follow up, important, sort out before end of week).",
+      "check": "shortens without losing the ask",
+      "rawOutput": "- Follow up on earlier discussion\n- Important for us to sort out before week end",
+      "cleanedOutput": "- Follow up on earlier discussion\n- Important for us to sort out before week end",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": false,
+      "latencyMs": 1199,
+      "usage": {
+        "completion_tokens": 18,
+        "prompt_tokens": 205,
+        "total_tokens": 223,
+        "prompt_tokens_details": {
+          "cached_tokens": 204
+        }
+      }
+    },
+    {
+      "variant": "one-shot",
+      "id": "core-fix-grammar",
+      "category": "tested-core",
+      "instruction": "fix the grammar",
+      "selection": "Me and him was going to the shops but we dont has enough time.",
+      "expect": "Grammatical version, same meaning: 'He and I were going to the shops but we don't have enough time.'",
+      "check": "corrects errors only",
+      "rawOutput": "- I and he were going to the shops, but we didn't have enough time.",
+      "cleanedOutput": "- I and he were going to the shops, but we didn't have enough time.",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": false,
+      "latencyMs": 1100,
+      "usage": {
+        "completion_tokens": 19,
+        "prompt_tokens": 178,
+        "total_tokens": 197,
+        "prompt_tokens_details": {
+          "cached_tokens": 177
+        }
+      }
+    },
+    {
+      "variant": "one-shot",
+      "id": "core-snake-case",
+      "category": "tested-core",
+      "instruction": "snake case that",
+      "selection": "getUserProfileData",
+      "expect": "get_user_profile_data",
+      "check": "exact identifier transform",
+      "rawOutput": "get_user_profile_data",
+      "cleanedOutput": "get_user_profile_data",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": false,
+      "latencyMs": 456,
+      "usage": {
+        "completion_tokens": 8,
+        "prompt_tokens": 167,
+        "total_tokens": 175,
+        "prompt_tokens_details": {
+          "cached_tokens": 166
+        }
+      }
+    },
+    {
+      "variant": "one-shot",
+      "id": "core-camel-case",
+      "category": "tested-core",
+      "instruction": "make this camel case",
+      "selection": "user profile display name",
+      "expect": "userProfileDisplayName",
+      "check": "exact identifier transform",
+      "rawOutput": "user_profile_display_name",
+      "cleanedOutput": "user_profile_display_name",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": false,
+      "latencyMs": 458,
+      "usage": {
+        "completion_tokens": 8,
+        "prompt_tokens": 168,
+        "total_tokens": 176,
+        "prompt_tokens_details": {
+          "cached_tokens": 167
+        }
+      }
+    },
+    {
+      "variant": "one-shot",
+      "id": "core-numbered-list",
+      "category": "tested-core",
+      "instruction": "make this a numbered list",
+      "selection": "First open the settings window. Then pick a new shortcut. Finally relaunch the app.",
+      "expect": "Three numbered steps, wording preserved.",
+      "check": "numbered structure, no rewording",
+      "rawOutput": "- First open the settings window\n- Then pick a new shortcut\n- Finally relaunch the app",
+      "cleanedOutput": "- First open the settings window\n- Then pick a new shortcut\n- Finally relaunch the app",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": false,
+      "latencyMs": 1174,
+      "usage": {
+        "completion_tokens": 22,
+        "prompt_tokens": 184,
+        "total_tokens": 206,
+        "prompt_tokens_details": {
+          "cached_tokens": 183
+        }
+      }
+    },
+    {
+      "variant": "one-shot",
+      "id": "core-capitalise",
+      "category": "tested-core",
+      "instruction": "capitalise the first letter of each word",
+      "selection": "local first voice dictation for macos",
+      "expect": "Local First Voice Dictation For Macos",
+      "check": "casing only",
+      "rawOutput": "Local First Voice Dictation for MacOS",
+      "cleanedOutput": "Local First Voice Dictation for MacOS",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": false,
+      "latencyMs": 478,
+      "usage": {
+        "completion_tokens": 9,
+        "prompt_tokens": 176,
+        "total_tokens": 185,
+        "prompt_tokens_details": {
+          "cached_tokens": 175
+        }
+      }
+    },
+    {
+      "variant": "one-shot",
+      "id": "preserve-hedge",
+      "category": "preservation",
+      "instruction": "fix the grammar",
+      "selection": "I think this approach are the best one, but we should probaly check.",
+      "expect": "Grammar fixed; 'I think' and the tentativeness kept: 'I think this approach is the best one, but we should probably check.'",
+      "check": "does not drop the hedge (the #24 failure)",
+      "rawOutput": "- I think this approach is the best one, but we should probably check.",
+      "cleanedOutput": "- I think this approach is the best one, but we should probably check.",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": false,
+      "latencyMs": 926,
+      "usage": {
+        "completion_tokens": 17,
+        "prompt_tokens": 179,
+        "total_tokens": 196,
+        "prompt_tokens_details": {
+          "cached_tokens": 178
+        }
+      }
+    },
+    {
+      "variant": "one-shot",
+      "id": "preserve-number-name",
+      "category": "preservation",
+      "instruction": "make this shorter",
+      "selection": "According to the report that Priya sent over on Tuesday, the latency dropped by 43 milliseconds after the change was deployed to the fleet.",
+      "expect": "Shorter; keeps 'Priya', 'Tuesday', '43 milliseconds'.",
+      "check": "keeps specific facts",
+      "rawOutput": "- Latency dropped by 43 milliseconds",
+      "cleanedOutput": "- Latency dropped by 43 milliseconds",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": false,
+      "latencyMs": 518,
+      "usage": {
+        "completion_tokens": 10,
+        "prompt_tokens": 192,
+        "total_tokens": 202,
+        "prompt_tokens_details": {
+          "cached_tokens": 191
+        }
+      }
+    },
+    {
+      "variant": "one-shot",
+      "id": "adv-make-better",
+      "category": "adversarial",
+      "instruction": "make this better",
+      "selection": "The meeting is at 3pm in room 2.",
+      "expect": "A vague instruction on an already-clear sentence - minimal or no change is the faithful answer.",
+      "check": "does not over-rewrite on a vague command",
+      "rawOutput": "- The meeting is at 3pm in room 2",
+      "cleanedOutput": "- The meeting is at 3pm in room 2",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": false,
+      "latencyMs": 768,
+      "usage": {
+        "completion_tokens": 13,
+        "prompt_tokens": 175,
+        "total_tokens": 188,
+        "prompt_tokens_details": {
+          "cached_tokens": 174
+        }
+      }
+    },
+    {
+      "variant": "one-shot",
+      "id": "adv-question",
+      "category": "adversarial",
+      "instruction": "what does this mean",
+      "selection": "The settle guard refuses to trust a target until the frontmost app has been stable for 400ms.",
+      "expect": "This is a question, not an edit - the right behaviour is to return the text unchanged or signal that it is not an edit, NOT to answer the question.",
+      "check": "does not answer a question in place of editing",
+      "rawOutput": "The settle guard refuses to trust a target until the frontmost app has been stable for 400ms.",
+      "cleanedOutput": "The settle guard refuses to trust a target until the frontmost app has been stable for 400ms.",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": true,
+      "latencyMs": 1304,
+      "usage": {
+        "completion_tokens": 24,
+        "prompt_tokens": 187,
+        "total_tokens": 211,
+        "prompt_tokens_details": {
+          "cached_tokens": 186
+        }
+      }
+    },
+    {
+      "variant": "one-shot",
+      "id": "adv-improve-comment",
+      "category": "adversarial",
+      "instruction": "improve this",
+      "selection": "// loop over the items and add each one to the set",
+      "expect": "Vague command on a fine comment - minimal change; must stay a comment, must not become code or prose.",
+      "check": "stays in-kind, minimal change",
+      "rawOutput": "// Iterate over the items and add each one to the set",
+      "cleanedOutput": "// Iterate over the items and add each one to the set",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": false,
+      "latencyMs": 891,
+      "usage": {
+        "completion_tokens": 14,
+        "prompt_tokens": 174,
+        "total_tokens": 188,
+        "prompt_tokens_details": {
+          "cached_tokens": 173
+        }
+      }
+    },
+    {
+      "variant": "one-shot",
+      "id": "adv-leave-alone",
+      "category": "adversarial",
+      "instruction": "leave this exactly as it is",
+      "selection": "Nothing about this sentence needs to change.",
+      "expect": "Returned verbatim.",
+      "check": "does not rewrite when told not to",
+      "rawOutput": "- Nothing about this sentence needs to change.",
+      "cleanedOutput": "- Nothing about this sentence needs to change.",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": false,
+      "latencyMs": 524,
+      "usage": {
+        "completion_tokens": 10,
+        "prompt_tokens": 174,
+        "total_tokens": 184,
+        "prompt_tokens_details": {
+          "cached_tokens": 173
+        }
+      }
+    },
+    {
+      "variant": "one-shot",
+      "id": "adv-out-of-scope",
+      "category": "adversarial",
+      "instruction": "translate this to French",
+      "selection": "The window remembers its size and position.",
+      "expect": "Out of the intended command surface. Either complies (documented) or returns unchanged - but must not add commentary about it.",
+      "check": "handles an off-surface command without chatter",
+      "rawOutput": "La fenêtre récompende sa taille et sa position.",
+      "cleanedOutput": "La fenêtre récompende sa taille et sa position.",
+      "guardOk": true,
+      "guardReason": null,
+      "unchanged": false,
+      "latencyMs": 1262,
+      "usage": {
+        "completion_tokens": 17,
+        "prompt_tokens": 172,
+        "total_tokens": 189,
+        "prompt_tokens_details": {
+          "cached_tokens": 171
+        }
+      }
+    }
+  ]
+}

--- a/prototypes/voice-edit-fidelity-222/review.html
+++ b/prototypes/voice-edit-fidelity-222/review.html
@@ -1,0 +1,338 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Voice-edit fidelity review — #222</title>
+<style>
+  body { font: 14px/1.5 -apple-system, system-ui, sans-serif; margin: 24px; color: #1d1d1f; background: #fff; }
+  h1 { font-size: 18px; } .meta { color: #6e6e73; margin-bottom: 16px; }
+  table { border-collapse: collapse; width: 100%; }
+  td, th { border: 1px solid #ddd; padding: 10px; vertical-align: top; text-align: left; }
+  th { background: #f7f7f8; width: 26%; }
+  pre { white-space: pre-wrap; margin: 4px 0; font: 12px/1.45 ui-monospace, Menlo, monospace; background: #f5f5f7; padding: 8px; border-radius: 6px; }
+  .id { font-weight: 700; } .cat { color: #6e6e73; font-size: 12px; }
+  .instr { margin: 4px 0; font-style: italic; }
+  .expect, .check { font-size: 12px; color: #3a3a3c; margin-top: 6px; }
+  .sel { background: #eef; }
+  .variant { font-size: 12px; color: #6e6e73; margin-bottom: 2px; }
+  b.u { color: #c0392b; } b.g { color: #9a6100; }
+  .sum td { text-align: center; }
+</style>
+<h1>Voice-edit fidelity review — issue #222</h1>
+<div class="meta">Ran 2026-08-28T15:58:48.073Z against http://127.0.0.1:8199/v1/chat/completions. Judge each cell: did it apply the instruction, and <em>only</em> the instruction?</div>
+<table class="sum">
+  <tr><th>variant</th><th>cases</th><th>returned unchanged</th><th>guard-rejected</th><th>latency min–median–max</th></tr>
+  <tr><td>zero-shot</td><td>15</td><td>6</td><td>0</td><td>370–861–2269 ms</td></tr><tr><td>strict</td><td>15</td><td>7</td><td>0</td><td>266–1018–2539 ms</td></tr><tr><td>one-shot</td><td>15</td><td>1</td><td>0</td><td>456–926–2802 ms</td></tr>
+</table>
+<p></p>
+<table><tr>
+      <th>
+        <div class="id">core-bullets-commalist</div>
+        <div class="cat">tested-core</div>
+        <div class="instr">“make this a bullet list”</div>
+        <pre class="sel">Buy milk, eggs, bread and coffee. Also pick up a birthday card.</pre>
+        <div class="expect"><b>only acceptable change:</b> Same items, one per line, each with a bullet marker. No items added or dropped.</div>
+        <div class="check"><b>probes:</b> applies a structural transform at all</div>
+      </th>
+      <td>
+          <div class="variant">zero-shot · 861ms · <b class="u">unchanged</b></div>
+          <pre>Buy milk, eggs, bread and coffee. Also pick up a birthday card.</pre>
+        </td><td>
+          <div class="variant">strict · 851ms · <b class="u">unchanged</b></div>
+          <pre>Buy milk, eggs, bread and coffee. Also pick up a birthday card.</pre>
+        </td><td>
+          <div class="variant">one-shot · 1786ms</div>
+          <pre>- Buy milk
+- Eggs
+- Bread
+- Coffee
+- Pick up a birthday card</pre>
+        </td>
+    </tr>
+<tr>
+      <th>
+        <div class="id">core-bullets-sentences</div>
+        <div class="cat">tested-core</div>
+        <div class="instr">“turn this into a bullet list”</div>
+        <pre class="sel">The build compiles the two engines from pinned commits. It downloads both models from pinned revisions. Every file is SHA-256 verified.</pre>
+        <div class="expect"><b>only acceptable change:</b> Three bullets, one per sentence, wording preserved.</div>
+        <div class="check"><b>probes:</b> one bullet per idea, no rewording</div>
+      </th>
+      <td>
+          <div class="variant">zero-shot · 1867ms · <b class="u">unchanged</b></div>
+          <pre>The build compiles the two engines from pinned commits. It downloads both models from pinned revisions. Every file is SHA-256 verified.</pre>
+        </td><td>
+          <div class="variant">strict · 1753ms · <b class="u">unchanged</b></div>
+          <pre>The build compiles the two engines from pinned commits. It downloads both models from pinned revisions. Every file is SHA-256 verified.</pre>
+        </td><td>
+          <div class="variant">one-shot · 2802ms</div>
+          <pre>- Build compiles the two engines from pinned commits
+- Downloads both models from pinned revisions
+- Every file is SHA-256 verified</pre>
+        </td>
+    </tr>
+<tr>
+      <th>
+        <div class="id">core-shorter</div>
+        <div class="cat">tested-core</div>
+        <div class="instr">“make this shorter”</div>
+        <pre class="sel">I just wanted to quickly follow up on the thing we were talking about earlier today, because I think it might actually be quite important for us to sort out before the end of the week if at all possible.</pre>
+        <div class="expect"><b>only acceptable change:</b> Noticeably shorter, same core ask (follow up, important, sort out before end of week).</div>
+        <div class="check"><b>probes:</b> shortens without losing the ask</div>
+      </th>
+      <td>
+          <div class="variant">zero-shot · 2269ms</div>
+          <pre>I just wanted to follow up on the thing we were talking about earlier today, because I think it might actually be quite important for us to sort out before the end of the week if at all possible.</pre>
+        </td><td>
+          <div class="variant">strict · 2539ms · <b class="u">unchanged</b></div>
+          <pre>I just wanted to quickly follow up on the thing we were talking about earlier today, because I think it might actually be quite important for us to sort out before the end of the week if at all possible.</pre>
+        </td><td>
+          <div class="variant">one-shot · 1199ms</div>
+          <pre>- Follow up on earlier discussion
+- Important for us to sort out before week end</pre>
+        </td>
+    </tr>
+<tr>
+      <th>
+        <div class="id">core-fix-grammar</div>
+        <div class="cat">tested-core</div>
+        <div class="instr">“fix the grammar”</div>
+        <pre class="sel">Me and him was going to the shops but we dont has enough time.</pre>
+        <div class="expect"><b>only acceptable change:</b> Grammatical version, same meaning: 'He and I were going to the shops but we don't have enough time.'</div>
+        <div class="check"><b>probes:</b> corrects errors only</div>
+      </th>
+      <td>
+          <div class="variant">zero-shot · 1072ms</div>
+          <pre>Me and him were going to the shops, but we didn't have enough time.</pre>
+        </td><td>
+          <div class="variant">strict · 1172ms</div>
+          <pre>Me and him were going to the shops, but we didn't have enough time.</pre>
+        </td><td>
+          <div class="variant">one-shot · 1100ms</div>
+          <pre>- I and he were going to the shops, but we didn't have enough time.</pre>
+        </td>
+    </tr>
+<tr>
+      <th>
+        <div class="id">core-snake-case</div>
+        <div class="cat">tested-core</div>
+        <div class="instr">“snake case that”</div>
+        <pre class="sel">getUserProfileData</pre>
+        <div class="expect"><b>only acceptable change:</b> get_user_profile_data</div>
+        <div class="check"><b>probes:</b> exact identifier transform</div>
+      </th>
+      <td>
+          <div class="variant">zero-shot · 397ms</div>
+          <pre>get_user_profile_data</pre>
+        </td><td>
+          <div class="variant">strict · 426ms</div>
+          <pre>get_user_profile_data</pre>
+        </td><td>
+          <div class="variant">one-shot · 456ms</div>
+          <pre>get_user_profile_data</pre>
+        </td>
+    </tr>
+<tr>
+      <th>
+        <div class="id">core-camel-case</div>
+        <div class="cat">tested-core</div>
+        <div class="instr">“make this camel case”</div>
+        <pre class="sel">user profile display name</pre>
+        <div class="expect"><b>only acceptable change:</b> userProfileDisplayName</div>
+        <div class="check"><b>probes:</b> exact identifier transform</div>
+      </th>
+      <td>
+          <div class="variant">zero-shot · 370ms</div>
+          <pre>userProfileDisplayName</pre>
+        </td><td>
+          <div class="variant">strict · 266ms</div>
+          <pre>userProfileDisplayName</pre>
+        </td><td>
+          <div class="variant">one-shot · 458ms</div>
+          <pre>user_profile_display_name</pre>
+        </td>
+    </tr>
+<tr>
+      <th>
+        <div class="id">core-numbered-list</div>
+        <div class="cat">tested-core</div>
+        <div class="instr">“make this a numbered list”</div>
+        <pre class="sel">First open the settings window. Then pick a new shortcut. Finally relaunch the app.</pre>
+        <div class="expect"><b>only acceptable change:</b> Three numbered steps, wording preserved.</div>
+        <div class="check"><b>probes:</b> numbered structure, no rewording</div>
+      </th>
+      <td>
+          <div class="variant">zero-shot · 1520ms</div>
+          <pre>1. First open the settings window.
+2. Then pick a new shortcut.
+3. Finally relaunch the app.</pre>
+        </td><td>
+          <div class="variant">strict · 1545ms</div>
+          <pre>1. First open the settings window.
+2. Then pick a new shortcut.
+3. Finally relaunch the app.</pre>
+        </td><td>
+          <div class="variant">one-shot · 1174ms</div>
+          <pre>- First open the settings window
+- Then pick a new shortcut
+- Finally relaunch the app</pre>
+        </td>
+    </tr>
+<tr>
+      <th>
+        <div class="id">core-capitalise</div>
+        <div class="cat">tested-core</div>
+        <div class="instr">“capitalise the first letter of each word”</div>
+        <pre class="sel">local first voice dictation for macos</pre>
+        <div class="expect"><b>only acceptable change:</b> Local First Voice Dictation For Macos</div>
+        <div class="check"><b>probes:</b> casing only</div>
+      </th>
+      <td>
+          <div class="variant">zero-shot · 459ms</div>
+          <pre>Local First Voice Dictation for MacOS</pre>
+        </td><td>
+          <div class="variant">strict · 447ms</div>
+          <pre>Local First Voice Dictation for MacOS</pre>
+        </td><td>
+          <div class="variant">one-shot · 478ms</div>
+          <pre>Local First Voice Dictation for MacOS</pre>
+        </td>
+    </tr>
+<tr>
+      <th>
+        <div class="id">preserve-hedge</div>
+        <div class="cat">preservation</div>
+        <div class="instr">“fix the grammar”</div>
+        <pre class="sel">I think this approach are the best one, but we should probaly check.</pre>
+        <div class="expect"><b>only acceptable change:</b> Grammar fixed; 'I think' and the tentativeness kept: 'I think this approach is the best one, but we should probably check.'</div>
+        <div class="check"><b>probes:</b> does not drop the hedge (the #24 failure)</div>
+      </th>
+      <td>
+          <div class="variant">zero-shot · 846ms</div>
+          <pre>I think this approach is the best one, but we should probably check.</pre>
+        </td><td>
+          <div class="variant">strict · 859ms</div>
+          <pre>I think this approach is the best one, but we should probably check.</pre>
+        </td><td>
+          <div class="variant">one-shot · 926ms</div>
+          <pre>- I think this approach is the best one, but we should probably check.</pre>
+        </td>
+    </tr>
+<tr>
+      <th>
+        <div class="id">preserve-number-name</div>
+        <div class="cat">preservation</div>
+        <div class="instr">“make this shorter”</div>
+        <pre class="sel">According to the report that Priya sent over on Tuesday, the latency dropped by 43 milliseconds after the change was deployed to the fleet.</pre>
+        <div class="expect"><b>only acceptable change:</b> Shorter; keeps 'Priya', 'Tuesday', '43 milliseconds'.</div>
+        <div class="check"><b>probes:</b> keeps specific facts</div>
+      </th>
+      <td>
+          <div class="variant">zero-shot · 1154ms</div>
+          <pre>According to Priya's report, the latency dropped by 43 milliseconds after the change was deployed.</pre>
+        </td><td>
+          <div class="variant">strict · 1145ms</div>
+          <pre>According to Priya's report, the latency dropped by 43 milliseconds after the change was deployed.</pre>
+        </td><td>
+          <div class="variant">one-shot · 518ms</div>
+          <pre>- Latency dropped by 43 milliseconds</pre>
+        </td>
+    </tr>
+<tr>
+      <th>
+        <div class="id">adv-make-better</div>
+        <div class="cat">adversarial</div>
+        <div class="instr">“make this better”</div>
+        <pre class="sel">The meeting is at 3pm in room 2.</pre>
+        <div class="expect"><b>only acceptable change:</b> A vague instruction on an already-clear sentence - minimal or no change is the faithful answer.</div>
+        <div class="check"><b>probes:</b> does not over-rewrite on a vague command</div>
+      </th>
+      <td>
+          <div class="variant">zero-shot · 699ms · <b class="u">unchanged</b></div>
+          <pre>The meeting is at 3pm in room 2.</pre>
+        </td><td>
+          <div class="variant">strict · 674ms · <b class="u">unchanged</b></div>
+          <pre>The meeting is at 3pm in room 2.</pre>
+        </td><td>
+          <div class="variant">one-shot · 768ms</div>
+          <pre>- The meeting is at 3pm in room 2</pre>
+        </td>
+    </tr>
+<tr>
+      <th>
+        <div class="id">adv-question</div>
+        <div class="cat">adversarial</div>
+        <div class="instr">“what does this mean”</div>
+        <pre class="sel">The settle guard refuses to trust a target until the frontmost app has been stable for 400ms.</pre>
+        <div class="expect"><b>only acceptable change:</b> This is a question, not an edit - the right behaviour is to return the text unchanged or signal that it is not an edit, NOT to answer the question.</div>
+        <div class="check"><b>probes:</b> does not answer a question in place of editing</div>
+      </th>
+      <td>
+          <div class="variant">zero-shot · 1296ms · <b class="u">unchanged</b></div>
+          <pre>The settle guard refuses to trust a target until the frontmost app has been stable for 400ms.</pre>
+        </td><td>
+          <div class="variant">strict · 1636ms · <b class="u">unchanged</b></div>
+          <pre>The settle guard refuses to trust a target until the frontmost app has been stable for 400ms.</pre>
+        </td><td>
+          <div class="variant">one-shot · 1304ms · <b class="u">unchanged</b></div>
+          <pre>The settle guard refuses to trust a target until the frontmost app has been stable for 400ms.</pre>
+        </td>
+    </tr>
+<tr>
+      <th>
+        <div class="id">adv-improve-comment</div>
+        <div class="cat">adversarial</div>
+        <div class="instr">“improve this”</div>
+        <pre class="sel">// loop over the items and add each one to the set</pre>
+        <div class="expect"><b>only acceptable change:</b> Vague command on a fine comment - minimal change; must stay a comment, must not become code or prose.</div>
+        <div class="check"><b>probes:</b> stays in-kind, minimal change</div>
+      </th>
+      <td>
+          <div class="variant">zero-shot · 677ms · <b class="u">unchanged</b></div>
+          <pre>// loop over the items and add each one to the set</pre>
+        </td><td>
+          <div class="variant">strict · 1018ms · <b class="u">unchanged</b></div>
+          <pre>// loop over the items and add each one to the set</pre>
+        </td><td>
+          <div class="variant">one-shot · 891ms</div>
+          <pre>// Iterate over the items and add each one to the set</pre>
+        </td>
+    </tr>
+<tr>
+      <th>
+        <div class="id">adv-leave-alone</div>
+        <div class="cat">adversarial</div>
+        <div class="instr">“leave this exactly as it is”</div>
+        <pre class="sel">Nothing about this sentence needs to change.</pre>
+        <div class="expect"><b>only acceptable change:</b> Returned verbatim.</div>
+        <div class="check"><b>probes:</b> does not rewrite when told not to</div>
+      </th>
+      <td>
+          <div class="variant">zero-shot · 477ms · <b class="u">unchanged</b></div>
+          <pre>Nothing about this sentence needs to change.</pre>
+        </td><td>
+          <div class="variant">strict · 639ms · <b class="u">unchanged</b></div>
+          <pre>Nothing about this sentence needs to change.</pre>
+        </td><td>
+          <div class="variant">one-shot · 524ms</div>
+          <pre>- Nothing about this sentence needs to change.</pre>
+        </td>
+    </tr>
+<tr>
+      <th>
+        <div class="id">adv-out-of-scope</div>
+        <div class="cat">adversarial</div>
+        <div class="instr">“translate this to French”</div>
+        <pre class="sel">The window remembers its size and position.</pre>
+        <div class="expect"><b>only acceptable change:</b> Out of the intended command surface. Either complies (documented) or returns unchanged - but must not add commentary about it.</div>
+        <div class="check"><b>probes:</b> handles an off-surface command without chatter</div>
+      </th>
+      <td>
+          <div class="variant">zero-shot · 910ms</div>
+          <pre>La fenêtre réfère à sa taille et à sa position.</pre>
+        </td><td>
+          <div class="variant">strict · 1134ms</div>
+          <pre>La fenêtre réfère à sa taille et à sa position.</pre>
+        </td><td>
+          <div class="variant">one-shot · 1262ms</div>
+          <pre>La fenêtre récompende sa taille et sa position.</pre>
+        </td>
+    </tr></table>

--- a/prototypes/voice-edit-fidelity-222/review.mjs
+++ b/prototypes/voice-edit-fidelity-222/review.mjs
@@ -1,0 +1,78 @@
+// Renders results.json as a static HTML page for hand-judging
+// faithfulness: node review.mjs > review.html
+// No dependencies, no network - open the file in a browser.
+
+import { readFile } from "node:fs/promises";
+
+const { ranAt, url, summary, runs } = JSON.parse(
+  await readFile(new URL("./results.json", import.meta.url), "utf8"),
+);
+
+const esc = (s) =>
+  String(s).replace(/[&<>]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" })[c]);
+
+const byCase = new Map();
+for (const row of runs) {
+  if (!byCase.has(row.id)) byCase.set(row.id, []);
+  byCase.get(row.id).push(row);
+}
+
+const rows = [...byCase.entries()]
+  .map(([id, variants]) => {
+    const first = variants[0];
+    const cells = variants
+      .map(
+        (v) => `<td>
+          <div class="variant">${esc(v.variant)} · ${v.latencyMs}ms${v.unchanged ? ' · <b class="u">unchanged</b>' : ""}${v.guardOk ? "" : ` · <b class="g">guard: ${esc(v.guardReason)}</b>`}</div>
+          <pre>${esc(v.cleanedOutput ?? v.error ?? "")}</pre>
+        </td>`,
+      )
+      .join("");
+    return `<tr>
+      <th>
+        <div class="id">${esc(id)}</div>
+        <div class="cat">${esc(first.category)}</div>
+        <div class="instr">“${esc(first.instruction)}”</div>
+        <pre class="sel">${esc(first.selection)}</pre>
+        <div class="expect"><b>only acceptable change:</b> ${esc(first.expect)}</div>
+        <div class="check"><b>probes:</b> ${esc(first.check)}</div>
+      </th>
+      ${cells}
+    </tr>`;
+  })
+  .join("\n");
+
+const summaryRows = Object.entries(summary)
+  .map(
+    ([v, s]) =>
+      `<tr><td>${esc(v)}</td><td>${s.cases}</td><td>${s.returnedUnchanged}</td><td>${s.guardRejected}</td><td>${s.latencyMs.min}–${s.latencyMs.median}–${s.latencyMs.max} ms</td></tr>`,
+  )
+  .join("");
+
+process.stdout.write(`<!doctype html>
+<meta charset="utf-8">
+<title>Voice-edit fidelity review — #222</title>
+<style>
+  body { font: 14px/1.5 -apple-system, system-ui, sans-serif; margin: 24px; color: #1d1d1f; background: #fff; }
+  h1 { font-size: 18px; } .meta { color: #6e6e73; margin-bottom: 16px; }
+  table { border-collapse: collapse; width: 100%; }
+  td, th { border: 1px solid #ddd; padding: 10px; vertical-align: top; text-align: left; }
+  th { background: #f7f7f8; width: 26%; }
+  pre { white-space: pre-wrap; margin: 4px 0; font: 12px/1.45 ui-monospace, Menlo, monospace; background: #f5f5f7; padding: 8px; border-radius: 6px; }
+  .id { font-weight: 700; } .cat { color: #6e6e73; font-size: 12px; }
+  .instr { margin: 4px 0; font-style: italic; }
+  .expect, .check { font-size: 12px; color: #3a3a3c; margin-top: 6px; }
+  .sel { background: #eef; }
+  .variant { font-size: 12px; color: #6e6e73; margin-bottom: 2px; }
+  b.u { color: #c0392b; } b.g { color: #9a6100; }
+  .sum td { text-align: center; }
+</style>
+<h1>Voice-edit fidelity review — issue #222</h1>
+<div class="meta">Ran ${esc(ranAt)} against ${esc(url)}. Judge each cell: did it apply the instruction, and <em>only</em> the instruction?</div>
+<table class="sum">
+  <tr><th>variant</th><th>cases</th><th>returned unchanged</th><th>guard-rejected</th><th>latency min–median–max</th></tr>
+  ${summaryRows}
+</table>
+<p></p>
+<table>${rows}</table>
+`);

--- a/prototypes/voice-edit-fidelity-222/run.mjs
+++ b/prototypes/voice-edit-fidelity-222/run.mjs
@@ -1,0 +1,91 @@
+// Runs the #222 corpus against a running rewrite model server and writes
+// results.json. Does NOT start the server - point it at one:
+//
+//   node run.mjs --url http://127.0.0.1:8199/v1/chat/completions
+//
+// For each (prompt variant x case) it records the raw output, the guard
+// verdict, and warm latency. Faithfulness is judged by a human from the
+// review page (review.mjs), not here.
+
+import { readFile, writeFile } from "node:fs/promises";
+import { performance } from "node:perf_hooks";
+import { PROMPTS, SAMPLING } from "./prompts.mjs";
+import { applyGuards } from "./guards.mjs";
+
+const url =
+  process.argv[process.argv.indexOf("--url") + 1] || "http://127.0.0.1:8179/v1/chat/completions";
+
+const { cases } = JSON.parse(await readFile(new URL("./corpus.json", import.meta.url), "utf8"));
+
+async function complete(messages) {
+  const started = performance.now();
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ messages, ...SAMPLING }),
+  });
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+  const body = await response.json();
+  return {
+    text: body.choices?.[0]?.message?.content ?? "",
+    latencyMs: Math.round(performance.now() - started),
+    usage: body.usage ?? null,
+  };
+}
+
+const runs = [];
+for (const [variant, build] of Object.entries(PROMPTS)) {
+  for (const testCase of cases) {
+    process.stderr.write(`  ${variant} / ${testCase.id} … `);
+    let record;
+    try {
+      // one warm-up throwaway per case so latency is warm, then the real one
+      await complete(build(testCase));
+      const result = await complete(build(testCase));
+      const guard = applyGuards(result.text, testCase.selection);
+      record = {
+        variant,
+        id: testCase.id,
+        category: testCase.category,
+        instruction: testCase.instruction,
+        selection: testCase.selection,
+        expect: testCase.expect,
+        check: testCase.check,
+        rawOutput: result.text,
+        cleanedOutput: guard.cleaned,
+        guardOk: guard.ok,
+        guardReason: guard.reason,
+        unchanged: guard.cleaned.trim() === testCase.selection.trim(),
+        latencyMs: result.latencyMs,
+        usage: result.usage,
+      };
+      process.stderr.write(`${result.latencyMs}ms${guard.ok ? "" : ` [guard: ${guard.reason}]`}\n`);
+    } catch (error) {
+      record = { variant, id: testCase.id, error: String(error) };
+      process.stderr.write(`ERROR ${error}\n`);
+    }
+    runs.push(record);
+  }
+}
+
+const summary = {};
+for (const variant of Object.keys(PROMPTS)) {
+  const rows = runs.filter((r) => r.variant === variant && !r.error);
+  summary[variant] = {
+    cases: rows.length,
+    guardRejected: rows.filter((r) => !r.guardOk).length,
+    returnedUnchanged: rows.filter((r) => r.unchanged).length,
+    latencyMs: {
+      min: Math.min(...rows.map((r) => r.latencyMs)),
+      median: rows.map((r) => r.latencyMs).sort((a, b) => a - b)[Math.floor(rows.length / 2)],
+      max: Math.max(...rows.map((r) => r.latencyMs)),
+    },
+  };
+}
+
+await writeFile(
+  new URL("./results.json", import.meta.url),
+  JSON.stringify({ ranAt: new Date().toISOString(), url, summary, runs }, null, 2),
+);
+console.log(JSON.stringify(summary, null, 2));
+console.error("\nwrote results.json - now: node review.mjs > review.html");


### PR DESCRIPTION
Runs the #222 spike and records the result. Throwaway harness under `prototypes/voice-edit-fidelity-222/`, no production code.

## Verdict: no — prompting SmolLM2-1.7B does not clear the bar for voice editing

Run on the target machine (macOS 26.2, Apple Silicon) against the repo's own pinned `llama-server` + SmolLM2 GGUF at the production 2048-token context. 15 selection/command cases × 3 prompt variants. Full write-up in `RESULTS.md`; hand-judge the outputs yourself from `review.html`.

- **Latency is fine** — warm median ~900ms, max 2.5s, well inside #17's "multi-second is acceptable" bar.
- **The core commands fail.** "Make this a bullet list" and "make this shorter" come back *unchanged* under both the plain and the stricter prompt (6–7 of 15 cases returned verbatim). Adding a worked example makes it worse — it then does the wrong transform and sprays stray `-` markers onto plain sentences, and flattened one test sentence from 25 words to "- Latency dropped by 43 milliseconds".
- **The #17 guards catch none of it** (0/45) — they're built for a rambling model; this one fails by doing nothing or doing the wrong thing cleanly. An "output == input → tell the user" check is worth adding, but it only turns a silent no-op into an error.
- What *does* work: identifier case conversion, numbered lists, capitalisation, and being conservative on vague/adversarial commands.

## Recommendation

The feature design in #17 holds; the model in the rewrite role doesn't. Either narrow #17's launch surface to the transforms that work (small fixed set, not open NL), or re-run this exact spike against the #192 candidates (Qwen3-1.7B, Granite-3.3-2B) — `run.mjs` takes `--url`, so that's one command once another server is up.
