### PR TITLE
Close the gaps behind IDE-terminal dictation failures (#227)

### DIFF
--- a/docs/testing/hotkey-transcribe-manual-check.md
+++ b/docs/testing/hotkey-transcribe-manual-check.md
@@ -17,7 +17,7 @@ The automated coverage behind the wizard also includes:
 - `whisper-server` serving `/inference` and producing a transcription from a synthetic WAV.
 - A valid mono 16kHz 16-bit WAV from the capture path.
 - `hotkey-helper` and `accessibility-helper` handling missing permissions without hanging or crashing.
-- Twelve `InjectionEngine` tests covering the fallback chain, settle guard, and blind-paste gate. Run them with `swift test --package-path native/accessibility-helper` on a full Xcode installation.
+- Fourteen `InjectionEngine` tests covering the fallback chain, settle guard, blind-paste gate, and the #227 focus-resolution retry. Run them with `swift test --package-path native/accessibility-helper` on a full Xcode installation.
 - Four overlay-positioning tests covering centering, the bottom margin, offset work areas, and a custom margin. Run them with `node --test electron/overlayPosition.test.js`. The actual Dock clearance still needs a human check.
 - `node --check` passing for all new and changed JavaScript files.
 

--- a/docs/testing/ide-terminal-dictation-227.md
+++ b/docs/testing/ide-terminal-dictation-227.md
@@ -1,0 +1,64 @@
+# Manual check: dictation launched from an IDE terminal (#227)
+
+[#227](https://github.com/Nabzx/openstream/issues/227): a dictation produced no
+visible text when OpenStream was started from **VS Code's integrated terminal**.
+That was seen on a build without [#181](https://github.com/Nabzx/openstream/issues/181)
+(context AX-readiness fallback) or [#47](https://github.com/Nabzx/openstream/issues/47)
+(launch permission gate), both of which are on `main` now, so this check
+confirms whether anything is still wrong and, if so, names the stage.
+
+## What changed for this
+
+- **Context detection no longer hard-fails** on a not-yet-ready AX tree
+  (#181) — it falls back to an unknown-field context and the dictation
+  proceeds, denying line breaks.
+- **The injection path now retries focus resolution** within
+  `Config.axInjectBudgetMs` (200 ms) before dropping to blind-paste-or-hold
+  (#227). An Electron target (VS Code, Slack) whose AX tree isn't up on the
+  first read usually comes good within that window.
+- **A context read that fails outright now holds the transcript** for manual
+  paste instead of dropping it silently.
+- **One summary line per dictation**: `[dictation] outcome: <status> …`.
+
+## Steps
+
+1. Grant Microphone, Input Monitoring, and Accessibility. If the app opens
+   on the **Permissions** screen, the helper's grant is missing — fix that
+   first (remove the stale OpenStream entry in System Settings, re-add the
+   fresh build), it is a separate problem from #227.
+2. Launch the final build from **VS Code's integrated terminal**
+   (`npm start`).
+3. Click into a text field in **another** app (TextEdit, Notes).
+4. Hold the push-to-talk key, dictate a sentence, release.
+5. Repeat with the target being an Electron app (a second VS Code window, a
+   Slack message box).
+6. As a control, quit and repeat the whole thing launched from
+   **Terminal.app** instead.
+
+Pass: the text lands in the target app in every case, within the latency
+budget.
+
+## Reading the console when it fails
+
+The one line that names the stage:
+
+```
+[dictation] outcome: held reason="couldn't read the focused field: …"
+[dictation] outcome: failed stage=transcription reason="…"
+[dictation] outcome: delivered
+```
+
+Alongside it:
+
+| Line | Means |
+|---|---|
+| `[dictation] context.bundleId: "com.microsoft.VSCode"` | context detection resolved the **wrong** app — it should be the app you dictated into, not VS Code. Points at the app-switch tracker (#173). |
+| `[dictation] context.axReady: false` | the target's AX tree wasn't ready in time; delivery fell back. Expected occasionally for a cold Electron target, not every time. |
+| `[dictation] outcome: held …` + the overlay shows the text | delivery couldn't place it. The words are recoverable — copy from the overlay. |
+| `[accessibility-helper] resolveFocusedElement: … trusted=false` | the helper's Accessibility grant is not active for this build — a permission problem, not #227. |
+| `[accessibility-helper] resolveFocusedElement: … AXError -25204` | the AX API timed out on the target (tree not ready / not responding). |
+
+If context resolves the correct app and `axReady` is `true` but delivery
+still holds, capture the full `[accessibility-helper]` block from that
+attempt and attach it to #227 — that is a delivery-path bug the retry
+didn't cover.

--- a/electron/accessibilityHelper.js
+++ b/electron/accessibilityHelper.js
@@ -112,7 +112,13 @@ function createAccessibilityHelper({
       reply.bundleId.length === 0 ||
       typeof reply.isOneLineField !== "boolean"
     ) {
-      throw new Error(`accessibility-helper returned an invalid context reply${reply.reason ? `: ${reply.reason}` : ""}`);
+      // #227: carry the helper's own AXIsProcessTrusted() through when it
+      // sends one, so "no frontmost application (trusted=false)" points
+      // straight at a lost Accessibility grant rather than a mystery.
+      const trust = typeof reply.trusted === "boolean" ? ` (trusted=${reply.trusted})` : "";
+      throw new Error(
+        `accessibility-helper returned an invalid context reply${reply.reason ? `: ${reply.reason}` : ""}${trust}`,
+      );
     }
     // #181: axReady is false when the focused element never became AX-ready
     // in time and isOneLineField is the safe default, not the real role.

--- a/electron/dictationCoordinator.js
+++ b/electron/dictationCoordinator.js
@@ -77,11 +77,27 @@ function createDictationIntake(options) {
         throw new Error("context adapter returned an invalid focus context");
       }
       // #181: when the focused element wasn't AX-ready, isOneLineField is a
-      // safe guess (deny breaks), not the real role. Logged so we can see
-      // how often the fallback fires in practice.
+      // safe guess (deny breaks), not the real role. #227: the resolved
+      // bundle id goes out too, so one failed dictation's console log names
+      // the app context detection actually landed on.
+      emitDiagnostic("context.bundleId", focusContext.bundleId);
       emitDiagnostic("context.axReady", focusContext.axReady !== false);
     } catch (error) {
-      return failed("context", error);
+      // #227: a context read that fails outright (the helper is down, or
+      // nothing is frontmost) used to drop the transcript silently as a
+      // `failed` outcome. We have the words - hold them for manual paste,
+      // cleaned with the safe defaults (deny line breaks), exactly as a
+      // failed delivery does.
+      emitDiagnostic("context.failure", errorMessage(error));
+      const salvaged = cleanup(rawText, { oneLineBox: false, breakSafe: false });
+      if (!salvaged) {
+        return { status: "no-speech" };
+      }
+      return {
+        status: "held",
+        text: salvaged,
+        reason: `couldn't read the focused field: ${errorMessage(error)}`,
+      };
     }
 
     const breakSafe = isBreakSafeApplication(focusContext.bundleId);

--- a/electron/dictationCoordinator.test.js
+++ b/electron/dictationCoordinator.test.js
@@ -241,6 +241,7 @@ test("repairs malformed break indices without retrying and records format and re
   });
   assert.deepEqual(harness.diagnostics, [
     ["vocabulary.promptLength", 0],
+    ["context.bundleId", "com.apple.TextEdit"],
     ["context.axReady", true],
     ["paragraphBreaks.formatValid", false],
     ["paragraphBreaks.repairUsed", true],
@@ -422,7 +423,7 @@ test("transcription failure does not insert partial output", async () => {
   assert.equal(deliveryCalls, 0);
 });
 
-test("context detection failure leaves the target application unchanged", async () => {
+test("context detection failure holds the transcript instead of dropping it (#227)", async () => {
   let deliveryCalls = 0;
   const harness = createIntake({
     getFocusContext: async () => {
@@ -436,12 +437,15 @@ test("context detection failure leaves the target application unchanged", async 
 
   const result = await harness.intake.complete(completedWav);
 
-  assert.deepEqual(result, {
-    status: "failed",
-    stage: "context",
-    reason: "accessibility unavailable",
-  });
-  assert.equal(deliveryCalls, 0);
+  // We have the words, we just don't know where they go - that's "held",
+  // not a silent failure. Cleaned with the safe defaults (no line breaks).
+  assert.equal(result.status, "held");
+  assert.equal(result.text, "Hello world.");
+  assert.match(result.reason, /couldn't read the focused field: accessibility unavailable/);
+  assert.equal(deliveryCalls, 0, "a context failure never reaches delivery");
+  assert.ok(
+    harness.diagnostics.some(([name, value]) => name === "context.failure" && value === "accessibility unavailable"),
+  );
 });
 
 test("delivery failure holds the complete finished text without retrying delivery", async () => {

--- a/electron/main.js
+++ b/electron/main.js
@@ -388,6 +388,14 @@ async function transcribeAndPrint(wavBuffer, timing) {
     return;
   }
 
+  // #227: one greppable line per dictation, so a single failed attempt on a
+  // real Mac names the stage that failed without piecing the diagnostics
+  // together by hand.
+  const summary = [`[dictation] outcome: ${result.status}`];
+  if (result.stage) summary.push(`stage=${result.stage}`);
+  if (result.reason) summary.push(`reason=${JSON.stringify(result.reason)}`);
+  console.log(summary.join(" "));
+
   if (result.status === "delivered") {
     console.log(`[dictation] ${result.text}`);
     console.log("[dictation] inserted through accessibility");

--- a/native/accessibility-helper/Sources/AccessibilityInjection/Config.swift
+++ b/native/accessibility-helper/Sources/AccessibilityInjection/Config.swift
@@ -15,6 +15,13 @@ public struct Config {
     // sub-1s dictation budget, so this is deliberately short: catch a
     // target that's a beat slow, fall back for one that's genuinely cold.
     public var axReadyBudgetMs: Double
+    // #227: the same idea on the injection path. decide() used to resolve
+    // the focused element once and, on a miss, drop to blind-paste-or-hold
+    // - so an Electron target whose AX tree wasn't up on the first read
+    // (VS Code, Slack; the #28 case) lost the dictation even though the
+    // tree came good a beat later. Shorter than axReadyBudgetMs because
+    // this sits on the release-to-cursor latency the product commits to.
+    public var axInjectBudgetMs: Double
     public var restoreMs: Double
     public var axValueMaxChars: Int
     public var longTextChars: Int
@@ -25,6 +32,7 @@ public struct Config {
         settleBudgetMs: Double = 1200,
         axDeadlineMs: Double = 150,
         axReadyBudgetMs: Double = 250,
+        axInjectBudgetMs: Double = 200,
         restoreMs: Double = 300,
         axValueMaxChars: Int = 2000,
         longTextChars: Int = 120,
@@ -34,6 +42,7 @@ public struct Config {
         self.settleBudgetMs = settleBudgetMs
         self.axDeadlineMs = axDeadlineMs
         self.axReadyBudgetMs = axReadyBudgetMs
+        self.axInjectBudgetMs = axInjectBudgetMs
         self.restoreMs = restoreMs
         self.axValueMaxChars = axValueMaxChars
         self.longTextChars = longTextChars

--- a/native/accessibility-helper/Sources/AccessibilityInjection/InjectionEngine.swift
+++ b/native/accessibility-helper/Sources/AccessibilityInjection/InjectionEngine.swift
@@ -48,7 +48,22 @@ public final class InjectionEngine {
             sleep(0.02)
         }
 
-        guard let focused = focusResolver.resolveFocusedElement(deadlineMs: config.axDeadlineMs) else {
+        // Resolve the focused element, retrying a not-yet-ready AX tree
+        // within a short budget (#227). #181 gave context detection this
+        // same treatment; the injection path had none, so an Electron
+        // target whose tree wasn't up on the first read (VS Code, Slack -
+        // the #28 case, common when OpenStream itself was launched from an
+        // IDE terminal) fell straight through to blind-paste-or-hold. Each
+        // attempt is still capped by axDeadlineMs; the retry only costs
+        // latency when the first read actually missed.
+        let focusDeadline = now().addingTimeInterval(config.axInjectBudgetMs / 1000.0)
+        var resolved = focusResolver.resolveFocusedElement(deadlineMs: config.axDeadlineMs)
+        while resolved == nil, now() < focusDeadline {
+            sleep(0.04)
+            resolved = focusResolver.resolveFocusedElement(deadlineMs: config.axDeadlineMs)
+        }
+
+        guard let focused = resolved else {
             // Rung 0 didn't answer, or nothing is frontmost at all. The
             // narrow exception settled on #62: a known app that has sat
             // still well past the settle guard is a much smaller unknown

--- a/native/accessibility-helper/Sources/accessibility-helper/main.swift
+++ b/native/accessibility-helper/Sources/accessibility-helper/main.swift
@@ -69,7 +69,17 @@ while let line = readLine(strippingNewline: true) {
             deadlineMs: config.axDeadlineMs,
             budgetMs: config.axReadyBudgetMs
         ) else {
-            emit(["id": id, "status": "error", "reason": "focused element unavailable"])
+            // Post-#181 a not-ready AX tree no longer lands here - it comes
+            // back as a context with axReady:false. This nil now means the
+            // tracker has no frontmost app or it carries no bundle id.
+            // trusted is included so a lost Accessibility grant (#46/#88)
+            // is distinguishable from a genuinely missing frontmost app.
+            emit([
+                "id": id,
+                "status": "error",
+                "reason": "no frontmost application",
+                "trusted": AXIsProcessTrusted(),
+            ])
             continue
         }
         emit([

--- a/native/accessibility-helper/Tests/AccessibilityInjectionTests/Fakes.swift
+++ b/native/accessibility-helper/Tests/AccessibilityInjectionTests/Fakes.swift
@@ -42,13 +42,23 @@ final class FakeAccessibilityTarget: AccessibilityTarget {
 
 final class FakeFocusResolver: FocusResolving {
     var target: AccessibilityTarget?
+    // #227: the injection path now retries within a budget. A positive
+    // value here makes the first N reads miss, so a test can prove the
+    // retry recovers a briefly-not-ready AX tree.
+    var missesBeforeSuccess: Int
+    private(set) var callCount = 0
 
-    init(target: AccessibilityTarget?) {
+    init(target: AccessibilityTarget?, missesBeforeSuccess: Int = 0) {
         self.target = target
+        self.missesBeforeSuccess = missesBeforeSuccess
     }
 
     func resolveFocusedElement(deadlineMs _: Double) -> AccessibilityTarget? {
-        target
+        callCount += 1
+        if callCount <= missesBeforeSuccess {
+            return nil
+        }
+        return target
     }
 }
 

--- a/native/accessibility-helper/Tests/AccessibilityInjectionTests/InjectionEngineTests.swift
+++ b/native/accessibility-helper/Tests/AccessibilityInjectionTests/InjectionEngineTests.swift
@@ -12,6 +12,7 @@ struct InjectionEngineTests {
 
     func makeEngine(
         focusTarget: AccessibilityTarget?,
+        missesBeforeSuccess: Int = 0,
         pasteResult: PasteResult = PasteResult(delivered: true, verified: false, note: ""),
         trackerAge: @escaping () -> Double = { 10_000 },
         appName: String? = "TestApp"
@@ -22,7 +23,7 @@ struct InjectionEngineTests {
         let tracker = FakeTracker(age: trackerAge, appName: appName)
         let engine = InjectionEngine(
             config: config,
-            focusResolver: FakeFocusResolver(target: focusTarget),
+            focusResolver: FakeFocusResolver(target: focusTarget, missesBeforeSuccess: missesBeforeSuccess),
             paster: paster,
             typer: typer,
             tracker: tracker,
@@ -159,6 +160,42 @@ struct InjectionEngineTests {
             return
         }
         #expect(note.contains("typed blind"), "note was: \(note)")
+    }
+
+    // MARK: - Rung 0: focus resolution retry (#227)
+
+    @Test func retriesFocusResolutionWhenTheAXTreeWasBrieflyNotReady() {
+        // The Electron/#28 case: AXManualAccessibility was just set and the
+        // first read misses, but the tree comes good a beat later. Before
+        // #227 this dropped straight to blind-paste-or-hold.
+        let target = FakeAccessibilityTarget(
+            fieldInfo: FieldInfo(role: "AXTextField", valueChars: 10, selectedTextSettable: true)
+        )
+        let (engine, time, paster, _) = makeEngine(focusTarget: target, missesBeforeSuccess: 2)
+
+        let outcome = engine.decide(text: "hello")
+
+        #expect(outcome == .delivered(method: "wrote into the field", verified: true, note: "inserted at the caret, clipboard untouched"))
+        #expect(target.writtenText == "hello")
+        #expect(paster.callCount == 0, "rung 1 should have succeeded once the retry resolved the field")
+        #expect(time.elapsedMs <= config.axInjectBudgetMs, "the retry must stay inside its budget")
+    }
+
+    @Test func focusRetryGivesUpAtTheBudgetAndFallsBackAsBefore() {
+        // Never resolves: the retry must not spin past its budget, and the
+        // fallback (blind paste into a known, stable app) is unchanged.
+        let (engine, time, paster, _) = makeEngine(
+            focusTarget: nil,
+            missesBeforeSuccess: 999,
+            pasteResult: PasteResult(delivered: true, verified: false, note: "sent, but nothing confirmed it landed"),
+            appName: "SomeApp"
+        )
+
+        let outcome = engine.decide(text: "hello")
+
+        #expect(outcome == .delivered(method: "pasted into SomeApp, field unknown", verified: false, note: "sent, but nothing confirmed it landed"))
+        #expect(paster.callCount == 1)
+        #expect(time.elapsedMs >= config.axInjectBudgetMs, "should have waited out the whole budget before giving up")
     }
 
     // MARK: - Rung 0 / 1b: focus never resolved


### PR DESCRIPTION
## Context

#227 was seen on a build without #181 (context AX-readiness fallback) or #47 (launch permission gate), both now on `main`. This PR closes the gaps those two left and makes the next real-Mac pass conclusive.

Fundamentally #227 still needs a diagnostic run on a real Mac — I can't drive the AX tree from here. What I've done is (a) fix a real silent-failure class and (b) make one failed attempt self-explanatory.

## Changes

**Retry focus resolution on the injection path (`InjectionEngine.decide`)**
#181 gave *context detection* a bounded retry for a not-yet-ready AX tree; the *injection path* had none — a single-shot `resolveFocusedElement`, and on a miss it dropped straight to blind-paste-or-hold. An Electron target (VS Code, Slack — the #28 case, common when OpenStream itself was launched from an IDE terminal) whose tree wasn't up on the first read lost the dictation even though the tree came good a beat later. Now it retries within `Config.axInjectBudgetMs` (200 ms, shorter than context's 250 because it sits on the release-to-cursor budget). The retry only costs latency when the first read actually missed. Two new `InjectionEngine` tests.

**Hold the transcript when context detection fails outright (`dictationCoordinator`)**
A context read that fails (helper down, nothing frontmost) returned a silent `failed` outcome and the words vanished. Now it cleans the transcript with the safe defaults (deny line breaks) and returns it as a `held` result — the overlay shows it for manual copy, same as a failed delivery.

**Say why it failed**
- `main.js` logs one line per dictation: `[dictation] outcome: <status> [stage=..] [reason=..]`.
- `dictationCoordinator` emits `context.bundleId` (which app context landed on) and `context.failure`.
- The helper's `context` error reply now carries an accurate reason (`no frontmost application`, not the misleading `focused element unavailable`) and `trusted: AXIsProcessTrusted()`, so a lost Accessibility grant is distinguishable from a genuinely missing frontmost app.

**`docs/testing/ide-terminal-dictation-227.md`** — the reproduction steps and a table for reading the console when it fails. Feeds the #228 pre-launch pass.

## Tests

- `npm test` — vitest 116/116; `node --test` unchanged from baseline (same 5 pre-existing failures: #186, empty eval fixture, #125 list tests).
- `npm run typecheck`, `npm run build` — clean.
- `swift build` (debug + release) — clean. The new `InjectionEngine` tests need a full-Xcode machine to run (`swift test`); this environment is CLT-only, as the existing test docs note.

## Not in this PR

If the real-Mac run shows context resolving the *wrong* app from an IDE terminal, that's a second bug in the #173 tracker and stays on #227. If it's purely a lost TCC grant on rebuild, that's #46/#88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
