### PR TITLE
Launch-at-login opens hidden + documented startup behaviour (#135)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,13 @@ On launch the app checks these grants: if Accessibility or Input Monitoring is m
 
 Source runs can be attributed to Terminal, Electron, or OpenStream in System Settings. Permission identity across rebuilds is still being worked out.
 
+## Startup
+
+- The menu bar icon appears immediately. The window opens only on the very first run, or when you pick **Open Window** from the tray / click the Dock icon.
+- Both model servers start resident at launch and stay up for the app's life — the `whisper-server` Metal warm-up (15–20 s) happens once, not per dictation.
+- **Launch at login** (Settings → Startup) opens OpenStream hidden — straight to the menu bar, no window. Model-server start is held back a few seconds so the warm-up doesn't fight everything else macOS is doing at login.
+- Closing the window backgrounds the app. Quit from the tray, the app menu, or `⌘Q`.
+
 ## Design
 
 - **Electron and React** provide the menu bar shell, hidden capture window, overlay, and renderer.

--- a/electron/main.js
+++ b/electron/main.js
@@ -602,7 +602,9 @@ function probeHttp(url, timeoutMs = 800) {
 // #135) - whether the window shows, notifications - is out of scope here.
 ipcMain.handle("app:get-login-item", () => app.getLoginItemSettings().openAtLogin);
 ipcMain.handle("app:set-login-item", (event, enabled) => {
-  app.setLoginItemSettings({ openAtLogin: Boolean(enabled) });
+  // openAsHidden: a login launch should start silently in the tray, not
+  // throw the window up - it's a background dictation tool (#135).
+  app.setLoginItemSettings({ openAtLogin: Boolean(enabled), openAsHidden: Boolean(enabled) });
   return app.getLoginItemSettings().openAtLogin;
 });
 
@@ -706,6 +708,10 @@ app.whenReady().then(() => {
   // stay silent in the tray - it's a background tool, not something that
   // should throw a window up every login. See issue #209.
   const isFirstLaunch = !fs.existsSync(settingsPath);
+  // #135: a launch triggered by the login item never opens the Home
+  // window, even on a first run - the user asked for it to start quietly.
+  // A missing permission still surfaces (below) because that's actionable.
+  const launchedAtLogin = process.platform === "darwin" && app.getLoginItemSettings().wasOpenedAtLogin;
   // Regular Dock app (issue #209) - no app.dock.hide().
   settingsStore = createSettingsStore({ filePath: settingsPath });
   createApplicationMenu();
@@ -729,9 +735,18 @@ app.whenReady().then(() => {
   createTray();
   createCaptureWindow();
   createOverlayWindow();
-  whisperServer.start();
-  rewriteModelServer.start();
   accessibilityHelper.start();
+
+  // #135: the two model servers stay resident for the app's life (#29), so
+  // they start here rather than per-dictation. At login, hold them back a
+  // few seconds so the ~15-20s Metal warm-up isn't competing with
+  // everything else macOS is starting.
+  const startModelServers = () => {
+    whisperServer.start();
+    rewriteModelServer.start();
+  };
+  if (launchedAtLogin) setTimeout(startModelServers, 3000);
+  else startModelServers();
 
   // #47: if a hard grant is missing, the app silently does nothing on every
   // push-to-talk - so open the window on the Permissions view and say so,
@@ -742,11 +757,11 @@ app.whenReady().then(() => {
     .then((verdict) => {
       updateTrayForPermissions(verdict);
       if (!verdict.ok) openWindowTo("permissions");
-      else if (isFirstLaunch) createWindow();
+      else if (isFirstLaunch && !launchedAtLogin) createWindow();
     })
     .catch((error) => {
       console.error("[permissions] startup check failed:", error);
-      if (isFirstLaunch) createWindow();
+      if (isFirstLaunch && !launchedAtLogin) createWindow();
     });
 });
 

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -13,12 +13,13 @@ function StartupSection() {
 
   return (
     <div className="group">
-      <h2>
-        Startup <span className="tag">Issue #135</span>
-      </h2>
+      <h2>Startup</h2>
       <div className="card">
         <div className="row">
-          <span className="row-label">Launch OpenStream at login</span>
+          <span className="row-label">
+            Launch OpenStream at login
+            <small>Starts quietly in the menu bar — no window.</small>
+          </span>
           <Toggle
             label="Launch OpenStream at login"
             checked={openAtLogin ?? false}


### PR DESCRIPTION
Closes #135.

- **Launch at login opens hidden.** `setLoginItemSettings` now passes `openAsHidden: true` alongside `openAtLogin`, and `wasOpenedAtLogin` suppresses the first-run window when the app is started by the login item — straight to the menu bar, no window.
- **Model-server start is deferred 3 s at login** so the `whisper-server` Metal warm-up (~15–20 s) isn't competing with everything else macOS starts at login. A normal launch starts them immediately, unchanged. They stay resident either way (the #29 decision).
- **Startup sequence documented** in the README: tray immediate, window only on first run / explicit open, model servers resident, closing the window backgrounds the app.
- Settings → Startup drops its `#135` tag and gains a one-line "starts quietly in the menu bar" hint.

## Testing

- typecheck + build clean; 236 pass / 5 pre-existing fail.
- No new unit tests — `wasOpenedAtLogin` / `openAsHidden` are Electron login-item APIs; the login-launch path needs a real Mac (add "toggle launch-at-login, log out and back in, confirm it starts hidden" to #228).

## Not touched

The hotkey helper / shortcut controller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
