### PR TITLE
Release workflow: tag → unsigned DMG + GitHub release (#20)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,9 @@ jobs:
       - name: Set the package version from the tag
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          [[ "$VERSION" =~ ^[0-9]+\.[0-9]+$ ]] && VERSION="${VERSION}.0"
+          if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            VERSION="${VERSION}.0"
+          fi
           npm version "$VERSION" --no-git-tag-version --allow-same-version
 
       - name: Typecheck and build the renderer

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+name: Release
+
+# Cut a GitHub release when a version tag is pushed. The tag's own
+# annotation becomes the release notes; the auto-generated commit list is
+# appended. An unsigned arm64 DMG is attached for convenience - the
+# supported install path stays "git clone && npm install" until signed
+# distribution is decided (issues #11, #37).
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.12
+          cache: npm
+
+      # postinstall compiles whisper.cpp and fetches ~1.15 GiB of weights -
+      # slow, but it's the same work every push already does in build.yml.
+      - run: npm ci
+
+      - name: Set the package version from the tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          [[ "$VERSION" =~ ^[0-9]+\.[0-9]+$ ]] && VERSION="${VERSION}.0"
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
+
+      - name: Typecheck and build the renderer
+        run: npm run build
+
+      - name: Package the unsigned DMG
+        run: npm run dist
+
+      - name: Assemble release notes
+        id: notes
+        run: |
+          {
+            echo 'body<<EOF'
+            git tag -l --format='%(contents)' "${GITHUB_REF_NAME}"
+            echo
+            echo '---'
+            echo
+            echo '**The attached DMG is unsigned.** macOS Gatekeeper will warn on first open (right-click → Open, or allow it in System Settings → Privacy & Security). The supported install is still `git clone` + `npm install` - see the README.'
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create the release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref_name }}
+          body: ${{ steps.notes.outputs.body }}
+          generate_release_notes: true
+          files: release/*.dmg
+          fail_on_unmatched_files: true

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ To create an unsigned DMG under `release/`:
 npm run dist
 ```
 
+### Releases
+
+Pushing a `v*` tag runs [`.github/workflows/release.yml`](.github/workflows/release.yml): it builds an unsigned arm64 DMG and publishes a GitHub release, using the tag's annotation as the notes. The DMG is a convenience download — Gatekeeper will warn on it (right-click → Open, or allow it in System Settings). The supported install is still `git clone` + `npm install`; a Homebrew formula waits on the signed-distribution decision ([#11](https://github.com/Nabzx/openstream/issues/11)).
+
 There is no code signing or notarization yet. macOS may block the DMG until you explicitly allow it.
 
 ## First-run permissions


### PR DESCRIPTION
Part of #20.

`.github/workflows/release.yml` — on a `v*` tag push:
1. `npm ci` (the full postinstall — same work `build.yml` already does)
2. set `package.json` version from the tag (so the DMG isn't named `0.0.1`)
3. `npm run build` (typecheck + renderer)
4. `npm run dist` — electron-builder's unsigned arm64 DMG
5. `softprops/action-gh-release@v2` publishes a release named for the tag, body = the tag's git annotation + the auto commit list + an "unsigned, here's how to open it" note, with the DMG attached.

README gains a short **Releases** subsection.

## Scope: Homebrew formula deferred

#20 also mentions "bump the Homebrew formula on tag". Not done here, deliberately:

- OpenStream's install fetches ~1.15 GiB of weights and compiles whisper.cpp from source. Homebrew builds in a **no-network sandbox**, so a straight `npm install` in the formula's `install` block fails — every artifact would need its own `resource` block with URL + SHA, duplicating the pinned fetch scripts.
- Per #37, v1.0 is source-only anyway (`git clone` + `npm install`), so there's no signed artifact for a cask to point at.

The Homebrew path is best decided alongside #11 (signing / cask / auto-update), once there's a signed build. Left a note on #20.

## Testing

- Workflow is structurally valid (no tabs, `on`/`jobs`/`steps` present); the version step is guarded against `set -e` on a non-match.
- Can't run end-to-end without pushing a tag — the first real `v*` tag after merge exercises it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
