### PR TITLE
Finish the settings UI: break-safe app picker, restore defaults (#19)

### DIFF
--- a/docs/testing/break-safe-apps-settings-19.md
+++ b/docs/testing/break-safe-apps-settings-19.md
@@ -1,0 +1,25 @@
+# Manual check: the break-safe applications setting (#19)
+
+CI covers the store, the bundle-id reader, and the name map. What it can't
+drive: the real file dialog, the persisted list surviving a relaunch, and a
+line break actually landing (or not) in the chosen app.
+
+## Steps
+
+1. Open **Settings → Break-safe applications**. The four defaults show with
+   friendly names (TextEdit, Notes, Obsidian, Visual Studio Code) and their
+   bundle id underneath.
+2. **Add application…** → pick an app from `/Applications` (say iA Writer).
+   It appears in the list with its name; no bundle id typing.
+3. Pick a non-`.app` file, or an `.app` with no `Info.plist` — an error
+   line shows, the list is unchanged.
+4. Add one by hand: type a bundle id into the field, press **Add**.
+5. Dictate a two-sentence phrase with a spoken "new paragraph" into the
+   app you added — the break lands. Do the same in Terminal — the break is
+   dropped, the text runs on.
+6. **Remove** an app, then **Restore defaults** — the list returns to the
+   original four.
+7. Quit and relaunch OpenStream. The list (minus anything removed, plus
+   anything added) is exactly as left. Picker-resolved names for non-default
+   apps fall back to the bare bundle id after a relaunch — expected.
+8. Confirm there is no Microphone section (deferred to #137).

--- a/electron/appBundleId.js
+++ b/electron/appBundleId.js
@@ -1,0 +1,35 @@
+const { execFile } = require("child_process");
+const path = require("path");
+
+// Reads an .app bundle's CFBundleIdentifier. `defaults read` is the
+// canonical macOS way to do this - it handles the binary Info.plist that
+// most apps ship, which a plain JSON/plist parse in Node would choke on.
+//
+// execFile is injected so this is testable without a real .app on disk.
+function createBundleIdReader({ run = execFile } = {}) {
+  function readBundleId(appPath) {
+    return new Promise((resolve, reject) => {
+      if (typeof appPath !== "string" || !appPath.endsWith(".app")) {
+        reject(new Error("not an application bundle"));
+        return;
+      }
+      const infoPath = path.join(appPath, "Contents", "Info");
+      run("defaults", ["read", infoPath, "CFBundleIdentifier"], { timeout: 4000 }, (error, stdout) => {
+        if (error) {
+          reject(new Error(`couldn't read a bundle identifier from ${path.basename(appPath)}`));
+          return;
+        }
+        const bundleId = String(stdout).trim();
+        if (!bundleId) {
+          reject(new Error(`${path.basename(appPath)} has no bundle identifier`));
+          return;
+        }
+        resolve({ bundleId, name: path.basename(appPath, ".app") });
+      });
+    });
+  }
+
+  return { readBundleId };
+}
+
+module.exports = { createBundleIdReader };

--- a/electron/appBundleId.test.js
+++ b/electron/appBundleId.test.js
@@ -1,0 +1,50 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { createBundleIdReader } = require("./appBundleId");
+
+function fakeRun(result) {
+  return (_cmd, _args, _opts, callback) => {
+    if (result.error) callback(result.error);
+    else callback(null, result.stdout ?? "", "");
+  };
+}
+
+test("reads the bundle identifier and derives a display name from the path", async () => {
+  const calls = [];
+  const { readBundleId } = createBundleIdReader({
+    run: (cmd, args, opts, callback) => {
+      calls.push({ cmd, args });
+      callback(null, "com.apple.Notes\n", "");
+    },
+  });
+
+  const result = await readBundleId("/Applications/Notes.app");
+
+  assert.deepEqual(result, { bundleId: "com.apple.Notes", name: "Notes" });
+  assert.equal(calls[0].cmd, "defaults");
+  assert.deepEqual(calls[0].args, ["read", "/Applications/Notes.app/Contents/Info", "CFBundleIdentifier"]);
+});
+
+test("rejects a path that is not an application bundle without spawning anything", async () => {
+  let ran = false;
+  const { readBundleId } = createBundleIdReader({
+    run: () => {
+      ran = true;
+    },
+  });
+
+  await assert.rejects(readBundleId("/Users/me/notes.txt"), /not an application bundle/);
+  assert.equal(ran, false);
+});
+
+test("rejects with a friendly message when defaults read fails", async () => {
+  const { readBundleId } = createBundleIdReader({ run: fakeRun({ error: new Error("does not exist") }) });
+
+  await assert.rejects(readBundleId("/Applications/Mystery.app"), /couldn't read a bundle identifier from Mystery\.app/);
+});
+
+test("rejects when the plist has no CFBundleIdentifier", async () => {
+  const { readBundleId } = createBundleIdReader({ run: fakeRun({ stdout: "\n" }) });
+
+  await assert.rejects(readBundleId("/Applications/Bare.app"), /Bare\.app has no bundle identifier/);
+});

--- a/electron/breakSafety.js
+++ b/electron/breakSafety.js
@@ -10,6 +10,16 @@ const DEFAULT_BREAK_SAFE_BUNDLE_IDS = [
   "com.microsoft.VSCode",
 ];
 
+// Friendly names for the built-in entries, so the settings list reads as
+// "Notes" rather than a bare bundle id. User-added apps carry the name the
+// picker resolved; a manually typed id just shows as itself.
+const DEFAULT_BREAK_SAFE_APP_NAMES = {
+  "com.apple.TextEdit": "TextEdit",
+  "com.apple.Notes": "Notes",
+  "md.obsidian": "Obsidian",
+  "com.microsoft.VSCode": "Visual Studio Code",
+};
+
 let breakSafeBundleIds = new Set(DEFAULT_BREAK_SAFE_BUNDLE_IDS);
 
 function isBreakSafeApplication(bundleId) {
@@ -29,4 +39,5 @@ module.exports = {
   setBreakSafeApplications,
   getBreakSafeApplications,
   DEFAULT_BREAK_SAFE_BUNDLE_IDS,
+  DEFAULT_BREAK_SAFE_APP_NAMES,
 };

--- a/electron/breakSafety.test.js
+++ b/electron/breakSafety.test.js
@@ -5,6 +5,7 @@ const {
   setBreakSafeApplications,
   getBreakSafeApplications,
   DEFAULT_BREAK_SAFE_BUNDLE_IDS,
+  DEFAULT_BREAK_SAFE_APP_NAMES,
 } = require("./breakSafety");
 
 test.afterEach(() => {
@@ -12,6 +13,12 @@ test.afterEach(() => {
   // leak into the next (or into dictationCoordinator.test.js, which relies
   // on the default list including com.apple.TextEdit).
   setBreakSafeApplications(DEFAULT_BREAK_SAFE_BUNDLE_IDS);
+});
+
+test("every default bundle id has a friendly name (#19)", () => {
+  for (const bundleId of DEFAULT_BREAK_SAFE_BUNDLE_IDS) {
+    assert.equal(typeof DEFAULT_BREAK_SAFE_APP_NAMES[bundleId], "string", `missing a name for ${bundleId}`);
+  }
 });
 
 test("defaults match the original hardcoded allow-list", () => {

--- a/electron/main.js
+++ b/electron/main.js
@@ -22,7 +22,8 @@ const rewriteModelServer = require("./rewriteModelServer");
 const hotkeyHelper = require("./hotkeyHelper");
 const accessibilityHelper = require("./accessibilityHelper");
 const { createSettingsStore } = require("./settingsStore");
-const { setBreakSafeApplications } = require("./breakSafety");
+const { setBreakSafeApplications, DEFAULT_BREAK_SAFE_BUNDLE_IDS } = require("./breakSafety");
+const { createBundleIdReader } = require("./appBundleId");
 const { createTranscriptionHttpAdapter } = require("./transcriptionHttpAdapter");
 const { createBreakPlacementHttpAdapter } = require("./breakPlacementHttpAdapter");
 const { createDictationIntake } = require("./dictationCoordinator");
@@ -668,6 +669,28 @@ ipcMain.handle("settings:set-break-safe-apps", (event, apps) => {
   const settings = settingsStore.setBreakSafeApps(apps);
   setBreakSafeApplications(settings.breakSafeApps);
   return settings;
+});
+
+ipcMain.handle("settings:reset-break-safe-apps", () => {
+  const settings = settingsStore.setBreakSafeApps([...DEFAULT_BREAK_SAFE_BUNDLE_IDS]);
+  setBreakSafeApplications(settings.breakSafeApps);
+  return settings;
+});
+
+// #19: pick an app from disk instead of hunting down its bundle id by
+// hand. Returns { bundleId, name } for the renderer to add, or null if the
+// dialog was cancelled; a bundle with no readable identifier rejects.
+const bundleIdReader = createBundleIdReader();
+ipcMain.handle("settings:pick-break-safe-app", async () => {
+  if (!win) return null;
+  const result = await dialog.showOpenDialog(win, {
+    defaultPath: "/Applications",
+    properties: ["openFile"],
+    filters: [{ name: "Applications", extensions: ["app"] }],
+    message: "Choose an app where a spoken line break should insert a real newline",
+  });
+  if (result.canceled || result.filePaths.length === 0) return null;
+  return bundleIdReader.readBundleId(result.filePaths[0]);
 });
 
 // #16: setting the path persists it and triggers a rescan in the same

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -24,6 +24,8 @@ contextBridge.exposeInMainWorld("openstream", {
     get: () => ipcRenderer.invoke("settings:get"),
     setShortcut: (shortcut) => ipcRenderer.invoke("settings:set-shortcut", shortcut),
     setBreakSafeApps: (apps) => ipcRenderer.invoke("settings:set-break-safe-apps", apps),
+    resetBreakSafeApps: () => ipcRenderer.invoke("settings:reset-break-safe-apps"),
+    pickBreakSafeApp: () => ipcRenderer.invoke("settings:pick-break-safe-app"),
     setVocabularyProjectPath: (projectPath) => ipcRenderer.invoke("settings:set-vocabulary-path", projectPath),
   },
   vocabulary: {

--- a/src/BreakSafeAppsSettings.tsx
+++ b/src/BreakSafeAppsSettings.tsx
@@ -1,7 +1,19 @@
 import { useEffect, useState } from "react";
 
+// Friendly names for the built-in entries - kept in step with
+// electron/breakSafety.js's DEFAULT_BREAK_SAFE_APP_NAMES. Anything the
+// picker resolves is added to this map for the session; a manually typed
+// bundle id just shows as itself.
+const KNOWN_APP_NAMES: Record<string, string> = {
+  "com.apple.TextEdit": "TextEdit",
+  "com.apple.Notes": "Notes",
+  "md.obsidian": "Obsidian",
+  "com.microsoft.VSCode": "Visual Studio Code",
+};
+
 export default function BreakSafeAppsSettings() {
   const [apps, setApps] = useState<string[] | null>(null);
+  const [names, setNames] = useState<Record<string, string>>(KNOWN_APP_NAMES);
   const [newBundleId, setNewBundleId] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
@@ -10,14 +22,17 @@ export default function BreakSafeAppsSettings() {
     window.openstream.settings.get().then((settings) => setApps(settings.breakSafeApps));
   }, []);
 
-  function save(next: string[]) {
+  function afterSave(next: Promise<{ breakSafeApps: string[] }>) {
     setSaving(true);
     setError(null);
-    window.openstream.settings
-      .setBreakSafeApps(next)
+    next
       .then((settings) => setApps(settings.breakSafeApps))
       .catch((err) => setError(err instanceof Error ? err.message : String(err)))
       .finally(() => setSaving(false));
+  }
+
+  function save(next: string[]) {
+    afterSave(window.openstream.settings.setBreakSafeApps(next));
   }
 
   function addApp() {
@@ -30,6 +45,23 @@ export default function BreakSafeAppsSettings() {
   function removeApp(bundleId: string) {
     if (!apps) return;
     save(apps.filter((id) => id !== bundleId));
+  }
+
+  function pickApp() {
+    if (!apps) return;
+    setError(null);
+    window.openstream.settings
+      .pickBreakSafeApp()
+      .then((picked) => {
+        if (!picked) return;
+        setNames((current) => ({ ...current, [picked.bundleId]: picked.name }));
+        if (!apps.includes(picked.bundleId)) save([...apps, picked.bundleId]);
+      })
+      .catch((err) => setError(err instanceof Error ? err.message : String(err)));
+  }
+
+  function restoreDefaults() {
+    afterSave(window.openstream.settings.resetBreakSafeApps());
   }
 
   return (
@@ -50,13 +82,16 @@ export default function BreakSafeAppsSettings() {
             )}
             {apps.map((bundleId) => (
               <div className="row" key={bundleId}>
-                <span className="row-label mono">{bundleId}</span>
+                <span className="row-label">
+                  {names[bundleId] ?? bundleId}
+                  {names[bundleId] && <small className="mono">{bundleId}</small>}
+                </span>
                 <button
                   type="button"
                   className="btn btn--ghost"
                   onClick={() => removeApp(bundleId)}
                   disabled={saving}
-                  aria-label={`Remove ${bundleId}`}
+                  aria-label={`Remove ${names[bundleId] ?? bundleId}`}
                 >
                   Remove
                 </button>
@@ -87,9 +122,22 @@ export default function BreakSafeAppsSettings() {
         )}
       </div>
       {error && <p className="error-text">{error}</p>}
+      <div className="row-actions">
+        <button type="button" className="btn" onClick={pickApp} disabled={saving || apps === null}>
+          Add application…
+        </button>
+        <button
+          type="button"
+          className="btn btn--ghost"
+          onClick={restoreDefaults}
+          disabled={saving || apps === null}
+        >
+          Restore defaults
+        </button>
+      </div>
       <p className="hint">
-        Find an app’s bundle identifier with{" "}
-        <span className="mono">osascript -e 'id of app "…"'</span>.
+        “Add application…” picks an app and reads its bundle identifier for you. To add one by hand, find its
+        identifier with <span className="mono">osascript -e 'id of app "…"'</span>.
       </p>
     </>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -254,6 +254,14 @@ button {
   cursor: default;
 }
 
+/* A row of buttons that sits under a card, not inside it (#19). */
+.row-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 10px;
+}
+
 .field {
   flex: 1;
   height: 28px;

--- a/src/openstreamBridge.d.ts
+++ b/src/openstreamBridge.d.ts
@@ -58,6 +58,8 @@ declare global {
         get(): Promise<StoredSettings>;
         setShortcut(shortcut: StoredHotkey): Promise<SetShortcutResult>;
         setBreakSafeApps(apps: string[]): Promise<StoredSettings>;
+        resetBreakSafeApps(): Promise<StoredSettings>;
+        pickBreakSafeApp(): Promise<{ bundleId: string; name: string } | null>;
         setVocabularyProjectPath(
           projectPath: string | null
         ): Promise<{ settings: StoredSettings; status: VocabularyStatus }>;

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from "react";
 import HotkeySettings from "../HotkeySettings";
 import BreakSafeAppsSettings from "../BreakSafeAppsSettings";
 import Toggle from "../components/Toggle";
-import { ChevronDownIcon } from "../components/Icons";
 
 function StartupSection() {
   const [openAtLogin, setOpenAtLogin] = useState<boolean | null>(null);
@@ -35,27 +34,6 @@ function StartupSection() {
   );
 }
 
-function MicrophoneSection() {
-  // Device enumeration and selection is issue #137 - the section exists
-  // so the layout is settled, but the control is inert for now.
-  return (
-    <div className="group">
-      <h2>
-        Microphone <span className="tag">Issue #137</span>
-      </h2>
-      <div className="card">
-        <div className="row">
-          <span className="row-label">Input device</span>
-          <span className="select" aria-disabled="true" style={{ opacity: 0.5 }}>
-            System Default
-            <ChevronDownIcon />
-          </span>
-        </div>
-      </div>
-    </div>
-  );
-}
-
 export default function Settings() {
   return (
     <main className="page">
@@ -74,7 +52,6 @@ export default function Settings() {
       </div>
 
       <StartupSection />
-      <MicrophoneSection />
     </main>
   );
 }


### PR DESCRIPTION
Closes #19.

The Phase 4 DoD for the settings UI is "hotkey remapping + the user-editable break-safe app list, no mode rules, no model choice". Hotkey remapping landed with Zazai's #218; the break-safe list existed but was raw (type a bundle id, or go run `osascript`). This finishes it.

## Changes

**Pick a break-safe app from a dialog** — `Add application…` opens a file picker scoped to `/Applications`, reads the chosen bundle's `CFBundleIdentifier` (`defaults read` — handles the binary `Info.plist`), and adds it. The manual bundle-id field stays for apps outside `/Applications`.

**Restore defaults** — one button back to the original four.

**Friendly names** — the list shows `Notes`, `Visual Studio Code`, etc. for the built-in entries (and for anything the picker resolved this session), with the bundle id underneath. A test keeps `breakSafety.js`'s name map in step with its default list.

**Dropped the inert Microphone section** — it was a disabled fake dropdown with an "Issue #137" tag. Device selection is #137; a dead control doesn't belong in a v1.0 settings screen. The layout note it was preserving is captured in #137.

`HotkeySettings` is untouched — its restyle waits on the one-key shortcut work (#216).

## New surface

- `electron/appBundleId.js` — `createBundleIdReader({ run })`, `readBundleId(appPath)` → `{ bundleId, name }`. execFile injected; 4 tests.
- IPC: `settings:pick-break-safe-app`, `settings:reset-break-safe-apps`.

## Tests

- `npm test` — vitest 116/116; `node --test` 248 tests, same 5 pre-existing failures as `main` (#186 ×2, empty eval fixture, #125 list tests), no new ones.
- `npm run typecheck`, `npm run build` — clean.
- `docs/testing/break-safe-apps-settings-19.md` — the manual pass (real dialog, persistence across relaunch, a break actually landing / being dropped). Feeds #228.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
