### PR TITLE
Fix the break-placement timeout test under Node 22 (#186)

### DIFF
--- a/electron/breakPlacementHttpAdapter.js
+++ b/electron/breakPlacementHttpAdapter.js
@@ -22,7 +22,16 @@ const SYSTEM_PROMPT = [
 ].join("\n");
 
 function createBreakPlacementHttpAdapter(options) {
-  const { chatCompletionsUrl, fetchImpl = fetch, requestTimeoutMs = 300 } = options;
+  const {
+    chatCompletionsUrl,
+    fetchImpl = fetch,
+    requestTimeoutMs = 300,
+    // #186: AbortSignal.timeout()'s internal timer is unref()'d by design,
+    // which trips node --test's "is there work left?" heuristic on Node 22 -
+    // the test gets cancelled before a real millisecond-scale timer fires.
+    // Injectable so a test can drive the abort itself, no real clock.
+    timeoutSignal = (ms) => AbortSignal.timeout(ms),
+  } = options;
   if (typeof chatCompletionsUrl !== "function") {
     throw new Error("Break-placement HTTP adapter requires a chatCompletionsUrl function");
   }
@@ -32,7 +41,7 @@ function createBreakPlacementHttpAdapter(options) {
     const response = await fetchImpl(chatCompletionsUrl(), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      signal: AbortSignal.timeout(requestTimeoutMs),
+      signal: timeoutSignal(requestTimeoutMs),
       body: JSON.stringify({
         messages: [
           { role: "system", content: SYSTEM_PROMPT },

--- a/electron/breakPlacementHttpAdapter.test.js
+++ b/electron/breakPlacementHttpAdapter.test.js
@@ -55,18 +55,29 @@ test("fails clearly when the rewrite model server rejects break placement", asyn
 });
 
 test("bounds a break-placement request by the dictation latency headroom", async () => {
+  // #186: drive the timeout ourselves instead of leaning on a real
+  // AbortSignal.timeout() millisecond timer, which node --test on Node 22
+  // cancels the test out from under before it fires.
+  const controller = new AbortController();
+  let requestedTimeoutMs = null;
   const adapter = createBreakPlacementHttpAdapter({
     chatCompletionsUrl: () => "http://127.0.0.1:8179/v1/chat/completions",
     requestTimeoutMs: 5,
-    fetchImpl: async (_url, options) => new Promise((_resolve, reject) => {
-      options.signal.addEventListener("abort", () => reject(options.signal.reason));
-    }),
+    timeoutSignal: (ms) => {
+      requestedTimeoutMs = ms;
+      return controller.signal;
+    },
+    fetchImpl: (_url, options) =>
+      new Promise((_resolve, reject) => {
+        options.signal.addEventListener("abort", () => reject(options.signal.reason));
+      }),
   });
 
-  await assert.rejects(
-    () => adapter.placeParagraphBreaks(["One.", "Two.", "Three."]),
-    { name: "TimeoutError" }
-  );
+  const pending = adapter.placeParagraphBreaks(["One.", "Two.", "Three."]);
+  controller.abort(new DOMException("The operation timed out.", "TimeoutError"));
+
+  await assert.rejects(pending, { name: "TimeoutError" });
+  assert.equal(requestedTimeoutMs, 5, "the configured timeout is passed through to the signal factory");
 });
 
 test("rejects a malformed break-placement response", async () => {

--- a/electron/dictationCoordinator.test.js
+++ b/electron/dictationCoordinator.test.js
@@ -295,6 +295,9 @@ test("a flagged spoken list renders as bullets set off from the surrounding pros
     text: "Here is my shopping list.\n\n- Buy milk.\n- Buy eggs.\n- Buy bread.",
   });
   assert.deepEqual(harness.diagnostics, [
+    ["vocabulary.promptLength", 0],
+    ["context.bundleId", "com.apple.TextEdit"],
+    ["context.axReady", true],
     ["paragraphBreaks.formatValid", true],
     ["paragraphBreaks.repairUsed", false],
     ["listBoundaries.formatValid", true],
@@ -316,6 +319,9 @@ test("an out-of-range list range is clamped into the text and recorded as repair
     text: "First sentence.\n\n- Second sentence.\n- Third sentence.\n- Fourth sentence.",
   });
   assert.deepEqual(harness.diagnostics, [
+    ["vocabulary.promptLength", 0],
+    ["context.bundleId", "com.apple.TextEdit"],
+    ["context.axReady", true],
     ["paragraphBreaks.formatValid", true],
     ["paragraphBreaks.repairUsed", false],
     ["listBoundaries.formatValid", true],
@@ -337,6 +343,9 @@ test("a malformed LIST line fails closed to prose without dropping paragraph bre
     text: "First sentence. Second sentence.\n\nThird sentence. Fourth sentence.",
   });
   assert.deepEqual(harness.diagnostics, [
+    ["vocabulary.promptLength", 0],
+    ["context.bundleId", "com.apple.TextEdit"],
+    ["context.axReady", true],
     ["paragraphBreaks.formatValid", true],
     ["paragraphBreaks.repairUsed", false],
     ["listBoundaries.formatValid", false],
@@ -357,6 +366,9 @@ test("list detection is off by default: a valid range is parsed and reported but
     text: "Here is my shopping list. Buy milk. Buy eggs. Buy bread.",
   });
   assert.deepEqual(harness.diagnostics, [
+    ["vocabulary.promptLength", 0],
+    ["context.bundleId", "com.apple.TextEdit"],
+    ["context.axReady", true],
     ["paragraphBreaks.formatValid", true],
     ["paragraphBreaks.repairUsed", false],
     ["listBoundaries.formatValid", true],


### PR DESCRIPTION
Closes #186. Takes `npm test` from 5 failures + 2 cancelled down to 1 (the #171 fixture reminder).

## The #186 fix

`breakPlacementHttpAdapter.test.js`'s timeout test drove a real `AbortSignal.timeout(5)`. That timer is `unref()`'d by Node's design, and `node --test` on Node 22 treats the file as "no work left" and cancels the still-pending test before it fires — deterministically. Test 4 was collateral (next in the file, cancelled once the runner gave up on 3).

Fix: `createBreakPlacementHttpAdapter` takes an injectable `timeoutSignal` (default `(ms) => AbortSignal.timeout(ms)` — production unchanged). The test passes its own `AbortController` and aborts it explicitly with a `TimeoutError` `DOMException`. No real clock, no unref'd timer. Ran it 3× in isolation and in the full suite — passes every time.

## Also folded in

The four dormant `listDetection: true` tests in `dictationCoordinator.test.js` (issue #125's parser, gated off by default) asserted an exact `diagnostics` array that predated `vocabulary.promptLength` (#16), `context.axReady` (#181) and `context.bundleId` (#227). Their `result` assertions always passed — only the stale arrays failed. Refreshed the arrays; no behaviour change.

## Still red (out of scope)

`electron/cleanup/realDictation.test.js` — "real-dictation fixture set is non-empty" is an intentional reminder that fails until #171 adds recorded dictation samples. That's #171's work (needs real audio), not this.

## Tests

- `node --test` — 247 pass, 1 fail (the #171 reminder above), 0 cancelled.
- vitest 116/116, `npm run typecheck`, `npm run build` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
