### PR TITLE
Escape to cancel an in-progress recording (#134)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ OpenStream needs three macOS permissions:
 2. Input Monitoring for the hotkey helper.
 3. Accessibility for the text-insertion helper.
 
-After granting Input Monitoring and Accessibility, quit and restart the app. Click a text field, hold `Option`, speak, and release it. Existing saved combinations such as `Control+Option+D` remain usable until changed. A cold start can take 15 to 20 seconds while `whisper-server` loads its Metal shaders.
+After granting Input Monitoring and Accessibility, quit and restart the app. Click a text field, hold `Option`, speak, and release it. Press `Escape` while the key is held to abort a recording without inserting anything. Existing saved combinations such as `Control+Option+D` remain usable until changed. A cold start can take 15 to 20 seconds while `whisper-server` loads its Metal shaders.
 
 On launch the app checks these grants: if Accessibility or Input Monitoring is missing it opens on a **Permissions** screen with links straight to the right System Settings pane. `npm run doctor` runs the same check from the terminal.
 

--- a/electron/capture/capture.js
+++ b/electron/capture/capture.js
@@ -117,4 +117,12 @@ window.capture.onStop((timing) => {
   window.capture.sendRecording(wav, timing);
 });
 
+// #134: stop recording and throw the audio away - no WAV, no
+// recording-complete, so the pipeline never sees it.
+window.capture.onCancel(() => {
+  isRecording = false;
+  chunks = [];
+  window.capture.sendSoundLevel(0);
+});
+
 prepareCapture();

--- a/electron/capture/capturePreload.js
+++ b/electron/capture/capturePreload.js
@@ -6,6 +6,7 @@ const { contextBridge, ipcRenderer } = require("electron");
 contextBridge.exposeInMainWorld("capture", {
   onStart: (callback) => ipcRenderer.on("start-recording", callback),
   onStop: (callback) => ipcRenderer.on("stop-recording", (_event, timing) => callback(timing)),
+  onCancel: (callback) => ipcRenderer.on("cancel-recording", callback),
   sendReady: () => ipcRenderer.send("capture-ready"),
   sendRecording: (wavBuffer, timing) => ipcRenderer.send("recording-complete", wavBuffer, timing),
   sendSoundLevel: (level) => ipcRenderer.send("sound-level", level),

--- a/electron/main.js
+++ b/electron/main.js
@@ -5,6 +5,7 @@ const {
   BrowserWindow,
   clipboard,
   dialog,
+  globalShortcut,
   ipcMain,
   nativeImage,
   screen,
@@ -411,15 +412,35 @@ async function transcribeAndPrint(wavBuffer, timing) {
   }
 }
 
+// #134: Escape aborts a recording in progress. Registered only while
+// recording (a few seconds), so it isn't hijacking Escape from the app
+// the user is dictating into the rest of the time - and during a
+// dictation, an Escape press means "cancel this", not something in that
+// app the user is deliberately not touching.
+function armCancelShortcut() {
+  const registered = globalShortcut.register("Escape", () => pushToTalkCoordinator.cancel());
+  if (!registered) console.error("[dictation] couldn't register Escape to cancel - Escape won't abort a recording");
+}
+function disarmCancelShortcut() {
+  globalShortcut.unregister("Escape");
+}
+
 const pushToTalkCoordinator = createPushToTalkCoordinator({
   startCapture() {
     if (!captureWin) return;
     captureWin.webContents.send("start-recording");
-    console.log("[dictation] recording - release the hotkey to stop");
+    armCancelShortcut();
+    console.log("[dictation] recording - release the hotkey to stop, Escape to cancel");
   },
   stopCapture(timing) {
+    disarmCancelShortcut();
     if (!captureWin) return;
     captureWin.webContents.send("stop-recording", timing);
+  },
+  cancelCapture() {
+    disarmCancelShortcut();
+    if (captureWin) captureWin.webContents.send("cancel-recording");
+    console.log("[dictation] cancelled");
   },
   setUserVisibleState,
   onStuckRecording() {
@@ -730,6 +751,7 @@ app.whenReady().then(() => {
 });
 
 app.on("will-quit", () => {
+  globalShortcut.unregisterAll();
   pushToTalkShortcut?.stop();
   accessibilityHelper.stop();
   whisperServer.stop();

--- a/electron/pushToTalkCoordinator.js
+++ b/electron/pushToTalkCoordinator.js
@@ -8,6 +8,8 @@ const DEFAULT_MAX_RECORDING_MS = 60_000;
 function createPushToTalkCoordinator({
   startCapture,
   stopCapture,
+  // #134: discard the recording without running it through the pipeline.
+  cancelCapture = () => {},
   setUserVisibleState,
   now = performance.now.bind(performance),
   setSafetyTimer = setTimeout,
@@ -18,12 +20,16 @@ function createPushToTalkCoordinator({
   let recording = false;
   let safetyTimer = null;
 
-  function finishRecording() {
+  function stopRecordingState() {
     recording = false;
     if (safetyTimer) {
       clearSafetyTimer(safetyTimer);
       safetyTimer = null;
     }
+  }
+
+  function finishRecording() {
+    stopRecordingState();
     stopCapture({ releasedAtMs: now() });
     setUserVisibleState("transcribing");
   }
@@ -48,6 +54,19 @@ function createPushToTalkCoordinator({
     keyUp() {
       if (!recording) return;
       finishRecording();
+    },
+
+    // #134: called when the user hits Escape mid-recording. Drops the audio
+    // and returns to idle without transcribing or delivering anything.
+    cancel() {
+      if (!recording) return;
+      stopRecordingState();
+      cancelCapture();
+      setUserVisibleState("idle");
+    },
+
+    isRecording() {
+      return recording;
     },
   };
 }

--- a/electron/pushToTalkCoordinator.test.js
+++ b/electron/pushToTalkCoordinator.test.js
@@ -95,6 +95,59 @@ test("a keyUp that never arrives is force-stopped by the safety timeout, and the
   assert.deepEqual(captureCommands, ["start", "stop", "start"]);
 });
 
+// #134: Escape mid-recording discards the audio without transcribing.
+test("cancel() during a recording discards the capture and returns to idle", () => {
+  const captureCommands = [];
+  const states = [];
+  const timers = createFakeTimers();
+  const coordinator = createPushToTalkCoordinator({
+    startCapture: () => captureCommands.push("start"),
+    stopCapture: () => captureCommands.push("stop"),
+    cancelCapture: () => captureCommands.push("cancel"),
+    setUserVisibleState: (state) => states.push(state),
+    setSafetyTimer: timers.setSafetyTimer,
+    clearSafetyTimer: timers.clearSafetyTimer,
+  });
+
+  coordinator.keyDown();
+  coordinator.cancel();
+
+  // No stopCapture, so no WAV is encoded and recording-complete never fires.
+  assert.deepEqual(captureCommands, ["start", "cancel"]);
+  assert.deepEqual(states, ["recording", "idle"]);
+  assert.equal(timers.isPending(), false);
+  assert.equal(coordinator.isRecording(), false);
+});
+
+test("cancel() with no recording in progress is a no-op", () => {
+  const captureCommands = [];
+  const coordinator = createPushToTalkCoordinator({
+    startCapture: () => captureCommands.push("start"),
+    stopCapture: () => captureCommands.push("stop"),
+    cancelCapture: () => captureCommands.push("cancel"),
+    setUserVisibleState: () => {},
+  });
+
+  coordinator.cancel();
+  assert.deepEqual(captureCommands, []);
+});
+
+test("a keyUp after a cancel does nothing - the recording is already over", () => {
+  const captureCommands = [];
+  const coordinator = createPushToTalkCoordinator({
+    startCapture: () => captureCommands.push("start"),
+    stopCapture: () => captureCommands.push("stop"),
+    cancelCapture: () => captureCommands.push("cancel"),
+    setUserVisibleState: () => {},
+  });
+
+  coordinator.keyDown();
+  coordinator.cancel();
+  coordinator.keyUp();
+
+  assert.deepEqual(captureCommands, ["start", "cancel"]);
+});
+
 test("a normal keyUp cancels the safety timeout instead of double-stopping later", () => {
   const captureCommands = [];
   const stuckEvents = [];


### PR DESCRIPTION
Closes #134.

There was no way to abort a dictation once the hotkey was held — a mistaken or stuck recording ran to completion and got inserted.

## What's here

- **`pushToTalkCoordinator.cancel()`** — stops the recording, clears the safety timer, and tells the capture window to **drop the audio**: a new `cancel-recording` IPC that stops without encoding a WAV or firing `recording-complete`, so the pipeline never sees the cancelled take. Back to idle.
- **Escape triggers it.** `globalShortcut.register("Escape", …)` is armed only while a recording is active (a few seconds) and unregistered on stop / cancel / quit — so it isn't hijacking Escape from the app you're dictating into the rest of the time. During a dictation, an Escape press means "cancel this".
- Feedback: the overlay clears (recording indicator gone). A "Cancelled" toast would be nice polish but isn't here.

## Testing

- typecheck + build clean; 234 pass / 5 pre-existing fail / 2 cancelled.
- 3 new coordinator tests: cancel discards the capture and returns to idle; cancel with nothing recording is a no-op; a keyUp after a cancel does nothing.
- The global Escape hook + capture discard need a real Mac to exercise end to end (→ #228).

## Not touched

The hotkey helper / shortcut controller — Zazai's area. Escape is a separate `globalShortcut`, not part of the push-to-talk tap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
