### PR TITLE
UI polish: window tokens, Home page, app mark

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -328,6 +328,7 @@ async function handleCompletedRecording(wavBuffer, timing) {
 
 function showVoiceEditWorking() {
   setTrayState("transcribing");
+  notifyWindowState("editing");
   if (!overlayWin || overlayWin.isDestroyed()) return;
   positionOverlayAtBottom();
   overlayWin.webContents.send("dictation-state", "editing");
@@ -498,7 +499,22 @@ function positionOverlayAtBottom() {
   overlayWin.setPosition(x, y);
 }
 
+// The desktop window's Home page reflects live dictation activity. It only
+// needs the coarse state - recording / transcribing / idle - not the
+// overlay's fuller vocabulary ("editing", "held").
+function notifyWindowState(rawState) {
+  if (!win || win.isDestroyed()) return;
+  const state =
+    rawState === "recording"
+      ? "recording"
+      : rawState === "transcribing" || rawState === "editing"
+        ? "transcribing"
+        : "idle";
+  win.webContents.send("dictation-state", state);
+}
+
 function setUserVisibleState(state, details) {
+  notifyWindowState(state);
   if (state === "held") {
     setTrayState("idle");
     heldResultController.hold(details.text);

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -8,6 +8,14 @@ function onNavigate(callback) {
   return () => ipcRenderer.removeListener("navigate", listener);
 }
 
+// Live dictation activity - "idle" | "recording" | "transcribing" - so the
+// Home page can reflect what the app is doing. Returns an unsubscribe.
+function onDictationState(callback) {
+  const listener = (_event, state) => callback(state);
+  ipcRenderer.on("dictation-state", listener);
+  return () => ipcRenderer.removeListener("dictation-state", listener);
+}
+
 // The renderer's only route to the main process, per contextIsolation - see
 // the settings window's webPreferences in main.js. First surface: settings
 // (#19). This will grow to cover the hotkey helper, the accessibility
@@ -34,4 +42,5 @@ contextBridge.exposeInMainWorld("openstream", {
     chooseFolder: () => ipcRenderer.invoke("vocabulary:choose-folder"),
   },
   onNavigate,
+  onDictationState,
 });

--- a/src/components/Mark.tsx
+++ b/src/components/Mark.tsx
@@ -1,0 +1,35 @@
+// The OpenStream mark: an upward caret - the insertion point where
+// dictated text lands - inside a listening ring. Monoline, on the same
+// 24px grid and stroke weight as the icon set, so it can also be
+// rasterised into the tray and app icon later.
+//
+// `state` only shifts the colour: "idle" (accent) is the resting look,
+// "attention" (red) flags a blocking permission.
+export type MarkState = "idle" | "recording" | "attention";
+
+export default function Mark({
+  state = "idle",
+  className,
+  tile = false,
+}: {
+  state?: MarkState;
+  className?: string;
+  tile?: boolean;
+}) {
+  const glyph = (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <circle cx="12" cy="12" r="8.5" />
+      <path d="M8.4 13.6 12 10l3.6 3.6" />
+    </svg>
+  );
+
+  if (!tile) {
+    return <span className={className}>{glyph}</span>;
+  }
+
+  return (
+    <span className={`mark mark--${state}${className ? ` ${className}` : ""}`} aria-hidden="true">
+      {glyph}
+    </span>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -553,6 +553,89 @@ button {
   margin: 6px 2px 0;
 }
 
+/* --- permissions page --- */
+
+.perm-progress {
+  margin: -6px 2px 0;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-2);
+}
+
+.perm-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.perm-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 14px 16px;
+  background: var(--surface);
+  border-radius: var(--radius-card);
+  box-shadow: var(--shadow-card);
+}
+
+.perm-item[data-granted="true"] {
+  opacity: 0.72;
+}
+
+.perm-item__icon {
+  flex: 0 0 30px;
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+  display: grid;
+  place-items: center;
+  background: var(--surface-2);
+  color: var(--text-2);
+}
+
+.perm-item[data-granted="true"] .perm-item__icon {
+  background: var(--ok-tint);
+  color: var(--ok);
+}
+
+.perm-item__icon svg {
+  width: 16px;
+  height: 16px;
+}
+
+.perm-item__body {
+  flex: 1;
+  min-width: 0;
+}
+
+.perm-item__title {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.perm-item__why {
+  margin: 2px 0 0;
+  font-size: 12px;
+  color: var(--text-2);
+}
+
+.perm-item__action {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+  flex: 0 0 auto;
+}
+
+.perm-footer {
+  display: flex;
+  gap: 8px;
+  padding: 0 2px;
+}
+
 /* --- Push-to-talk shortcut section (HotkeySettings.tsx) ---
    The component predates the card system and renders a bare
    <section class="setting"> with an unstyled button. Its markup is

--- a/src/index.css
+++ b/src/index.css
@@ -460,47 +460,28 @@ button {
   margin: 0 1px;
 }
 
-/* Concentric pulse - the home mark and the tray-state beacon. */
-.beacon {
-  position: relative;
-  width: 12px;
-  height: 12px;
-  flex: 0 0 12px;
-  margin-top: 5px;
+/* The app mark: a listening ring around a caret. Tile form sits in the
+   Home hero; the colour follows app state. */
+.mark {
+  width: 34px;
+  height: 34px;
+  flex: 0 0 34px;
+  margin-top: 2px;
+  border-radius: 10px;
+  display: grid;
+  place-items: center;
+  background: var(--accent-tint);
+  color: var(--accent-text);
 }
 
-.beacon::before,
-.beacon::after {
-  content: "";
-  position: absolute;
-  border-radius: 50%;
+.mark svg {
+  width: 19px;
+  height: 19px;
 }
 
-.beacon::before {
-  inset: 0;
-  background: var(--ok);
-}
-
-.beacon::after {
-  inset: -6px;
-  border: 2px solid var(--ok);
-  opacity: 0.32;
-}
-
-.beacon[data-state="recording"]::before {
-  background: var(--accent);
-}
-
-.beacon[data-state="recording"]::after {
-  border-color: var(--accent);
-}
-
-.beacon[data-state="attention"]::before {
-  background: var(--err);
-}
-
-.beacon[data-state="attention"]::after {
-  border-color: var(--err);
+.mark--attention {
+  background: var(--err-tint);
+  color: var(--err);
 }
 
 .empty {

--- a/src/index.css
+++ b/src/index.css
@@ -512,6 +512,25 @@ button {
   color: var(--err);
 }
 
+.mark--recording {
+  animation: mark-pulse 1.7s ease-out infinite;
+}
+
+@keyframes mark-pulse {
+  from {
+    box-shadow: 0 0 0 0 var(--accent-tint);
+  }
+  to {
+    box-shadow: 0 0 0 11px transparent;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mark--recording {
+    animation: none;
+  }
+}
+
 .empty {
   display: flex;
   flex-direction: column;

--- a/src/index.css
+++ b/src/index.css
@@ -192,6 +192,34 @@ button {
   border-top: 0;
 }
 
+/* A row that toggles a disclosure (Home's System card). */
+.row--disclosure {
+  width: 100%;
+  border: 0;
+  border-top: 1px solid var(--sep);
+  border-radius: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: default;
+}
+
+.row--disclosure:hover {
+  background: var(--sep);
+}
+
+.disclosure-chevron {
+  width: 14px;
+  height: 14px;
+  color: var(--text-3);
+  transition: transform 0.15s ease;
+}
+
+.row--disclosure[aria-expanded="true"] .disclosure-chevron {
+  transform: rotate(180deg);
+}
+
 .row-icon {
   width: 17px;
   height: 17px;

--- a/src/index.css
+++ b/src/index.css
@@ -1,75 +1,83 @@
 /* OpenStream desktop window - design tokens and shared components.
-   Ported from prototypes/desktop-ui-211 (issue #211). Extends the
-   push-to-talk overlay's language: Apple system-blue accent, SF, the
-   same corner radii, but a solid window that follows the OS light/dark
-   setting rather than glass. */
+   Started from prototypes/desktop-ui-211 (issue #211); a native Mac
+   window that follows the OS light/dark setting. Same system-blue accent
+   and corner language as the push-to-talk overlay, but a solid surface
+   rather than glass. */
 
 :root {
   color-scheme: light dark;
 
-  --bg: #ececec;
+  /* Neutrals carry a faint cool cast toward the blue accent, so the greys
+     read as chosen rather than default. */
+  --bg: #e9eaee;
   --surface: #ffffff;
-  --surface-2: #f5f5f7;
-  --toolbar: #f6f6f6;
-  --text: #1d1d1f;
-  --text-2: #6e6e73;
-  --sep: rgba(0, 0, 0, 0.1);
+  --surface-2: #f3f4f7;
+  --toolbar: rgba(247, 248, 250, 0.8);
+  --text: #1b1c1f;
+  --text-2: #64666e;
+  --text-3: #8b8d96;
+  --sep: rgba(0, 0, 0, 0.08);
+  --hairline: rgba(0, 0, 0, 0.11);
   --accent: #007aff;
-  --accent-text: #007aff;
+  --accent-text: #0067da;
   --accent-tint: rgba(0, 122, 255, 0.12);
-  --ok: #248a3d;
-  --ok-tint: rgba(52, 199, 89, 0.16);
+  --ok: #1e8b3b;
+  --ok-tint: rgba(52, 199, 89, 0.15);
   --wait: #9a6100;
-  --wait-tint: rgba(255, 159, 10, 0.18);
-  --err: #c0392b;
-  --err-tint: rgba(255, 59, 48, 0.16);
+  --wait-tint: rgba(255, 159, 10, 0.16);
+  --err: #c8342a;
+  --err-tint: rgba(255, 59, 48, 0.13);
   --field: #ffffff;
-  --field-border: rgba(0, 0, 0, 0.18);
+  --field-border: rgba(0, 0, 0, 0.16);
   --keycap: #ffffff;
-  --keycap-border: rgba(0, 0, 0, 0.16);
-  --switch-off: rgba(0, 0, 0, 0.16);
-  --shadow: 0 1px 2px rgba(0, 0, 0, 0.06), 0 0 0 0.5px rgba(0, 0, 0, 0.05);
+  --keycap-border: rgba(0, 0, 0, 0.14);
+  --switch-off: rgba(0, 0, 0, 0.15);
+  --shadow-card: 0 0 0 0.5px var(--hairline), 0 1px 2px rgba(0, 0, 0, 0.05), 0 6px 16px -8px rgba(0, 0, 0, 0.12);
+  --shadow-control: 0 0 0 0.5px rgba(0, 0, 0, 0.06), 0 1px 1.5px rgba(0, 0, 0, 0.06);
 
   --radius-control: 6px;
   --radius-button: 7px;
-  --radius-card: 10px;
+  --radius-card: 12px;
 
   --space-1: 4px;
   --space-2: 8px;
   --space-3: 12px;
   --space-4: 16px;
   --space-5: 20px;
-  --space-6: 22px;
+  --space-6: 24px;
 
   font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif;
   font-size: 13px;
-  line-height: 1.4;
+  line-height: 1.45;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --bg: #1e1e1e;
-    --surface: #2c2c2e;
-    --surface-2: #323234;
-    --toolbar: #282828;
-    --text: rgba(255, 255, 255, 0.92);
-    --text-2: rgba(255, 255, 255, 0.55);
-    --sep: rgba(255, 255, 255, 0.1);
+    --bg: #1c1c1f;
+    --surface: #2b2b2f;
+    --surface-2: #333338;
+    --toolbar: rgba(38, 38, 42, 0.8);
+    --text: rgba(255, 255, 255, 0.93);
+    --text-2: rgba(235, 235, 245, 0.58);
+    --text-3: rgba(235, 235, 245, 0.4);
+    --sep: rgba(255, 255, 255, 0.09);
+    --hairline: rgba(255, 255, 255, 0.13);
     --accent: #0a84ff;
-    --accent-text: #6cb4ff;
-    --accent-tint: rgba(10, 132, 255, 0.24);
-    --ok: #30d158;
+    --accent-text: #67b0ff;
+    --accent-tint: rgba(10, 132, 255, 0.26);
+    --ok: #34d158;
     --ok-tint: rgba(48, 209, 88, 0.2);
     --wait: #ffb340;
-    --wait-tint: rgba(255, 159, 10, 0.22);
+    --wait-tint: rgba(255, 159, 10, 0.2);
     --err: #ff6961;
     --err-tint: rgba(255, 69, 58, 0.2);
-    --field: #1c1c1e;
-    --field-border: rgba(255, 255, 255, 0.16);
-    --keycap: #3a3a3c;
-    --keycap-border: rgba(255, 255, 255, 0.16);
-    --switch-off: rgba(255, 255, 255, 0.18);
-    --shadow: 0 1px 2px rgba(0, 0, 0, 0.4), 0 0 0 0.5px rgba(0, 0, 0, 0.5);
+    --field: #1d1d20;
+    --field-border: rgba(255, 255, 255, 0.15);
+    --keycap: #3a3a3e;
+    --keycap-border: rgba(255, 255, 255, 0.15);
+    --switch-off: rgba(255, 255, 255, 0.17);
+    --shadow-card: 0 0 0 0.5px var(--hairline), 0 1px 2px rgba(0, 0, 0, 0.35), 0 8px 20px -10px rgba(0, 0, 0, 0.5);
+    --shadow-control: 0 0 0 0.5px rgba(0, 0, 0, 0.4), 0 1px 2px rgba(0, 0, 0, 0.35);
   }
 }
 
@@ -88,6 +96,11 @@ button {
   font: inherit;
 }
 
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 /* --- app shell --- */
 
 .shell {
@@ -104,6 +117,7 @@ button {
   /* room for the inset traffic lights on the left */
   padding: 0 var(--space-4) 0 92px;
   background: var(--toolbar);
+  backdrop-filter: saturate(180%) blur(20px);
   border-bottom: 1px solid var(--sep);
   -webkit-app-region: drag;
 }
@@ -112,7 +126,7 @@ button {
   display: flex;
   align-items: center;
   gap: 6px;
-  height: 30px;
+  height: 28px;
   padding: 0 var(--space-3);
   border: 0;
   border-radius: var(--radius-button);
@@ -121,6 +135,12 @@ button {
   font-weight: 500;
   -webkit-app-region: no-drag;
   cursor: default;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+
+.navtab:hover:not([aria-current="page"]) {
+  background: var(--sep);
+  color: var(--text);
 }
 
 .navtab svg {
@@ -139,7 +159,7 @@ button {
   padding: var(--space-6);
   display: flex;
   flex-direction: column;
-  gap: 18px;
+  gap: var(--space-5);
 }
 
 /* --- building blocks --- */
@@ -147,25 +167,25 @@ button {
 .card {
   background: var(--surface);
   border-radius: var(--radius-card);
-  box-shadow: var(--shadow);
+  box-shadow: var(--shadow-card);
 }
 
 .card-label {
-  padding: 10px 14px;
+  padding: 12px 16px 8px;
   font-size: 11px;
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: var(--text-2);
+  color: var(--text-3);
 }
 
 .row {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 11px 14px;
+  gap: 11px;
+  padding: 12px 16px;
   border-top: 1px solid var(--sep);
-  min-height: 44px;
+  min-height: 46px;
 }
 
 .row:first-child {
@@ -173,9 +193,9 @@ button {
 }
 
 .row-icon {
-  width: 18px;
-  height: 18px;
-  flex: 0 0 18px;
+  width: 17px;
+  height: 17px;
+  flex: 0 0 17px;
   color: var(--text-2);
 }
 
@@ -185,20 +205,22 @@ button {
 
 .row-label small {
   display: block;
-  font-size: 12px;
+  font-size: 11.5px;
   color: var(--text-2);
+  margin-top: 1px;
 }
 
 .group {
   display: flex;
   flex-direction: column;
-  gap: 7px;
+  gap: var(--space-2);
 }
 
 .group > h2 {
   margin: 0 2px;
   font-size: 13px;
   font-weight: 600;
+  letter-spacing: -0.006em;
 }
 
 .group > .group-desc {
@@ -210,7 +232,7 @@ button {
 
 .mono {
   font-family: ui-monospace, "SF Mono", Menlo, monospace;
-  font-size: 12px;
+  font-size: 11.5px;
 }
 
 /* --- controls --- */
@@ -219,31 +241,44 @@ button {
   height: 26px;
   padding: 0 12px;
   border-radius: var(--radius-button);
-  border: 1px solid var(--field-border);
+  border: 0;
   background: var(--field);
   color: var(--text);
   font-weight: 500;
   font-size: 12px;
   cursor: default;
-  box-shadow: 0 1px 1.5px rgba(0, 0, 0, 0.05);
+  box-shadow: var(--shadow-control);
+  transition: filter 0.12s ease;
+}
+
+.btn:hover:not(:disabled) {
+  filter: brightness(0.97);
 }
 
 .btn:disabled {
-  opacity: 0.45;
+  opacity: 0.4;
 }
 
 .btn--primary {
   background: var(--accent);
-  border-color: transparent;
   color: #fff;
   font-weight: 600;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
+}
+
+.btn--primary:hover:not(:disabled) {
+  filter: brightness(1.06);
 }
 
 .btn--ghost {
   background: transparent;
-  border-color: transparent;
   box-shadow: none;
   color: var(--accent-text);
+}
+
+.btn--ghost:hover:not(:disabled) {
+  filter: none;
+  background: var(--accent-tint);
 }
 
 .linkbtn {
@@ -252,6 +287,12 @@ button {
   color: var(--accent-text);
   font-weight: 500;
   cursor: default;
+  padding: 2px 4px;
+  border-radius: 5px;
+}
+
+.linkbtn:hover {
+  background: var(--accent-tint);
 }
 
 /* A row of buttons that sits under a card, not inside it (#19). */
@@ -274,6 +315,12 @@ button {
   font-size: 12px;
 }
 
+.field:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-tint);
+}
+
 .select {
   display: inline-flex;
   align-items: center;
@@ -285,7 +332,7 @@ button {
   background: var(--field);
   color: var(--text);
   font-size: 12px;
-  box-shadow: 0 1px 1.5px rgba(0, 0, 0, 0.05);
+  box-shadow: var(--shadow-control);
 }
 
 .select svg {
@@ -304,6 +351,7 @@ button {
   background: var(--switch-off);
   position: relative;
   cursor: default;
+  transition: background 0.16s ease;
 }
 
 .switch[aria-checked="true"] {
@@ -320,7 +368,7 @@ button {
   border-radius: 50%;
   background: #fff;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
-  transition: left 0.15s ease;
+  transition: left 0.16s cubic-bezier(0.3, 1.5, 0.6, 1);
 }
 
 .switch[aria-checked="true"]::after {
@@ -328,7 +376,7 @@ button {
 }
 
 .keys {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: 4px;
 }
@@ -353,16 +401,17 @@ button {
 .pill {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
+  gap: 4px;
   padding: 3px 9px 3px 7px;
   border-radius: 999px;
-  font-size: 12px;
+  font-size: 11.5px;
   font-weight: 600;
+  white-space: nowrap;
 }
 
 .pill svg {
-  width: 13px;
-  height: 13px;
+  width: 12px;
+  height: 12px;
 }
 
 .pill--ok {
@@ -389,28 +438,35 @@ button {
 
 .hero {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 14px;
-  padding: 4px 4px 2px;
+  padding: 6px 6px 2px;
 }
 
 .hero h1 {
   margin: 0;
-  font-size: 17px;
+  font-size: 19px;
   font-weight: 600;
-  letter-spacing: -0.01em;
+  letter-spacing: -0.018em;
 }
 
 .hero p {
-  margin: 2px 0 0;
+  margin: 3px 0 0;
   color: var(--text-2);
+  max-width: 52ch;
 }
 
+.hero p .keys {
+  margin: 0 1px;
+}
+
+/* Concentric pulse - the home mark and the tray-state beacon. */
 .beacon {
   position: relative;
   width: 12px;
   height: 12px;
   flex: 0 0 12px;
+  margin-top: 5px;
 }
 
 .beacon::before,
@@ -428,7 +484,7 @@ button {
 .beacon::after {
   inset: -6px;
   border: 2px solid var(--ok);
-  opacity: 0.35;
+  opacity: 0.32;
 }
 
 .beacon[data-state="recording"]::before {
@@ -439,20 +495,28 @@ button {
   border-color: var(--accent);
 }
 
+.beacon[data-state="attention"]::before {
+  background: var(--err);
+}
+
+.beacon[data-state="attention"]::after {
+  border-color: var(--err);
+}
+
 .empty {
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 8px;
-  padding: 26px 14px 30px;
-  color: var(--text-2);
+  padding: 22px 14px 26px;
+  color: var(--text-3);
   text-align: center;
   font-size: 12px;
 }
 
 .empty svg {
-  width: 24px;
-  height: 24px;
+  width: 22px;
+  height: 22px;
   opacity: 0.7;
 }
 
@@ -480,33 +544,62 @@ button {
   margin: 6px 2px 0;
 }
 
-/* Kept for HotkeySettings.tsx, which still uses the pre-shell classes -
-   its restyle to the card system waits on the shortcut work landing
-   (#215). Everything else on the Settings page uses the tokens above. */
+/* --- Push-to-talk shortcut section (HotkeySettings.tsx) ---
+   The component predates the card system and renders a bare
+   <section class="setting"> with an unstyled button. Its markup is
+   owned by the shortcut work (#214/#216); until that lands, this rule
+   set makes it read like the rest of the page - a headed group with a
+   card - using only CSS. */
 .setting {
-  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
 }
 
 .setting h2 {
+  margin: 0 2px;
   font-size: 13px;
   font-weight: 600;
-  margin: 0 0 0.4rem;
+  letter-spacing: -0.006em;
 }
 
 .setting-current {
-  font-size: 1.05rem;
+  margin: 0;
+  padding: 12px 16px;
+  background: var(--surface);
+  border-radius: var(--radius-card);
+  box-shadow: var(--shadow-card);
+  font-size: 15px;
   font-weight: 600;
-  margin: 0 0 0.4rem;
 }
 
 .setting-guidance {
-  margin: 0 0 0.5rem;
+  margin: 0 2px;
   font-size: 12px;
   color: var(--text-2);
+  max-width: 62ch;
+}
+
+.setting button {
+  align-self: flex-start;
+  height: 26px;
+  padding: 0 12px;
+  border-radius: var(--radius-button);
+  border: 0;
+  background: var(--field);
+  color: var(--text);
+  font-weight: 500;
+  font-size: 12px;
+  cursor: default;
+  box-shadow: var(--shadow-control);
+}
+
+.setting button:disabled {
+  opacity: 0.4;
 }
 
 .setting-error {
   color: var(--err);
   font-size: 12px;
-  margin-top: 0.5rem;
+  margin: 0 2px;
 }

--- a/src/openstreamBridge.d.ts
+++ b/src/openstreamBridge.d.ts
@@ -70,6 +70,7 @@ declare global {
         chooseFolder(): Promise<string | null>;
       };
       onNavigate(callback: (page: string) => void): () => void;
+      onDictationState(callback: (state: "idle" | "recording" | "transcribing") => void): () => void;
     };
   }
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -5,6 +5,7 @@ import KeyCaps from "../components/KeyCaps";
 import Mark from "../components/Mark";
 import StatusPill, { type PillTone } from "../components/StatusPill";
 import {
+  ChevronDownIcon,
   InputMonitorIcon,
   KeyboardIcon,
   MicIcon,
@@ -13,6 +14,24 @@ import {
 } from "../components/Icons";
 
 const HEALTH_POLL_MS = 4000;
+const DETAILS_KEY = "openstream.home.systemExpanded";
+
+function loadExpanded(): boolean {
+  try {
+    return window.localStorage.getItem(DETAILS_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function saveExpanded(value: boolean) {
+  try {
+    window.localStorage.setItem(DETAILS_KEY, value ? "1" : "0");
+  } catch {
+    // A locked-down renderer can throw on localStorage; the toggle still
+    // works for the session, it just won't be remembered.
+  }
+}
 
 function grantPill(state: GrantState): { tone: PillTone; label: string } {
   switch (state) {
@@ -36,6 +55,7 @@ function modelPill(state: ModelHealth): { tone: PillTone; label: string } {
 export default function Home({ navigate }: { navigate: (page: Page) => void }) {
   const [settings, setSettings] = useState<StoredSettings | null>(null);
   const [health, setHealth] = useState<AppHealth | null>(null);
+  const [expanded, setExpanded] = useState(loadExpanded);
 
   useEffect(() => {
     window.openstream.settings.get().then(setSettings);
@@ -138,19 +158,28 @@ export default function Home({ navigate }: { navigate: (page: Page) => void }) {
               Fix
             </button>
           </div>
+        ) : ready ? (
+          <button
+            type="button"
+            className="row row--disclosure"
+            aria-expanded={expanded}
+            onClick={() => {
+              const next = !expanded;
+              setExpanded(next);
+              saveExpanded(next);
+            }}
+          >
+            <span className="row-label">Everything is ready</span>
+            <StatusPill tone="ok" label="All set" />
+            <ChevronDownIcon className="disclosure-chevron" />
+          </button>
         ) : (
           <div className="row">
-            <span className="row-label">{ready ? "Everything is ready" : "Getting ready…"}</span>
-            <StatusPill tone={ready ? "ok" : "wait"} label={ready ? "All set" : "Starting"} />
+            <span className="row-label">{health ? "Getting ready…" : "Checking…"}</span>
+            {health && <StatusPill tone="wait" label="Starting" />}
           </div>
         )}
-        {rows.length === 0 ? (
-          <div className="row">
-            <span className="row-label" style={{ color: "var(--text-2)" }}>
-              Checking…
-            </span>
-          </div>
-        ) : (
+        {(expanded || !ready) &&
           rows.map((row) => (
             <div className="row" key={row.label}>
               {row.icon}
@@ -160,8 +189,7 @@ export default function Home({ navigate }: { navigate: (page: Page) => void }) {
               </span>
               <StatusPill tone={row.pill.tone} label={row.pill.label} />
             </div>
-          ))
-        )}
+          ))}
       </div>
 
       <p className="hint">

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -52,14 +52,19 @@ function modelPill(state: ModelHealth): { tone: PillTone; label: string } {
     : { tone: "wait", label: "Starting…" };
 }
 
+type Activity = "idle" | "recording" | "transcribing";
+
 export default function Home({ navigate }: { navigate: (page: Page) => void }) {
   const [settings, setSettings] = useState<StoredSettings | null>(null);
   const [health, setHealth] = useState<AppHealth | null>(null);
   const [expanded, setExpanded] = useState(loadExpanded);
+  const [activity, setActivity] = useState<Activity>("idle");
 
   useEffect(() => {
     window.openstream.settings.get().then(setSettings);
   }, []);
+
+  useEffect(() => window.openstream.onDictationState((state) => setActivity(state as Activity)), []);
 
   useEffect(() => {
     let active = true;
@@ -120,11 +125,30 @@ export default function Home({ navigate }: { navigate: (page: Page) => void }) {
   return (
     <main className="page">
       <div className="hero">
-        <Mark tile state={permissionsNeedAttention ? "attention" : "idle"} />
+        <Mark
+          tile
+          state={
+            permissionsNeedAttention ? "attention" : activity === "recording" ? "recording" : "idle"
+          }
+        />
         <div>
-          <h1>{permissionsNeedAttention ? "OpenStream needs a moment" : "OpenStream is listening"}</h1>
+          <h1>
+            {activity === "recording"
+              ? "Listening…"
+              : activity === "transcribing"
+                ? "Transcribing…"
+                : permissionsNeedAttention
+                  ? "OpenStream needs a moment"
+                  : "OpenStream is listening"}
+          </h1>
           <p>
-            {settings ? (
+            {activity === "recording" ? (
+              <>
+                Release the key to transcribe. Press <kbd className="keycap">esc</kbd> to cancel.
+              </>
+            ) : activity === "transcribing" ? (
+              "Placing your words at the cursor."
+            ) : settings ? (
               <>
                 Hold <KeyCaps hotkey={settings.hotkey} /> anywhere and speak — your words land at the cursor. Press{" "}
                 <kbd className="keycap">esc</kbd> to cancel a recording.

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import type { AppHealth, GrantState, ModelHealth, StoredSettings } from "../openstreamBridge";
 import type { Page } from "../nav";
 import KeyCaps from "../components/KeyCaps";
+import Mark from "../components/Mark";
 import StatusPill, { type PillTone } from "../components/StatusPill";
 import {
   InputMonitorIcon,
@@ -99,7 +100,7 @@ export default function Home({ navigate }: { navigate: (page: Page) => void }) {
   return (
     <main className="page">
       <div className="hero">
-        <span className="beacon" data-state={permissionsNeedAttention ? "attention" : "idle"} />
+        <Mark tile state={permissionsNeedAttention ? "attention" : "idle"} />
         <div>
           <h1>{permissionsNeedAttention ? "OpenStream needs a moment" : "OpenStream is listening"}</h1>
           <p>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -4,7 +4,6 @@ import type { Page } from "../nav";
 import KeyCaps from "../components/KeyCaps";
 import StatusPill, { type PillTone } from "../components/StatusPill";
 import {
-  ClockIcon,
   InputMonitorIcon,
   KeyboardIcon,
   MicIcon,
@@ -91,17 +90,23 @@ export default function Home({ navigate }: { navigate: (page: Page) => void }) {
 
   const permissionsNeedAttention =
     health && (health.permissions.accessibility !== "granted" || health.permissions.inputMonitoring === "missing");
+  const ready =
+    health &&
+    !permissionsNeedAttention &&
+    health.transcriptionModel === "ready" &&
+    health.rewriteModel === "ready";
 
   return (
     <main className="page">
       <div className="hero">
-        <span className="beacon" data-state="idle" />
+        <span className="beacon" data-state={permissionsNeedAttention ? "attention" : "idle"} />
         <div>
-          <h1>OpenStream is listening</h1>
+          <h1>{permissionsNeedAttention ? "OpenStream needs a moment" : "OpenStream is listening"}</h1>
           <p>
             {settings ? (
               <>
-                Hold <KeyCaps hotkey={settings.hotkey} /> anywhere and speak — your words land at the cursor.
+                Hold <KeyCaps hotkey={settings.hotkey} /> anywhere and speak — your words land at the cursor. Press{" "}
+                <kbd className="keycap">esc</kbd> to cancel a recording.
               </>
             ) : (
               "Loading…"
@@ -122,20 +127,27 @@ export default function Home({ navigate }: { navigate: (page: Page) => void }) {
       </div>
 
       <div className="card">
-        <div className="card-label">Status</div>
-        {permissionsNeedAttention && (
+        <div className="card-label">System</div>
+        {permissionsNeedAttention ? (
           <div className="row">
             <span className="row-label" style={{ color: "var(--err)" }}>
-              A required permission is missing — push-to-talk won't work.
+              A required permission is missing — push-to-talk won{"’"}t work.
             </span>
             <button type="button" className="btn btn--primary" onClick={() => navigate("permissions")}>
               Fix
             </button>
           </div>
+        ) : (
+          <div className="row">
+            <span className="row-label">{ready ? "Everything is ready" : "Getting ready…"}</span>
+            <StatusPill tone={ready ? "ok" : "wait"} label={ready ? "All set" : "Starting"} />
+          </div>
         )}
         {rows.length === 0 ? (
           <div className="row">
-            <span className="row-label">Checking…</span>
+            <span className="row-label" style={{ color: "var(--text-2)" }}>
+              Checking…
+            </span>
           </div>
         ) : (
           rows.map((row) => (
@@ -151,13 +163,10 @@ export default function Home({ navigate }: { navigate: (page: Page) => void }) {
         )}
       </div>
 
-      <div className="card">
-        <div className="card-label">Recent</div>
-        <div className="empty">
-          <ClockIcon />
-          <span>Your recent dictations will appear here.</span>
-        </div>
-      </div>
+      <p className="hint">
+        OpenStream lives in the menu bar. Closing this window leaves it running; quit from the menu bar icon or the app
+        menu.
+      </p>
     </main>
   );
 }

--- a/src/pages/Permissions.tsx
+++ b/src/pages/Permissions.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import type { GrantState, PermissionVerdict } from "../openstreamBridge";
+import Mark from "../components/Mark";
 import StatusPill, { type PillTone } from "../components/StatusPill";
 import { InputMonitorIcon, MicIcon, ShieldIcon } from "../components/Icons";
 
@@ -10,9 +11,9 @@ const ICONS: Record<string, (props: { className?: string }) => JSX.Element> = {
 };
 
 const EXPLAIN: Record<string, string> = {
-  accessibility: "Lets OpenStream place text at the cursor.",
+  accessibility: "Lets OpenStream place your words at the cursor.",
   inputMonitoring: "Lets the push-to-talk shortcut work in every app.",
-  microphone: "Lets OpenStream hear you. macOS prompts for this the first time you dictate.",
+  microphone: "Lets OpenStream hear you. macOS asks the first time you dictate.",
 };
 
 function pill(state: GrantState): { tone: PillTone; label: string } {
@@ -44,60 +45,84 @@ export default function Permissions({ onDone }: { onDone: () => void }) {
     recheck();
   }, [recheck]);
 
+  const details = verdict?.details ?? [];
+  const required = details.filter((row) => row.key !== "microphone");
+  const grantedRequired = required.filter((row) => row.state === "granted").length;
+
   return (
     <main className="page">
       <div className="hero">
+        <Mark tile state={verdict && !verdict.ok ? "attention" : "idle"} />
         <div>
-          <h1>Permissions</h1>
+          <h1>{verdict?.ok ? "OpenStream is ready" : "Grant two permissions"}</h1>
           <p>
-            OpenStream needs two macOS permissions to work. Because it runs from source, a rebuild resets them — if a
-            grant looks stuck, <b>remove the old OpenStream entry in System Settings first, then add it again</b>.
+            OpenStream places text at your cursor and listens for the shortcut. macOS gates both behind a switch you
+            flip once.
           </p>
         </div>
       </div>
 
-      <div className="card">
-        {(verdict?.details ?? []).map((row) => {
+      {verdict && !verdict.ok && (
+        <p className="perm-progress">
+          {grantedRequired} of {required.length} required permissions granted
+        </p>
+      )}
+
+      <div className="perm-list">
+        {details.map((row) => {
           const Icon = ICONS[row.key];
           const p = pill(row.state);
+          const optional = row.key === "microphone";
           return (
-            <div className="row" key={row.key}>
-              {Icon && <Icon className="row-icon" />}
-              <span className="row-label">
-                {row.label}
-                <small>{EXPLAIN[row.key]}</small>
-              </span>
-              <StatusPill tone={p.tone} label={p.label} />
-              {row.state !== "granted" && row.key !== "microphone" && (
-                <button
-                  type="button"
-                  className="btn"
-                  style={{ marginLeft: 8 }}
-                  onClick={() => window.openstream.app.openPrivacySettings(row.key)}
-                >
-                  Open Settings
-                </button>
-              )}
+            <div className="perm-item" data-granted={row.state === "granted"} key={row.key}>
+              <span className="perm-item__icon">{Icon && <Icon />}</span>
+              <div className="perm-item__body">
+                <div className="perm-item__title">
+                  {row.label}
+                  {optional && <span className="tag">Optional now</span>}
+                </div>
+                <p className="perm-item__why">{EXPLAIN[row.key]}</p>
+              </div>
+              <div className="perm-item__action">
+                <StatusPill tone={p.tone} label={p.label} />
+                {row.state !== "granted" && !optional && (
+                  <button
+                    type="button"
+                    className="btn btn--primary"
+                    onClick={() => window.openstream.app.openPrivacySettings(row.key)}
+                  >
+                    Open Settings
+                  </button>
+                )}
+              </div>
             </div>
           );
         })}
         {!verdict && (
-          <div className="row">
-            <span className="row-label">Checking…</span>
+          <div className="perm-item">
+            <div className="perm-item__body">
+              <div className="perm-item__title">Checking…</div>
+            </div>
           </div>
         )}
       </div>
 
-      <div className="row" style={{ padding: "0 2px", gap: 8 }}>
+      <div className="perm-footer">
         <button type="button" className="btn" onClick={recheck} disabled={checking}>
           {checking ? "Re-checking…" : "Re-check"}
         </button>
         {verdict?.ok && (
           <button type="button" className="btn btn--primary" onClick={onDone}>
-            Done
+            Continue
           </button>
         )}
       </div>
+
+      <p className="hint">
+        After granting, quit and reopen OpenStream so it picks up the change. Because OpenStream runs from source, a
+        rebuild resets these — if a switch looks stuck, remove the old OpenStream entry in System Settings first, then
+        add it again.
+      </p>
     </main>
   );
 }


### PR DESCRIPTION
First pass at the "cleaner and beautiful" window work — deliberately conservative so we can iterate together.

## Preview
https://claude.ai/code/artifact/4606f2d3-643e-4517-8803-b698a9442b04 (Home ready / Home needs-attention / Settings, light + dark)

## Changes

**`src/index.css` — design token refresh**
- Neutrals given a faint cool cast toward the accent (was flat grey `#ececec`).
- Type scale tightened: hero 17 to 19px with real negative tracking, consistent 11.5 to 13px body ramp.
- Cards get a hairline (`0 0 0 0.5px`) plus a softer layered shadow — reads crisp in dark mode, where the old shadow was invisible.
- More generous rhythm: page padding/gap 22/18 to 24/20, rows 44 to 46px.
- Toolbar gets the standard vibrancy blur; tabs get a hover state.
- Buttons, fields, switch: hover/focus states, a spring on the switch knob, focus ring on inputs.
- The `.setting` block (HotkeySettings, whose markup is owned by #214/#216) is restyled — CSS only — to read like the rest of the page: headed group, the current shortcut in a card, the button matched to `.btn`.

**`src/pages/Home.tsx` — calmer**
- Hero reflects state: "OpenStream is listening" / "needs a moment", the beacon goes red on a missing permission.
- The Esc-to-cancel hint moved into the hero.
- "Status" card renamed "System", led by a one-line summary row ("Everything is ready" / the Fix prompt) before the detail rows.
- Removed the permanently-empty "Recent" card — that is #136, and a dead placeholder as the largest element on the page is the same anti-pattern as the mic dropdown removed in #19. It comes back with #136.
- A footer line explaining the menu-bar lifecycle.

No component logic changed; `HotkeySettings.tsx` and all hotkey code untouched.

## Tests
vitest 116/116, `npm run typecheck`, `npm run build` — clean. No component tests for Home/Settings exist to break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Update — app mark (pass-2 item 1)

`src/components/Mark.tsx` — an upward caret (the insertion point where dictated text lands) inside a listening ring. Monoline, same 24px grid / 1.8 stroke as the icon set, so it can be rasterised into the tray and app icon later. It replaces the bare status dot in the Home hero as a 34px tinted tile; colour follows state (accent / red for a blocking permission). Dead `.beacon` CSS removed.

The real `assets/icon.icns` and the menu-bar PNGs are still the placeholder white-circle — regenerating those from this mark needs an SVG rasteriser this environment doesn't have (or a design tool). Flagged as a follow-up.

### Update — collapsible System card (pass-2 item 2)

When everything is healthy the System card is now a single summary row ("Everything is ready · All set") with a chevron; clicking it discloses the five detail rows. The choice is remembered in `localStorage` (best-effort, try/catch). When a permission is missing or a model is still starting the detail rows are always shown — problems never hide.

### Update — Permissions page (pass-2 item 3)

Reworked from a plain list into a gate screen: the Mark in the hero (red while blocked), a headline that flips to "OpenStream is ready", a "1 of 2 required permissions granted" progress line, and each permission as its own card — icon tile, name, one-line reason, state pill, and a primary "Open Settings" button only where one is needed. Granted rows dim and their tile goes green. Microphone is tagged "Optional now" (macOS prompts on first dictation). The rebuild/stale-entry caveat moved out of the hero into a footnote, with a new line telling the user to quit and reopen after granting.

### Update — live activity on Home (pass-2 item 4)

`main.js` now pushes the coarse dictation state (`recording` / `transcribing` / `idle`) to the desktop window over the existing `dictation-state` channel (the overlay already got the fuller version). New `window.openstream.onDictationState` bridge. While the hotkey is held Home shows "Listening…" with the Mark pulsing; during transcription, "Transcribing…". Pulse respects `prefers-reduced-motion`.
