### PR TITLE
Bound the AX-context wait and fall back on timeout (#181)

### DIFF
--- a/electron/accessibilityHelper.js
+++ b/electron/accessibilityHelper.js
@@ -114,7 +114,14 @@ function createAccessibilityHelper({
     ) {
       throw new Error(`accessibility-helper returned an invalid context reply${reply.reason ? `: ${reply.reason}` : ""}`);
     }
-    return { bundleId: reply.bundleId, isOneLineField: reply.isOneLineField };
+    // #181: axReady is false when the focused element never became AX-ready
+    // in time and isOneLineField is the safe default, not the real role.
+    // The dictation still proceeds - deny-by-default on line breaks.
+    return {
+      bundleId: reply.bundleId,
+      isOneLineField: reply.isOneLineField,
+      axReady: reply.axReady !== false,
+    };
   }
 
   // #47: the two grants the pipeline can't work without, as this process

--- a/electron/accessibilityHelper.test.js
+++ b/electron/accessibilityHelper.test.js
@@ -55,7 +55,7 @@ test("accessibility helper correlates context and insertion replies received out
   child.stdout.write('{"id":"2","status":"delivered","method":"wrote into the field","verified":true}\n');
   child.stdout.write('{"id":"1","status":"ok","bundleId":"com.apple.TextEdit","isOneLineField":false}\n');
 
-  assert.deepEqual(await contextPromise, { bundleId: "com.apple.TextEdit", isOneLineField: false });
+  assert.deepEqual(await contextPromise, { bundleId: "com.apple.TextEdit", isOneLineField: false, axReady: true });
   assert.deepEqual(await insertionPromise, { kind: "inserted" });
   helper.stop();
 });
@@ -162,7 +162,7 @@ test("accessibility helper ignores logs and non-contract output on stdout", asyn
   child.stdout.write('{"id":7,"status":"ok"}\n');
   child.stdout.write(`{"id":"${requests[0].id}","status":"ok","bundleId":"com.apple.TextEdit","isOneLineField":true}\n`);
 
-  assert.deepEqual(await context, { bundleId: "com.apple.TextEdit", isOneLineField: true });
+  assert.deepEqual(await context, { bundleId: "com.apple.TextEdit", isOneLineField: true, axReady: true });
   helper.stop();
 });
 
@@ -181,7 +181,7 @@ test("accessibility helper keeps diagnostics on stderr and replies on stdout", a
   child.stderr.write("Accessibility access is missing\n");
   child.stdout.write(`{"id":"${requests[0].id}","status":"ok","bundleId":"com.apple.TextEdit","isOneLineField":false}\n`);
 
-  assert.deepEqual(await context, { bundleId: "com.apple.TextEdit", isOneLineField: false });
+  assert.deepEqual(await context, { bundleId: "com.apple.TextEdit", isOneLineField: false, axReady: true });
   assert.equal(stderrChunks.join(""), "[accessibility-helper] Accessibility access is missing\n");
   helper.stop();
 });

--- a/electron/dictationCoordinator.js
+++ b/electron/dictationCoordinator.js
@@ -76,6 +76,10 @@ function createDictationIntake(options) {
       ) {
         throw new Error("context adapter returned an invalid focus context");
       }
+      // #181: when the focused element wasn't AX-ready, isOneLineField is a
+      // safe guess (deny breaks), not the real role. Logged so we can see
+      // how often the fallback fires in practice.
+      emitDiagnostic("context.axReady", focusContext.axReady !== false);
     } catch (error) {
       return failed("context", error);
     }

--- a/electron/dictationCoordinator.test.js
+++ b/electron/dictationCoordinator.test.js
@@ -140,6 +140,27 @@ test("a one-line field removes line breaks and its final full stop in a break-sa
   assert.deepEqual(delivered, ["First line second line"]);
 });
 
+test("a not-AX-ready context (#181) delivers as one paragraph and records the fallback", async () => {
+  let breakCalls = 0;
+  const harness = createIntake({
+    transcript: "first topic. still first topic. second topic. more on the second topic.",
+    getFocusContext: async () => ({ bundleId: "com.apple.TextEdit", isOneLineField: true, axReady: false }),
+    placeParagraphBreaks: async () => {
+      breakCalls++;
+      return "3";
+    },
+  });
+
+  const result = await harness.intake.complete(completedWav);
+
+  // isOneLineField:true (the safe default when axReady is false) means no
+  // break-placement call and no line breaks - just deliver the text.
+  assert.equal(breakCalls, 0);
+  assert.equal(result.status, "delivered");
+  assert.ok(!result.text.includes("\n"));
+  assert.ok(harness.diagnostics.some(([name, value]) => name === "context.axReady" && value === false));
+});
+
 test("eligible long dictation sends cleaned sentences once and applies returned break indices", async () => {
   const harness = createIntake({
     transcript: "first topic. still first topic. second topic. more on the second topic.",
@@ -220,6 +241,7 @@ test("repairs malformed break indices without retrying and records format and re
   });
   assert.deepEqual(harness.diagnostics, [
     ["vocabulary.promptLength", 0],
+    ["context.axReady", true],
     ["paragraphBreaks.formatValid", false],
     ["paragraphBreaks.repairUsed", true],
     ["listBoundaries.formatValid", true],

--- a/native/accessibility-helper/Sources/AccessibilityInjection/Config.swift
+++ b/native/accessibility-helper/Sources/AccessibilityInjection/Config.swift
@@ -8,6 +8,13 @@ public struct Config {
     public var settleMs: Double
     public var settleBudgetMs: Double
     public var axDeadlineMs: Double
+    // #181: how long context detection retries a not-yet-ready AX tree
+    // before giving up and returning an unknown-field context. A cold
+    // Chrome tab can take 5+ seconds to become AX-ready (measured in
+    // prototypes/electron-ax-tree-10) - we can't win that race inside the
+    // sub-1s dictation budget, so this is deliberately short: catch a
+    // target that's a beat slow, fall back for one that's genuinely cold.
+    public var axReadyBudgetMs: Double
     public var restoreMs: Double
     public var axValueMaxChars: Int
     public var longTextChars: Int
@@ -17,6 +24,7 @@ public struct Config {
         settleMs: Double = 400,
         settleBudgetMs: Double = 1200,
         axDeadlineMs: Double = 150,
+        axReadyBudgetMs: Double = 250,
         restoreMs: Double = 300,
         axValueMaxChars: Int = 2000,
         longTextChars: Int = 120,
@@ -25,6 +33,7 @@ public struct Config {
         self.settleMs = settleMs
         self.settleBudgetMs = settleBudgetMs
         self.axDeadlineMs = axDeadlineMs
+        self.axReadyBudgetMs = axReadyBudgetMs
         self.restoreMs = restoreMs
         self.axValueMaxChars = axValueMaxChars
         self.longTextChars = longTextChars

--- a/native/accessibility-helper/Sources/AccessibilityInjection/RealAdapters.swift
+++ b/native/accessibility-helper/Sources/AccessibilityInjection/RealAdapters.swift
@@ -156,7 +156,29 @@ public final class RealFocusResolver: FocusResolving {
         return RealAXTarget(focusedRef as! AXUIElement) // swiftlint:disable:this force_cast
     }
 
-    public func focusContext(deadlineMs: Double) -> (bundleId: String, isOneLineField: Bool)? {
+    // #181: retry resolveFocusedElement until it works or the budget runs
+    // out. Each attempt is still capped by deadlineMs; a short sleep sits
+    // between attempts. Used only by context/selection detection, not by
+    // the injection path, so a slow AX tree can't add latency to delivery.
+    private func resolveFocusedElementWithin(budgetMs: Double, deadlineMs: Double) -> AccessibilityTarget? {
+        let start = Date()
+        while true {
+            if let target = resolveFocusedElement(deadlineMs: deadlineMs) {
+                return target
+            }
+            if Date().timeIntervalSince(start) * 1000 >= budgetMs {
+                return nil
+            }
+            Thread.sleep(forTimeInterval: 0.04)
+        }
+    }
+
+    // axReady is false when the focused element never became resolvable
+    // within the budget. The caller still gets a usable context - bundleId
+    // from the tracker, isOneLineField defaulted to true (deny line breaks,
+    // the safe direction for an unknown target) - rather than a hard nil
+    // that would fail the whole dictation. See #181.
+    public func focusContext(deadlineMs: Double, budgetMs: Double) -> (bundleId: String, isOneLineField: Bool, axReady: Bool)? {
         guard let frontApp = tracker.currentFrontmostApp() else {
             log("focusContext: tracker has no frontmost app cached")
             return nil
@@ -165,19 +187,20 @@ public final class RealFocusResolver: FocusResolving {
             log("focusContext: frontmost app \(frontApp.localizedName ?? "?") (pid \(frontApp.processIdentifier)) has no bundle identifier")
             return nil
         }
-        guard let focused = resolveFocusedElement(deadlineMs: deadlineMs) else {
-            return nil
+        guard let focused = resolveFocusedElementWithin(budgetMs: budgetMs, deadlineMs: deadlineMs) else {
+            log("focusContext: \(bundleId) focused element not AX-ready within \(budgetMs)ms - unknown-field context")
+            return (bundleId, true, false)
         }
 
         let role = focused.fieldInfo.role
-        return (bundleId, role == "AXTextField" || role == "AXComboBox")
+        return (bundleId, role == "AXTextField" || role == "AXComboBox", true)
     }
 
     // Voice editing (#17): the focused field's current selection, plus the
     // same bundle id / one-line-field context focusContext() returns.
     // nil means the focused element or the attribute could not be read;
     // an empty selectedText means there is simply nothing selected.
-    public func selectionContext(deadlineMs: Double) -> (bundleId: String, isOneLineField: Bool, selectedText: String)? {
+    public func selectionContext(deadlineMs: Double, budgetMs: Double) -> (bundleId: String, isOneLineField: Bool, selectedText: String)? {
         guard let frontApp = tracker.currentFrontmostApp() else {
             log("selectionContext: tracker has no frontmost app cached")
             return nil
@@ -186,7 +209,10 @@ public final class RealFocusResolver: FocusResolving {
             log("selectionContext: frontmost app has no bundle identifier")
             return nil
         }
-        guard let focused = resolveFocusedElement(deadlineMs: deadlineMs) else {
+        // A voice edit needs the selection; if the AX tree isn't ready in
+        // time there's nothing to read, so this returns nil and the caller
+        // falls through to ordinary dictation (#17).
+        guard let focused = resolveFocusedElementWithin(budgetMs: budgetMs, deadlineMs: deadlineMs) else {
             return nil
         }
         let role = focused.fieldInfo.role

--- a/native/accessibility-helper/Sources/accessibility-helper/main.swift
+++ b/native/accessibility-helper/Sources/accessibility-helper/main.swift
@@ -65,7 +65,10 @@ while let line = readLine(strippingNewline: true) {
 
     switch cmd {
     case "context":
-        guard let context = focusResolver.focusContext(deadlineMs: config.axDeadlineMs) else {
+        guard let context = focusResolver.focusContext(
+            deadlineMs: config.axDeadlineMs,
+            budgetMs: config.axReadyBudgetMs
+        ) else {
             emit(["id": id, "status": "error", "reason": "focused element unavailable"])
             continue
         }
@@ -74,6 +77,9 @@ while let line = readLine(strippingNewline: true) {
             "status": "ok",
             "bundleId": context.bundleId,
             "isOneLineField": context.isOneLineField,
+            // #181: false when the focused element never became AX-ready and
+            // isOneLineField is the safe default rather than the real role.
+            "axReady": context.axReady,
         ])
     case "insert", "inject":
         guard let text = obj["text"] as? String, !text.isEmpty else {
@@ -107,7 +113,10 @@ while let line = readLine(strippingNewline: true) {
         // #17: a get-only read of the focused field's current selection,
         // used at push-to-talk key-down to tell a voice edit from an
         // ordinary dictation. No settle guard, no injection.
-        guard let context = focusResolver.selectionContext(deadlineMs: config.axDeadlineMs) else {
+        guard let context = focusResolver.selectionContext(
+            deadlineMs: config.axDeadlineMs,
+            budgetMs: config.axReadyBudgetMs
+        ) else {
             emit(["id": id, "status": "error", "reason": "focused element unavailable"])
             continue
         }


### PR DESCRIPTION
Closes #181.

## The bug

Context detection did a **single** 150ms read of the focused element. A target that isn't AX-ready fails it instantly → `dictationCoordinator` returns `failed("context")` → **the whole dictation is lost**. `prototypes/electron-ax-tree-10` measured a cold Chrome tab taking 5+ seconds to become AX-ready.

## The fix

- **`Config.axReadyBudgetMs = 250`** — `focusContext` / `selectionContext` now retry `resolveFocusedElement` every ~40ms up to that budget. Deliberately short: we can't win the race with a genuinely cold target inside a sub-1s dictation budget, so the goal is to *not lose the dictation*, not to wait it out. Scoped to context/selection detection — the injection path is untouched, so a slow AX tree can't add latency to delivery.
- **On timeout, fall back instead of failing.** `focusContext` returns the `bundleId` (always known — from the app-switch tracker) with `isOneLineField: true` and `axReady: false`. The existing one-line-field handling turns that into: no break-placement call, no line breaks, deliver the text as one paragraph. Same deny-by-default posture an unlisted app already gets.
- **`context.axReady` diagnostic** so the fallback rate is visible in the logs.
- For voice edits, a not-ready selection read returns nil → the path falls through to ordinary dictation, unchanged.

## Testing

- typecheck + build + `swift build` clean; 231 pass / 5 pre-existing fail / 2 cancelled.
- New coordinator test: a not-AX-ready context delivers as one paragraph, makes no break-placement call, and records `context.axReady: false`.
- The Swift retry loop needs a real not-ready target (a cold Chrome tab) to exercise end to end — folded into #228.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
