### PR TITLE
Mark RC/beta tags as pre-releases (#20)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,5 +67,8 @@ jobs:
           name: ${{ github.ref_name }}
           body: ${{ steps.notes.outputs.body }}
           generate_release_notes: true
+          # A hyphen in the tag (v0.4.0-rc.1, v1.0.0-beta) marks a
+          # pre-release, so it never displaces the real "Latest" release.
+          prerelease: ${{ contains(github.ref_name, '-') }}
           files: release/*.dmg
           fail_on_unmatched_files: true


### PR DESCRIPTION
Small gap found while prepping a v0.4.0-rc.1 dry-run tag for #20: the release workflow published every tag as a full release, so an RC would show as **Latest** on the repo.

`prerelease: ${{ contains(github.ref_name, '-') }}` — any tag with a hyphen (`v0.4.0-rc.1`, `v1.0.0-beta`) is now a pre-release; `vX.Y` tags are unaffected.

YAML-only, no behaviour change for real releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)