### PR TITLE
Adopt standalone Option Push-to-talk shortcut (#216)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository is a development fork of [Nabzx/openstream](https://github.com/N
 The current app can:
 
 - run as a macOS menu bar app
-- listen for `Control+Option+D` through a native hotkey helper
+- listen for standalone `Option` through a native hotkey helper
 - record while the hotkey is held and transcribe after release
 - keep `whisper-server` resident instead of loading it for each dictation
 - insert text at the cursor through a separate Accessibility helper
@@ -81,7 +81,7 @@ OpenStream needs three macOS permissions:
 2. Input Monitoring for the hotkey helper.
 3. Accessibility for the text-insertion helper.
 
-After granting Input Monitoring and Accessibility, quit and restart the app. Click a text field, hold `Control+Option+D`, speak, and release the keys. A cold start can take 15 to 20 seconds while `whisper-server` loads its Metal shaders.
+After granting Input Monitoring and Accessibility, quit and restart the app. Click a text field, hold `Option`, speak, and release it. Existing saved combinations such as `Control+Option+D` remain usable until changed. A cold start can take 15 to 20 seconds while `whisper-server` loads its Metal shaders.
 
 Source runs can be attributed to Terminal, Electron, or OpenStream in System Settings. Permission identity across rebuilds is still being worked out.
 

--- a/docs/testing/hotkey-transcribe-manual-check.md
+++ b/docs/testing/hotkey-transcribe-manual-check.md
@@ -2,7 +2,7 @@
 
 Issue [#105](https://github.com/Nabzx/openstream/issues/105) covers the macOS boundaries that CI cannot drive: global key events, a real microphone, menu bar and overlay feedback, and insertion into another application.
 
-The default hotkey is `Control+Option+D`. Issue #84 replaced `Cmd+Shift+D` because the listen-only Command shortcut played the system alert beep in apps without a matching menu item. Whisper could transcribe that beep as "[Music]".
+The fresh-install default is standalone `Option`. Existing saved combinations remain active for backward compatibility. The helper is listen-only, so the selected key continues through macOS and the focused application.
 
 ## Run the wizard
 
@@ -27,7 +27,7 @@ The wizard checks the build, then walks through seven stages:
 
 1. Check that the Electron runtime has not been revoked by Gatekeeper, then run the automated test suite and typecheck on an Apple Silicon Mac.
 2. Start OpenStream and grant Microphone, Input Monitoring, and Accessibility permissions.
-3. Use `Control+Option+D` outside OpenStream and inspect the tray, push-to-talk overlay, and sound meter. Confirm that the overlay sits bottom-center, clear of the Dock, and shows a real frosted-glass blur (desktop content behind it should look visibly blurred, not a flat dark box) with a waveform that audibly reacts to your voice. On a multi-monitor setup, move the cursor to another display before pressing the key and confirm the overlay follows it. If the overlay looks like a flat dark rectangle with no blur, check System Settings > Accessibility > Display > Reduce Transparency isn't enabled - that setting flattens all vibrancy effects system-wide.
+3. Use standalone `Option` outside OpenStream and inspect the tray, push-to-talk overlay, and sound meter. Confirm that the overlay sits bottom-center, clear of the Dock, and shows a real frosted-glass blur (desktop content behind it should look visibly blurred, not a flat dark box) with a waveform that audibly reacts to your voice. On a multi-monitor setup, move the cursor to another display before pressing the key and confirm the overlay follows it. If the overlay looks like a flat dark rectangle with no blur, check System Settings > Accessibility > Display > Reduce Transparency isn't enabled - that setting flattens all vibrancy effects system-wide.
 4. Dictate into TextEdit and confirm the finished text is inserted once.
 5. Inspect both model-server listeners and sample their TCP connections during a dictation. Ports 8178 and 8179 must stay on `127.0.0.1`.
 6. Measure three warm dictations from key release to confirmed insertion. Every measurement must be below 1000 ms.

--- a/docs/testing/settings-hotkey-remap-manual-check.md
+++ b/docs/testing/settings-hotkey-remap-manual-check.md
@@ -1,68 +1,47 @@
-# Manual check: settings window, hotkey remapping (#19)
+# Manual check: settings window, one-key Push-to-talk (#216)
 
-What CI/a headless session can verify, and what still needs a human running
-the actual app: opening a real settings window, capturing a real keydown
-gesture, and confirming the native helper actually restarts with a new
-combo aren't things a sandboxed session can drive.
+CI cannot drive a real settings window, macOS key events, or the native helper
+through Input Monitoring. Those boundaries need one check on a real Mac.
 
 ## Already verified without a GUI
 
-- `settingsStore.js`: persists to and reads back from a JSON file, rejects
-  a hotkey with no modifiers or an unknown modifier, and leaves the
-  previously-saved hotkey untouched on a rejected write - 9 tests.
-- `keycodeMap.ts`: DOM `KeyboardEvent.code` → macOS virtual keycode
-  translation, and the reverse (`formatHotkey`) - 9 tests.
-- `captureHotkey.ts`: the pure decision behind hotkey capture - accepts a
-  mapped key held with at least one modifier, rejects an unmapped key or a
-  bare key with none - 5 tests.
-- `hotkeyHelper.js`: waits for the native `ready` event, rejects a candidate
-  that fails to start, exits early, or times out, and keeps automatic restart
-  for the active helper.
-- `pushToTalkShortcutController.js`: keeps the active helper and saved value
-  in place while a candidate starts, then commits both only after readiness.
-  Persistence and activation failures stop the candidate and restore the old
-  value.
-- `tsc --noEmit` and `vite build` both succeed with the settings screen
-  wired in.
-- The full `vitest` suite (32 tests) and `node --test "electron/**/*.test.js"`
-  both pass.
+- Fresh settings default to standalone Option; existing Control+Option+D
+  settings load without being rewritten.
+- Renderer capture accepts either physical Option key and rejects every other
+  input with exactly `Unsupported key`.
+- The active helper and saved shortcut remain in place until an Option
+  replacement is ready; failed replacements report the unavailable message.
+- The native matcher handles Option modifier-state transitions, legacy key
+  pairs, repeats, unrelated input, and release after other modifiers change.
+- `npm run typecheck`, `npm run build`, JavaScript tests, and native matcher
+  tests pass where their required toolchains are available.
 
-None of this drives the actual React component (`HotkeySettings.tsx`) or
-the real IPC round trip through a running Electron process - those are
-exactly what needs a human.
+The React component and the real IPC round trip still need a human.
 
 ## Needs a human, one time
 
 1. `npm start`, then click the tray icon → **Open Window**.
-2. The window should show **OpenStream Settings** with the current
-   hotkey - `⌃⌥D` on a fresh install (Control+Option+D, matching the
-   existing default).
-3. Click **Change shortcut**, then press a new combo - e.g. `⌘⇧Space`. The
-   button should read "Checking shortcut…" while the candidate helper starts.
-   The current shortcut must keep working during this check. The new combo
-   should appear only after the helper reports ready.
-4. Press just a letter with no modifier held. This should show an inline
-   error ("hold at least one modifier key...") and stay in recording mode
-   rather than silently closing or accepting it.
-5. Press an unmapped key (an arrow key, a function key). Same as step 4 -
-   an inline error naming the key, still recording.
-6. To exercise an unavailable replacement, temporarily make the candidate
-   helper fail before it reports ready. The settings window should show
+2. On a fresh settings file, the window should show **Option**.
+3. Click **Change shortcut**, then press Option. The button should read
+   "Checking shortcut…" while the candidate helper starts, and the display
+   should change only after the helper reports ready.
+4. While capturing, press a letter, digit, punctuation key, modifier-plus-key
+   combination, standalone Shift, or an unmapped key. Each should show the
+   exact error `Unsupported key` and leave capture available for another try.
+5. To exercise an unavailable replacement, make the candidate helper fail
+   before it reports ready. The settings window should show
    "Shortcut unavailable. Choose another shortcut." The previous shortcut
-   must remain displayed, saved, and usable. No confirmation step should send
-   a live test key event.
-7. After a successful remap (step 3), hold the **new** combo and confirm
-   push-to-talk still works - the terminal running `npm start` should log
-   `[dictation] recording...` same as before. The *old* hotkey
-   (`Control+Option+D`, or whatever it was before) should no longer do
-   anything.
-8. Quit and relaunch the app (`npm start` again). The new hotkey should
-   still be the one that works, and the settings window should still show
-   it - confirms the write actually persisted to
-   `~/Library/Application Support/openstream/settings.json` (or wherever
-   `app.getPath("userData")` resolves in dev) rather than only living in
-   memory for that session.
+   must remain displayed, saved, and usable. Confirmation must not send a
+   live test key event.
+6. Hold Option and confirm one Dictation starts and ends. Its normal Option
+   behavior must remain visible because the helper is listen-only.
+7. If the settings file already contains Control+Option+D, relaunch and
+   confirm it remains displayed and usable until a successful replacement.
+8. Quit and relaunch after a successful Option replacement. Option should
+   still work, the old shortcut should no longer work, and the settings
+   display should match the helper's active shortcut.
 
-If step 6 doesn't work after a successful-looking remap in step 3, check
-the terminal for `[hotkey-helper]` lines - a restart failure would show up
-there the same way a normal crash-restart does.
+Record the Mac model, macOS version, keyboard, observed native down/up pair,
+and whether the key's normal application behavior remained visible. OpenStream
+does not claim reliable conflict detection and never sends a live confirmation
+press.

--- a/docs/testing/voice-edit-manual-check.md
+++ b/docs/testing/voice-edit-manual-check.md
@@ -10,7 +10,7 @@ in place across different app types.
 ## Prerequisites
 
 OpenStream running with Accessibility, Input Monitoring and Microphone granted, both
-model servers up. Default hotkey `Control+Option+D`.
+model servers up. Fresh-install default hotkey `Option` (existing saved combinations remain supported).
 
 ## Checks
 

--- a/electron/hotkeyDefinitions.js
+++ b/electron/hotkeyDefinitions.js
@@ -1,0 +1,14 @@
+const STANDALONE_OPTION_KEY_CODE = 58;
+
+function isStandaloneOptionShortcut(shortcut) {
+  return (
+    shortcut?.keyCode === STANDALONE_OPTION_KEY_CODE &&
+    Array.isArray(shortcut.modifiers) &&
+    shortcut.modifiers.length === 0
+  );
+}
+
+module.exports = {
+  STANDALONE_OPTION_KEY_CODE,
+  isStandaloneOptionShortcut,
+};

--- a/electron/hotkeyHelper.js
+++ b/electron/hotkeyHelper.js
@@ -2,21 +2,14 @@ const { spawn } = require("child_process");
 const readline = require("readline");
 const path = require("path");
 const { resourcesRoot } = require("./paths");
+const { STANDALONE_OPTION_KEY_CODE } = require("./hotkeyDefinitions");
 
 const BIN_PATH = path.join(resourcesRoot(), "bin", "hotkey-helper");
 
-// Keycode 2 is 'D' on the ANSI layout - matches settingsStore.js's
-// DEFAULT_SETTINGS, so a fresh install with no settings file behaves
-// exactly as it always has. The helper only knows keycodes, not accelerator
-// strings, so the mapping lives here.
-//
-// Control+Option, not Cmd+Shift: this tap is listen-only (see main.swift),
-// so the keystroke still reaches whatever app is focused. A Cmd-combo that
-// doesn't match a menu item makes AppKit play the system alert beep, which
-// then gets captured at the start of the recording and Whisper hallucinates
-// as "[Music]". Control+Option isn't treated as a menu key-equivalent, so
-// nothing beeps.
-const DEFAULT_HOTKEY = { keyCode: 2, modifiers: ["ctrl", "alt"] };
+// The native helper uses keycode 58 as the logical standalone Option
+// identity. Its modifier-state event can represent either physical Option
+// key, so a fresh install can use Option without choosing a side.
+const DEFAULT_HOTKEY = { keyCode: STANDALONE_OPTION_KEY_CODE, modifiers: [] };
 
 const RESTART_DELAY_MS = 1000;
 const READY_TIMEOUT_MS = 5000;

--- a/electron/hotkeyHelper.test.js
+++ b/electron/hotkeyHelper.test.js
@@ -3,6 +3,7 @@ const assert = require("node:assert/strict");
 const { EventEmitter } = require("node:events");
 const { PassThrough, Writable } = require("node:stream");
 const { createHotkeyHelper, DEFAULT_HOTKEY } = require("./hotkeyHelper");
+const { STANDALONE_OPTION_KEY_CODE } = require("./hotkeyDefinitions");
 
 function fakeProcess() {
   const process = new EventEmitter();
@@ -131,12 +132,8 @@ test("spawns with the configured hotkey's args, defaulting to DEFAULT_HOTKEY", (
   helper.start();
 
   assert.equal(spawned.length, 1);
-  assert.deepEqual(spawned[0].args, [
-    "--keycode",
-    String(DEFAULT_HOTKEY.keyCode),
-    "--modifiers",
-    DEFAULT_HOTKEY.modifiers.join(","),
-  ]);
+  assert.deepEqual(DEFAULT_HOTKEY, { keyCode: STANDALONE_OPTION_KEY_CODE, modifiers: [] });
+  assert.deepEqual(spawned[0].args, ["--keycode", String(STANDALONE_OPTION_KEY_CODE), "--modifiers", ""]);
   helper.stop();
 });
 

--- a/electron/pushToTalkShortcutController.js
+++ b/electron/pushToTalkShortcutController.js
@@ -1,5 +1,5 @@
 const { createHotkeyHelper } = require("./hotkeyHelper");
-const { validateShortcut } = require("./settingsStore");
+const { validateNewShortcut } = require("./settingsStore");
 
 const UNAVAILABLE_MESSAGE = "Shortcut unavailable. Choose another shortcut.";
 const INTERNAL_FAILURE_MESSAGE = "Unable to change the Push-to-talk shortcut.";
@@ -103,7 +103,7 @@ function createPushToTalkShortcutController({
 
   async function replaceInternal(candidateShortcut) {
     try {
-      validateShortcut(candidateShortcut);
+      validateNewShortcut(candidateShortcut);
     } catch {
       return unsupportedResult();
     }

--- a/electron/pushToTalkShortcutController.test.js
+++ b/electron/pushToTalkShortcutController.test.js
@@ -1,9 +1,10 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const { createPushToTalkShortcutController } = require("./pushToTalkShortcutController");
+const { STANDALONE_OPTION_KEY_CODE } = require("./hotkeyDefinitions");
 
 const OLD_HOTKEY = { keyCode: 2, modifiers: ["ctrl", "alt"] };
-const NEW_HOTKEY = { keyCode: 49, modifiers: ["cmd"] };
+const NEW_HOTKEY = { keyCode: STANDALONE_OPTION_KEY_CODE, modifiers: [] };
 
 function fakeSettingsStore({ failFor = null } = {}) {
   let hotkey = { ...OLD_HOTKEY, modifiers: [...OLD_HOTKEY.modifiers] };
@@ -172,14 +173,19 @@ test("leaves persistence untouched when a ready candidate cannot become active",
   assert.deepEqual(settings.writes, []);
 });
 
-test("rejects malformed candidates without starting a helper", async () => {
+test("rejects legacy combinations and unsupported standalone keys without starting a helper", async () => {
   const settings = fakeSettingsStore();
   const factory = fakeHelperFactory();
   const controller = createController(settings, factory);
 
-  const result = await controller.replace({ keyCode: 2, modifiers: [] });
+  for (const candidate of [
+    { keyCode: 2, modifiers: ["ctrl"] },
+    { keyCode: 56, modifiers: [] },
+  ]) {
+    const result = await controller.replace(candidate);
+    assert.deepEqual(result, { ok: false, kind: "unsupported", message: "Unsupported key" });
+  }
 
-  assert.deepEqual(result, { ok: false, kind: "unsupported", message: "Unsupported key" });
   assert.equal(factory.helpers.length, 1);
   assert.deepEqual(settings.get().hotkey, OLD_HOTKEY);
 });

--- a/electron/settingsStore.js
+++ b/electron/settingsStore.js
@@ -1,12 +1,13 @@
 const fs = require("fs");
 const path = require("path");
 const { DEFAULT_BREAK_SAFE_BUNDLE_IDS } = require("./breakSafety");
+const { STANDALONE_OPTION_KEY_CODE, isStandaloneOptionShortcut } = require("./hotkeyDefinitions");
 
-// Matches hotkeyHelper.js's own default (Control+Option+D, see #84) and
-// breakSafety.js's own default allow-list, so a fresh install with no
-// settings file behaves exactly like it did before either was editable.
+// Matches hotkeyHelper.js's standalone Option default and breakSafety.js's
+// own default allow-list. Existing settings are read as-is below so this
+// only affects a fresh install with no settings file.
 const DEFAULT_SETTINGS = {
-  hotkey: { keyCode: 2, modifiers: ["ctrl", "alt"] },
+  hotkey: { keyCode: STANDALONE_OPTION_KEY_CODE, modifiers: [] },
   breakSafeApps: [...DEFAULT_BREAK_SAFE_BUNDLE_IDS],
   // #16: null means no project configured - vocabulary biasing is opt-in,
   // not a default every fresh install has to notice and turn off.
@@ -27,16 +28,23 @@ function validateShortcut(shortcut) {
   if (!shortcut || typeof shortcut.keyCode !== "number" || !Number.isInteger(shortcut.keyCode) || shortcut.keyCode < 0) {
     throw new Error("shortcut.keyCode must be a non-negative integer");
   }
-  if (!Array.isArray(shortcut.modifiers) || shortcut.modifiers.length === 0) {
-    // A shortcut with no modifiers would fire on every ordinary keystroke of
-    // that key - the native helper only ever taps global combos deliberately.
-    throw new Error("shortcut.modifiers must be a non-empty array");
+  if (!Array.isArray(shortcut.modifiers)) {
+    throw new Error("shortcut.modifiers must be an array");
   }
+  if (shortcut.modifiers.length === 0 && !isStandaloneOptionShortcut(shortcut)) {
+    throw new Error("Unsupported key");
+  }
+
   for (const modifier of shortcut.modifiers) {
     if (!VALID_MODIFIERS.has(modifier)) {
       throw new Error(`unknown modifier "${modifier}"`);
     }
   }
+}
+
+function validateNewShortcut(shortcut) {
+  validateShortcut(shortcut);
+  if (!isStandaloneOptionShortcut(shortcut)) throw new Error("Unsupported key");
 }
 
 function validateVocabularyProjectPath(projectPath) {
@@ -179,5 +187,6 @@ module.exports = {
   createSettingsStore,
   DEFAULT_SETTINGS,
   validateShortcut,
+  validateNewShortcut,
   validateHotkey: validateShortcut,
 };

--- a/electron/settingsStore.test.js
+++ b/electron/settingsStore.test.js
@@ -4,6 +4,7 @@ const fs = require("fs");
 const os = require("os");
 const path = require("path");
 const { createSettingsStore, DEFAULT_SETTINGS } = require("./settingsStore");
+const { STANDALONE_OPTION_KEY_CODE } = require("./hotkeyDefinitions");
 
 function tempFilePath() {
   return path.join(fs.mkdtempSync(path.join(os.tmpdir(), "openstream-settings-")), "settings.json");
@@ -14,7 +15,12 @@ test("returns defaults when no settings file exists yet", () => {
   assert.deepEqual(store.get(), DEFAULT_SETTINGS);
 });
 
-test("setHotkey persists to disk and get() reflects it afterwards", () => {
+test("fresh settings default to standalone Option", () => {
+  const store = createSettingsStore({ filePath: tempFilePath() });
+  assert.deepEqual(store.get().hotkey, { keyCode: STANDALONE_OPTION_KEY_CODE, modifiers: [] });
+});
+
+test("setHotkey persists a legacy combination to disk", () => {
   const filePath = tempFilePath();
   const store = createSettingsStore({ filePath });
 
@@ -53,15 +59,24 @@ test("a partial disk write leaves the cached and saved shortcut unchanged", () =
   assert.deepEqual(JSON.parse(fs.readFileSync(filePath, "utf8")).hotkey, { keyCode: 2, modifiers: ["ctrl", "alt"] });
 });
 
-test("rejects a hotkey with no modifiers", () => {
+test("persists standalone Option", () => {
+  const filePath = tempFilePath();
+  const store = createSettingsStore({ filePath });
+
+  store.setShortcut({ keyCode: STANDALONE_OPTION_KEY_CODE, modifiers: [] });
+  assert.deepEqual(store.get().hotkey, { keyCode: STANDALONE_OPTION_KEY_CODE, modifiers: [] });
+});
+
+test("rejects an unsupported standalone key", () => {
   const store = createSettingsStore({ filePath: tempFilePath() });
-  assert.throws(() => store.setHotkey({ keyCode: 2, modifiers: [] }), /non-empty/);
+  assert.throws(() => store.setHotkey({ keyCode: 2, modifiers: [] }), /Unsupported key/);
 });
 
 test("rejects an unknown modifier", () => {
   const store = createSettingsStore({ filePath: tempFilePath() });
   assert.throws(() => store.setHotkey({ keyCode: 2, modifiers: ["fn"] }), /unknown modifier/);
 });
+
 
 test("rejects a non-integer keyCode", () => {
   const store = createSettingsStore({ filePath: tempFilePath() });
@@ -85,6 +100,18 @@ test("onChange fires with the new settings after a successful setHotkey", () => 
 
   assert.equal(seen.length, 1);
   assert.deepEqual(seen[0].hotkey, { keyCode: 3, modifiers: ["cmd"] });
+});
+
+test("loads an existing legacy combination without rewriting it", () => {
+  const filePath = tempFilePath();
+  const saved = { ...DEFAULT_SETTINGS, hotkey: { keyCode: 2, modifiers: ["ctrl", "alt"] } };
+  fs.writeFileSync(filePath, JSON.stringify(saved, null, 2));
+  const before = fs.readFileSync(filePath, "utf8");
+
+  const store = createSettingsStore({ filePath });
+
+  assert.deepEqual(store.get().hotkey, saved.hotkey);
+  assert.equal(fs.readFileSync(filePath, "utf8"), before);
 });
 
 test("a corrupt settings file falls back to defaults instead of throwing", () => {

--- a/native/hotkey-helper/Package.swift
+++ b/native/hotkey-helper/Package.swift
@@ -5,9 +5,19 @@ let package = Package(
     name: "hotkey-helper",
     platforms: [.macOS(.v11)],
     targets: [
+        .target(
+            name: "HotkeyMatcher",
+            path: "Sources/HotkeyMatcher"
+        ),
         .executableTarget(
             name: "hotkey-helper",
+            dependencies: ["HotkeyMatcher"],
             path: "Sources/hotkey-helper"
+        ),
+        .testTarget(
+            name: "HotkeyMatcherTests",
+            dependencies: ["HotkeyMatcher"],
+            path: "Tests/HotkeyMatcherTests"
         )
     ]
 )

--- a/native/hotkey-helper/Sources/HotkeyMatcher/HotkeyMatcher.swift
+++ b/native/hotkey-helper/Sources/HotkeyMatcher/HotkeyMatcher.swift
@@ -1,0 +1,102 @@
+public struct HotkeyFlags: OptionSet, Equatable {
+    public let rawValue: UInt8
+
+    public init(rawValue: UInt8) {
+        self.rawValue = rawValue
+    }
+
+    public static let command = HotkeyFlags(rawValue: 1 << 0)
+    public static let shift = HotkeyFlags(rawValue: 1 << 1)
+    public static let alternate = HotkeyFlags(rawValue: 1 << 2)
+    public static let control = HotkeyFlags(rawValue: 1 << 3)
+}
+
+public enum HotkeyEventType {
+    case keyDown
+    case keyUp
+    case flagsChanged
+}
+
+public struct HotkeyEvent {
+    public let keyCode: Int64
+    public let type: HotkeyEventType
+    public let flags: HotkeyFlags
+    public let isAutorepeat: Bool
+
+    public init(keyCode: Int64, type: HotkeyEventType, flags: HotkeyFlags = [], isAutorepeat: Bool = false) {
+        self.keyCode = keyCode
+        self.type = type
+        self.flags = flags
+        self.isAutorepeat = isAutorepeat
+    }
+}
+
+public enum HotkeySignal: Equatable {
+    case down
+    case up
+}
+
+public struct HotkeyMatcher {
+    public static let standaloneOptionKeyCode: Int64 = 58
+    private static let rightOptionKeyCode: Int64 = 61
+
+    private let targetKeyCode: Int64
+    private let targetFlags: HotkeyFlags
+    private var isActive = false
+    private var previousFlags: HotkeyFlags = []
+
+    public init(keyCode: Int64, flags: HotkeyFlags) {
+        self.targetKeyCode = keyCode
+        self.targetFlags = flags
+    }
+
+    public mutating func handle(_ event: HotkeyEvent) -> HotkeySignal? {
+        if isStandaloneOption {
+            return handleStandaloneOption(event)
+        }
+        guard !targetFlags.isEmpty else { return nil }
+
+        switch event.type {
+        case .keyDown:
+            guard !event.isAutorepeat, !isActive else { return nil }
+            guard event.keyCode == targetKeyCode, event.flags == targetFlags else { return nil }
+            isActive = true
+            return .down
+        case .keyUp:
+            guard isActive, event.keyCode == targetKeyCode else { return nil }
+            isActive = false
+            return .up
+        case .flagsChanged:
+            return nil
+        }
+    }
+
+    private var isStandaloneOption: Bool {
+        targetKeyCode == Self.standaloneOptionKeyCode && targetFlags.isEmpty
+    }
+
+    private static func isOptionKeyCode(_ keyCode: Int64) -> Bool {
+        keyCode == Self.standaloneOptionKeyCode || keyCode == Self.rightOptionKeyCode
+    }
+
+    private mutating func handleStandaloneOption(_ event: HotkeyEvent) -> HotkeySignal? {
+        guard event.type == .flagsChanged else { return nil }
+
+        let wasDown = previousFlags.contains(.alternate)
+        let isDown = event.flags.contains(.alternate)
+        previousFlags = event.flags
+
+        guard Self.isOptionKeyCode(event.keyCode) else { return nil }
+        if !wasDown && isDown {
+            guard event.flags.subtracting(.alternate).isEmpty, !isActive else { return nil }
+            isActive = true
+            return .down
+        }
+        if wasDown && !isDown {
+            guard isActive else { return nil }
+            isActive = false
+            return .up
+        }
+        return nil
+    }
+}

--- a/native/hotkey-helper/Sources/hotkey-helper/main.swift
+++ b/native/hotkey-helper/Sources/hotkey-helper/main.swift
@@ -1,5 +1,6 @@
 import CoreGraphics
 import Foundation
+import HotkeyMatcher
 
 // Push-to-talk hotkey helper, per issue #5.
 //
@@ -26,23 +27,23 @@ func emit(_ event: String) {
     fflush(stdout)
 }
 
-func parseModifiers(_ raw: String) -> CGEventFlags {
-    var flags: CGEventFlags = []
+func parseModifiers(_ raw: String) -> HotkeyFlags {
+    var flags: HotkeyFlags = []
     for name in raw.split(separator: ",") {
         switch name.trimmingCharacters(in: .whitespaces) {
-        case "cmd": flags.insert(.maskCommand)
-        case "shift": flags.insert(.maskShift)
-        case "alt", "option": flags.insert(.maskAlternate)
-        case "ctrl", "control": flags.insert(.maskControl)
+        case "cmd": flags.insert(.command)
+        case "shift": flags.insert(.shift)
+        case "alt", "option": flags.insert(.alternate)
+        case "ctrl", "control": flags.insert(.control)
         default: eprint("hotkey-helper: ignoring unknown modifier \"\(name)\"")
         }
     }
     return flags
 }
 
-func parseArgs() -> (keyCode: Int64, flags: CGEventFlags) {
-    var keyCode: Int64 = 2 // 'D' on the ANSI layout - matches CommandOrControl+Shift+D
-    var flags: CGEventFlags = [.maskCommand, .maskShift]
+func parseArgs() -> (keyCode: Int64, flags: HotkeyFlags) {
+    var keyCode = HotkeyMatcher.standaloneOptionKeyCode
+    var flags: HotkeyFlags = []
 
     let args = CommandLine.arguments
     var i = 1
@@ -62,10 +63,19 @@ func parseArgs() -> (keyCode: Int64, flags: CGEventFlags) {
     return (keyCode, flags)
 }
 
-let (targetKeyCode, targetFlags) = parseArgs()
-let relevantFlagsMask: CGEventFlags = [.maskCommand, .maskShift, .maskAlternate, .maskControl]
+let configuration = parseArgs()
+var matcher = HotkeyMatcher(keyCode: configuration.keyCode, flags: configuration.flags)
 
 var tap: CFMachPort?
+
+func hotkeyFlags(for flags: CGEventFlags) -> HotkeyFlags {
+    var result: HotkeyFlags = []
+    if flags.contains(.maskCommand) { result.insert(.command) }
+    if flags.contains(.maskShift) { result.insert(.shift) }
+    if flags.contains(.maskAlternate) { result.insert(.alternate) }
+    if flags.contains(.maskControl) { result.insert(.control) }
+    return result
+}
 
 func handleEvent(proxy: CGEventTapProxy, type: CGEventType, event: CGEvent, refcon: UnsafeMutableRawPointer?) -> Unmanaged<CGEvent>? {
     if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
@@ -78,20 +88,26 @@ func handleEvent(proxy: CGEventTapProxy, type: CGEventType, event: CGEvent, refc
         return Unmanaged.passRetained(event)
     }
 
-    guard type == .keyDown || type == .keyUp else {
+    guard type == .keyDown || type == .keyUp || type == .flagsChanged else {
         return Unmanaged.passRetained(event)
     }
 
-    // Key repeat resends keyDown for as long as the key is held - only the
-    // first down and the eventual up are a press/release pair.
-    if type == .keyDown && event.getIntegerValueField(.keyboardEventAutorepeat) != 0 {
-        return Unmanaged.passRetained(event)
+    let eventType: HotkeyEventType
+    switch type {
+    case .keyDown: eventType = .keyDown
+    case .keyUp: eventType = .keyUp
+    case .flagsChanged: eventType = .flagsChanged
+    default: return Unmanaged.passRetained(event)
     }
 
-    let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
-    let flags = event.flags.intersection(relevantFlagsMask)
-    if keyCode == targetKeyCode && flags == targetFlags {
-        emit(type == .keyDown ? "down" : "up")
+    let hotkeyEvent = HotkeyEvent(
+        keyCode: event.getIntegerValueField(.keyboardEventKeycode),
+        type: eventType,
+        flags: hotkeyFlags(for: event.flags),
+        isAutorepeat: event.getIntegerValueField(.keyboardEventAutorepeat) != 0
+    )
+    if let signal = matcher.handle(hotkeyEvent) {
+        emit(signal == .down ? "down" : "up")
     }
 
     return Unmanaged.passRetained(event)
@@ -102,7 +118,10 @@ if !CGPreflightListenEventAccess() {
     _ = CGRequestListenEventAccess()
 }
 
-let eventMask: CGEventMask = (1 << CGEventType.keyDown.rawValue) | (1 << CGEventType.keyUp.rawValue)
+let eventMask: CGEventMask =
+    (1 << CGEventType.keyDown.rawValue) |
+    (1 << CGEventType.keyUp.rawValue) |
+    (1 << CGEventType.flagsChanged.rawValue)
 
 guard let createdTap = CGEvent.tapCreate(
     tap: .cgSessionEventTap,

--- a/native/hotkey-helper/Tests/HotkeyMatcherTests/HotkeyMatcherTests.swift
+++ b/native/hotkey-helper/Tests/HotkeyMatcherTests/HotkeyMatcherTests.swift
@@ -1,0 +1,108 @@
+import XCTest
+@testable import HotkeyMatcher
+
+final class HotkeyMatcherTests: XCTestCase {
+    func testLegacyKeyUpUsesThePressThatStartedThePair() {
+        var matcher = HotkeyMatcher(keyCode: 2, flags: [.control, .alternate])
+
+        XCTAssertEqual(
+            matcher.handle(HotkeyEvent(keyCode: 2, type: .keyDown, flags: [.control, .alternate])),
+            .down
+        )
+        XCTAssertEqual(matcher.handle(HotkeyEvent(keyCode: 2, type: .keyUp)), .up)
+    }
+
+    func testLegacyKeyRepeatAndUnrelatedInputAreIgnored() {
+        var matcher = HotkeyMatcher(keyCode: 2, flags: [.control, .alternate])
+
+        XCTAssertNil(
+            matcher.handle(
+                HotkeyEvent(keyCode: 2, type: .keyDown, flags: [.control, .alternate], isAutorepeat: true)
+            )
+        )
+        XCTAssertNil(matcher.handle(HotkeyEvent(keyCode: 3, type: .keyDown, flags: [.control, .alternate])))
+        XCTAssertEqual(
+            matcher.handle(HotkeyEvent(keyCode: 2, type: .keyDown, flags: [.control, .alternate])),
+            .down
+        )
+        XCTAssertNil(
+            matcher.handle(
+                HotkeyEvent(keyCode: 2, type: .keyDown, flags: [.control, .alternate], isAutorepeat: true)
+            )
+        )
+        XCTAssertEqual(matcher.handle(HotkeyEvent(keyCode: 2, type: .keyUp, flags: [.control])), .up)
+    }
+
+    func testStandaloneOptionUsesModifierStateTransitions() {
+        var matcher = HotkeyMatcher(keyCode: HotkeyMatcher.standaloneOptionKeyCode, flags: [])
+
+        XCTAssertEqual(
+            matcher.handle(
+                HotkeyEvent(
+                    keyCode: HotkeyMatcher.standaloneOptionKeyCode,
+                    type: .flagsChanged,
+                    flags: [.alternate]
+                )
+            ),
+            .down
+        )
+        XCTAssertNil(
+            matcher.handle(
+                HotkeyEvent(
+                    keyCode: HotkeyMatcher.standaloneOptionKeyCode,
+                    type: .flagsChanged,
+                    flags: [.alternate]
+                )
+            )
+        )
+        XCTAssertNil(
+            matcher.handle(
+                HotkeyEvent(keyCode: 55, type: .flagsChanged, flags: [.alternate, .command])
+            )
+        )
+        XCTAssertNil(
+            matcher.handle(HotkeyEvent(keyCode: 55, type: .flagsChanged, flags: [.alternate]))
+        )
+        XCTAssertEqual(
+            matcher.handle(HotkeyEvent(keyCode: 61, type: .flagsChanged, flags: [])),
+            .up
+        )
+    }
+
+    func testStandaloneOptionAcceptsEitherPhysicalOptionKey() {
+        var matcher = HotkeyMatcher(keyCode: HotkeyMatcher.standaloneOptionKeyCode, flags: [])
+
+        XCTAssertEqual(
+            matcher.handle(HotkeyEvent(keyCode: 61, type: .flagsChanged, flags: [.alternate])),
+            .down
+        )
+        XCTAssertEqual(matcher.handle(HotkeyEvent(keyCode: 61, type: .flagsChanged)), .up)
+    }
+
+    func testStandaloneOptionRejectsAnAdditionalModifierOnPress() {
+        var matcher = HotkeyMatcher(keyCode: HotkeyMatcher.standaloneOptionKeyCode, flags: [])
+
+        XCTAssertNil(
+            matcher.handle(
+                HotkeyEvent(
+                    keyCode: HotkeyMatcher.standaloneOptionKeyCode,
+                    type: .flagsChanged,
+                    flags: [.command, .alternate]
+                )
+            )
+        )
+        XCTAssertNil(
+            matcher.handle(
+                HotkeyEvent(keyCode: HotkeyMatcher.standaloneOptionKeyCode, type: .flagsChanged, flags: [.command])
+            )
+        )
+    }
+
+    func testMalformedEmptyModifierIdentityNeverMatches() {
+        var matcher = HotkeyMatcher(keyCode: 2, flags: [])
+
+        XCTAssertNil(matcher.handle(HotkeyEvent(keyCode: 2, type: .keyDown)))
+        XCTAssertNil(matcher.handle(HotkeyEvent(keyCode: 2, type: .keyUp)))
+        XCTAssertNil(matcher.handle(HotkeyEvent(keyCode: 2, type: .flagsChanged, flags: [.alternate])))
+    }
+}

--- a/scripts/verify-dictation-pipeline.sh
+++ b/scripts/verify-dictation-pipeline.sh
@@ -314,7 +314,7 @@ say "Both model servers are listening."
 stage "Check global push-to-talk feedback"
 open -a TextEdit
 step "Click inside a new TextEdit document. Keep OpenStream unfocused."
-step "Hold Control+Option+D and speak for two or three seconds."
+step "Hold Option and speak for two or three seconds."
 step "While holding the keys, confirm the tray shows recording, the overlay is visible, and its sound meter moves with your voice."
 step "Release the keys and confirm the tray shows transcribing before returning to idle."
 if confirm "Did the global hotkey, real microphone, tray, overlay, and sound meter all work?"; then
@@ -329,7 +329,7 @@ open -a TextEdit
 say "Use this unique three-sentence phrase:"
 note "Atomic amber river. Local models stay home. This text appears one time."
 step "Place the cursor on an empty line in TextEdit."
-step "Hold Control+Option+D, dictate the phrase, then release."
+step "Hold Option, dictate the phrase, then release."
 step "Wait for insertion. Do not paste or type any correction."
 if confirm "Did one finished block appear exactly once, with no provisional text or later revision?"; then
   INSERTION_RESULT="pass"
@@ -375,7 +375,7 @@ stage "Measure the dictation latency budget"
 LATENCY_LINE_START=$(wc -l < "$LOG_FILE")
 say "Run three warm dictations in TextEdit. Wait for each insertion before starting the next."
 for run in 1 2 3; do
-  step "Dictation $run of 3: hold Control+Option+D, speak one sentence, release, and wait for insertion."
+  step "Dictation $run of 3: hold Option, speak one sentence, release, and wait for insertion."
   pause "Press Enter after dictation $run arrives."
 done
 while IFS= read -r value; do

--- a/src/HotkeySettings.tsx
+++ b/src/HotkeySettings.tsx
@@ -47,7 +47,7 @@ export default function HotkeySettings() {
   }, [recording]);
 
   const buttonLabel = recording
-    ? "Press a key combo…"
+    ? "Press Option…"
     : shortcutChangePending
       ? "Checking shortcut…"
       : "Change shortcut";
@@ -57,8 +57,8 @@ export default function HotkeySettings() {
       <h2>Push-to-talk shortcut</h2>
       <p className="setting-current">{shortcut ? formatHotkey(shortcut) : "Loading…"}</p>
       <p className="setting-guidance">
-        OpenStream cannot reliably detect conflicts with macOS or other apps. If a shortcut does not work, choose another
-        shortcut.
+        OpenStream cannot reliably detect whether macOS or another app also uses Option. If it does not work, choose
+        another shortcut.
       </p>
       <button
         onClick={() => {

--- a/src/components/KeyCaps.tsx
+++ b/src/components/KeyCaps.tsx
@@ -1,7 +1,7 @@
 import { hotkeyParts } from "../hotkey/keycodeMap";
 import type { StoredHotkey } from "../hotkey/captureHotkey";
 
-// Renders a stored hotkey as separate keycaps: ⌃ ⌥ D.
+// Renders a stored shortcut as separate keycaps: ⌃ ⌥ D or Option.
 export default function KeyCaps({ hotkey }: { hotkey: StoredHotkey }) {
   return (
     <span className="keys">

--- a/src/hotkey/captureHotkey.test.ts
+++ b/src/hotkey/captureHotkey.test.ts
@@ -1,37 +1,30 @@
 import { describe, expect, it } from "vitest";
 import { captureHotkeyFromEvent, type CapturedKeyEvent } from "./captureHotkey";
+import { STANDALONE_OPTION_KEY_CODE } from "./keycodeMap";
 
 function keyEvent(overrides: Partial<CapturedKeyEvent> & { code: string }): CapturedKeyEvent {
   return { metaKey: false, shiftKey: false, altKey: false, ctrlKey: false, ...overrides };
 }
 
 describe("captureHotkeyFromEvent", () => {
-  it("accepts a letter held with one modifier", () => {
-    const result = captureHotkeyFromEvent(keyEvent({ code: "KeyD", ctrlKey: true }));
-    expect(result).toEqual({ ok: true, hotkey: { keyCode: 2, modifiers: ["ctrl"] } });
+  it.each(["AltLeft", "AltRight"])("accepts standalone %s as Option", (code) => {
+    const result = captureHotkeyFromEvent(keyEvent({ code, altKey: true }));
+    expect(result).toEqual({ ok: true, hotkey: { keyCode: STANDALONE_OPTION_KEY_CODE, modifiers: [] } });
   });
 
-  it("collects every held modifier, in event-property order", () => {
-    const result = captureHotkeyFromEvent(
-      keyEvent({ code: "KeyD", ctrlKey: true, altKey: true, shiftKey: true, metaKey: true })
-    );
-    expect(result).toEqual({ ok: true, hotkey: { keyCode: 2, modifiers: ["ctrl", "alt", "shift", "cmd"] } });
+  it.each([
+    { code: "KeyD", ctrlKey: true },
+    { code: "Digit1", metaKey: true },
+    { code: "Period", altKey: true },
+    { code: "KeyD" },
+    { code: "ShiftLeft", shiftKey: true },
+    { code: "ArrowUp", ctrlKey: true },
+  ])("rejects unsupported input with the exact error", (event) => {
+    expect(captureHotkeyFromEvent(keyEvent(event))).toEqual({ ok: false, reason: "Unsupported key" });
   });
 
-  it("rejects a key with no modifier held", () => {
-    const result = captureHotkeyFromEvent(keyEvent({ code: "KeyD" }));
-    expect(result.ok).toBe(false);
-    if (!result.ok) expect(result.reason).toMatch(/at least one modifier/);
-  });
-
-  it("rejects a key outside the mapped range", () => {
-    const result = captureHotkeyFromEvent(keyEvent({ code: "ArrowUp", ctrlKey: true }));
-    expect(result.ok).toBe(false);
-    if (!result.ok) expect(result.reason).toMatch(/ArrowUp/);
-  });
-
-  it("accepts a digit with the Command modifier", () => {
-    const result = captureHotkeyFromEvent(keyEvent({ code: "Digit1", metaKey: true }));
-    expect(result).toEqual({ ok: true, hotkey: { keyCode: 18, modifiers: ["cmd"] } });
+  it("rejects Option when another modifier is held", () => {
+    const result = captureHotkeyFromEvent(keyEvent({ code: "AltLeft", altKey: true, metaKey: true }));
+    expect(result).toEqual({ ok: false, reason: "Unsupported key" });
   });
 });

--- a/src/hotkey/captureHotkey.ts
+++ b/src/hotkey/captureHotkey.ts
@@ -1,4 +1,4 @@
-import { macKeyCodeForDomCode } from "./keycodeMap";
+import { macKeyCodeForDomCode, STANDALONE_OPTION_KEY_CODE } from "./keycodeMap";
 
 export type CapturedKeyEvent = {
   code: string;
@@ -12,30 +12,22 @@ export type StoredHotkey = { keyCode: number; modifiers: string[] };
 
 export type CaptureResult = { ok: true; hotkey: StoredHotkey } | { ok: false; reason: string };
 
+const UNSUPPORTED_KEY = "Unsupported key";
+const STANDALONE_OPTION_CODES = new Set(["AltLeft", "AltRight"]);
+
 // Kept separate from the DOM/React capture UI so the decision - which key
 // events are acceptable as a global hotkey, and why one isn't - is testable
 // without a browser. A component wires this to a real keydown listener.
 export function captureHotkeyFromEvent(event: CapturedKeyEvent): CaptureResult {
   const keyCode = macKeyCodeForDomCode(event.code);
-  if (keyCode === undefined) {
-    return { ok: false, reason: `${event.code} can't be used as a hotkey - pick a letter, digit or punctuation key` };
-  }
+  const isStandaloneOption =
+    keyCode === STANDALONE_OPTION_KEY_CODE &&
+    STANDALONE_OPTION_CODES.has(event.code) &&
+    !event.ctrlKey &&
+    !event.shiftKey &&
+    !event.metaKey;
 
-  const modifiers: string[] = [];
-  if (event.ctrlKey) modifiers.push("ctrl");
-  if (event.altKey) modifiers.push("alt");
-  if (event.shiftKey) modifiers.push("shift");
-  if (event.metaKey) modifiers.push("cmd");
+  if (!isStandaloneOption) return { ok: false, reason: UNSUPPORTED_KEY };
 
-  if (modifiers.length === 0) {
-    // A bare key would fire the hotkey on every ordinary keystroke of it -
-    // see settingsStore.js's validateHotkey, which enforces the same rule
-    // server-side.
-    return {
-      ok: false,
-      reason: "hold at least one modifier key (Control, Option, Shift or Command) together with the key",
-    };
-  }
-
-  return { ok: true, hotkey: { keyCode, modifiers } };
+  return { ok: true, hotkey: { keyCode: STANDALONE_OPTION_KEY_CODE, modifiers: [] } };
 }

--- a/src/hotkey/keycodeMap.test.ts
+++ b/src/hotkey/keycodeMap.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { formatHotkey, hotkeyParts, labelForMacKeyCode, macKeyCodeForDomCode } from "./keycodeMap";
+import {
+  formatHotkey,
+  hotkeyParts,
+  labelForMacKeyCode,
+  macKeyCodeForDomCode,
+  STANDALONE_OPTION_KEY_CODE,
+} from "./keycodeMap";
 
 describe("macKeyCodeForDomCode", () => {
   it("maps a letter key to its macOS virtual keycode", () => {
@@ -10,6 +16,11 @@ describe("macKeyCodeForDomCode", () => {
 
   it("maps a digit key", () => {
     expect(macKeyCodeForDomCode("Digit1")).toBe(18);
+  });
+
+  it("maps either physical Option key to one logical identity", () => {
+    expect(macKeyCodeForDomCode("AltLeft")).toBe(STANDALONE_OPTION_KEY_CODE);
+    expect(macKeyCodeForDomCode("AltRight")).toBe(STANDALONE_OPTION_KEY_CODE);
   });
 
   it("returns undefined for an unmapped key", () => {
@@ -23,6 +34,10 @@ describe("labelForMacKeyCode", () => {
     expect(labelForMacKeyCode(2)).toBe("D");
   });
 
+  it("labels the standalone Option identity", () => {
+    expect(labelForMacKeyCode(STANDALONE_OPTION_KEY_CODE)).toBe("Option");
+  });
+
   it("falls back to a numbered placeholder for an unmapped keycode", () => {
     expect(labelForMacKeyCode(999)).toBe("#999");
   });
@@ -33,12 +48,16 @@ describe("formatHotkey", () => {
     expect(formatHotkey({ keyCode: 2, modifiers: ["cmd", "ctrl"] })).toBe("⌃⌘D");
   });
 
-  it("formats the current default (Control+Option+D)", () => {
+  it("formats a legacy Control+Option+D combination", () => {
     expect(formatHotkey({ keyCode: 2, modifiers: ["ctrl", "alt"] })).toBe("⌃⌥D");
   });
 
   it("formats a single modifier", () => {
     expect(formatHotkey({ keyCode: 49, modifiers: ["cmd"] })).toBe("⌘Space");
+  });
+
+  it("formats standalone Option with its human-readable name", () => {
+    expect(formatHotkey({ keyCode: STANDALONE_OPTION_KEY_CODE, modifiers: [] })).toBe("Option");
   });
 });
 

--- a/src/hotkey/keycodeMap.ts
+++ b/src/hotkey/keycodeMap.ts
@@ -1,9 +1,9 @@
-// macOS virtual keycodes (Carbon Events.h kVK_ANSI_*) for the US ANSI
-// layout, keyed by the DOM KeyboardEvent.code values a renderer can
-// actually observe. Covers letters, digits and the punctuation keys next
-// to them - the plausible range for a dictation hotkey. Arrow, function
-// and other unmapped keys are rejected by captureHotkey.ts rather than
-// guessed at here.
+// macOS virtual keycodes (Carbon Events.h kVK_*) keyed by the DOM
+// KeyboardEvent.code values a renderer can actually observe. Legacy
+// combinations still use the ANSI character mappings; new captures only use
+// the logical standalone Option identity below.
+export const STANDALONE_OPTION_KEY_CODE = 58;
+
 export const DOM_CODE_TO_MAC_KEYCODE: Record<string, number> = {
   KeyA: 0, KeyB: 11, KeyC: 8, KeyD: 2, KeyE: 14, KeyF: 3, KeyG: 5, KeyH: 4,
   KeyI: 34, KeyJ: 38, KeyK: 40, KeyL: 37, KeyM: 46, KeyN: 45, KeyO: 31,
@@ -14,12 +14,14 @@ export const DOM_CODE_TO_MAC_KEYCODE: Record<string, number> = {
   Minus: 27, Equal: 24, BracketLeft: 33, BracketRight: 30, Backslash: 42,
   Semicolon: 41, Quote: 39, Comma: 43, Period: 47, Slash: 44, Backquote: 50,
   Space: 49, Tab: 48,
+  // Both physical Option keys share one logical identity for new captures.
+  AltLeft: STANDALONE_OPTION_KEY_CODE, AltRight: STANDALONE_OPTION_KEY_CODE,
 };
 
 const SYMBOL_LABELS: Record<string, string> = {
   Minus: "-", Equal: "=", BracketLeft: "[", BracketRight: "]", Backslash: "\\",
   Semicolon: ";", Quote: "'", Comma: ",", Period: ".", Slash: "/", Backquote: "`",
-  Space: "Space", Tab: "Tab",
+  Space: "Space", Tab: "Tab", AltLeft: "Option", AltRight: "Option",
 };
 
 function labelForDomCode(code: string): string {

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -59,7 +59,7 @@ export default function Settings() {
   return (
     <main className="page">
       {/* HotkeySettings renders its own headed `.setting` section - it's
-          kept as-is until the shortcut work settles (#215), then restyled
+          kept as-is until the one-key shortcut work settles (#216), then restyled
           into the card system like the rest of this page. */}
       <HotkeySettings />
 


### PR DESCRIPTION
## Summary

- make standalone Option the fresh-install Push-to-talk default
- accept only standalone Option for new captures while preserving legacy saved combinations
- match Option through native modifier-state events with an atomic helper replacement
- add renderer, Electron, native matcher, persistence, and manual verification coverage

## Validation

- `npm run typecheck`
- `npm run build`
- `npm run build:hotkey-helper`
- `swift test --package-path native/hotkey-helper`
- focused JavaScript and Vitest suites pass
- `npm test` runs 220 passing tests plus 5 pre-existing failures in cleanup fixture/diagnostic expectations

The branch is based on `upstream/main`, which already contains the atomic replacement work from #215.
