### PR TITLE
Pre-launch doc pass: README, roadmap, Phase 4 checkpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,71 +1,55 @@
 # OpenStream
 
-OpenStream is a local-first voice dictation app for Apple Silicon Macs. Hold a global hotkey, speak, then release it to place the transcript in the frontmost application. Audio and model requests stay on the Mac.
+OpenStream is a local-first voice dictation app for Apple Silicon Macs, built for developers. Hold a key, speak, release — the text lands in whatever app is frontmost. Audio and every model request stay on the machine.
 
-This repository is a development fork of [Nabzx/openstream](https://github.com/Nabzx/openstream). It now contains a runnable dictation path, an unsigned DMG build, and a tested completed-Dictation intake module. There is no published, signed release yet.
+Its one firm opinion: **a spoken line break is denied by default.** A newline can submit a half-typed terminal command or send an unfinished chat message, so OpenStream checks the frontmost app and the focused field before it turns "new paragraph" into a real break. It only survives in apps you have allow-listed.
 
-## What works
+## Features
 
-The current app can:
+- **Push-to-talk dictation** on a key you choose — standalone `Option` (default), `Command`, `Control`, `Fn`, `Caps Lock`, or `F1`–`F19`. Hold, speak, release; the transcript is placed at the cursor.
+- **Deny-by-default on line breaks** — a spoken break becomes a real newline only in break-safe apps; everywhere else the words run on. The allow-list is editable in Settings.
+- **Deterministic cleanup** — fillers, spoken punctuation, false starts and run-on segmentation are handled by a rules engine, not a model. No LLM rewrites your words. Sub-millisecond.
+- **Voice edits** — select text, hold the key, and speak a command from a fixed set: `snake case`, `camel case`, `wrap in backticks`, `bullet list`, and more. Pure string transforms, instant.
+- **`Escape` to cancel** a recording mid-flight — the audio is discarded, nothing is transcribed.
+- **Nothing leaves the machine** — `whisper.cpp` transcribes locally; a small local model places paragraph breaks in long dictations (sentence indices only, never text). No account, no cloud, no telemetry.
+- **A real desktop window** — Home and Settings, follows the system light/dark setting, opens on a Permissions screen if a grant is missing.
+- **Launch at login** — starts hidden in the menu bar.
 
-- run as a macOS menu bar app
-- listen for standalone `Option`, `Command`, `Control`, `Fn`, or `Caps Lock` through a native hotkey helper when macOS exposes the key
-- record while the hotkey is held and transcribe after release
-- keep `whisper-server` resident instead of loading it for each dictation
-- insert text at the cursor through a separate Accessibility helper
-- fall back from direct field writes to clipboard paste or synthesized keystrokes
-- show recording and transcription state in the tray, plus a small recording overlay
-- build an unsigned Apple Silicon DMG with `npm run dist`
+Planned, not yet in the app: codebase-vocabulary biasing (transcription weighted toward your project's identifiers), and semantic voice edits ("make this shorter") once a capable local model fills the rewrite role.
 
-The runnable path has tested rules cleanup and a completed-Dictation intake module. It covers Context detection, one-line fields, break-safe applications, paragraph break replies, Held results, failure outcomes, and FIFO processing of completed recordings.
+## Install
 
-## Why another dictation app
-
-Most dictation tools treat every target the same. That is risky when a newline can submit a terminal command or send a chat message. OpenStream is moving toward a deny-by-default rule for line breaks. It checks the frontmost app and focused field before deciding whether a break is safe.
-
-The planned product has two other developer-focused features:
-
-- codebase vocabulary biasing, using identifiers and project terms to improve transcription
-- voice edits, where selected text can be rewritten with a spoken command such as "make this a bullet list"
-
-Neither feature is available in the app yet.
-
-## Build and run
+OpenStream installs from source. There is a convenience DMG on the [releases page](https://github.com/Nabzx/openstream/releases), but it is unsigned — Gatekeeper will warn, and every rebuild resets the macOS permission grants (see below) — so `git clone` is the supported path.
 
 ### Requirements
 
-- Apple Silicon Mac
-- macOS 13 or newer
-- Node.js 20 or newer
+- Apple Silicon Mac, macOS 13 or newer
+- Node.js 22.12 or newer
 - Xcode Command Line Tools
 - CMake, Git, and curl
-- A network connection for model and server downloads during installation
-
-Clone this fork and install its dependencies:
+- A network connection during install, for the model and server downloads
 
 ```bash
-git clone https://github.com/Zazai840/openstream.git
+git clone https://github.com/Nabzx/openstream.git
 cd openstream
 npm install
 npm start
 ```
 
-`npm install` does more than install JavaScript packages. It:
+`npm install` does more than fetch JavaScript packages. It:
 
 - compiles a pinned `whisper.cpp` revision with Metal support
-- downloads and verifies the 141 MiB `ggml-base.en` model
+- downloads and verifies the 141 MiB `ggml-base.en` transcription model
 - compiles the Swift hotkey and Accessibility helpers
-- downloads and verifies `llama-server` and a roughly 1 GiB SmolLM2 model
+- downloads and verifies `llama-server` and a roughly 1 GiB SmolLM2 model for break placement
 
-The rewrite model files are prepared now. The app starts that server resident and uses it only for break placement during eligible long Dictations; it never rewrites dictated words.
-
-To run the Vite renderer and Electron in development mode:
+Development mode (Vite renderer + Electron):
 
 ```bash
 npm run dev
 ```
 
-To create an unsigned DMG under `release/`:
+Unsigned DMG under `release/`:
 
 ```bash
 npm run dist
@@ -73,43 +57,39 @@ npm run dist
 
 ### Releases
 
-Pushing a `v*` tag runs [`.github/workflows/release.yml`](.github/workflows/release.yml): it builds an unsigned arm64 DMG and publishes a GitHub release, using the tag's annotation as the notes. The DMG is a convenience download — Gatekeeper will warn on it (right-click → Open, or allow it in System Settings). The supported install is still `git clone` + `npm install`; a Homebrew formula waits on the signed-distribution decision ([#11](https://github.com/Nabzx/openstream/issues/11)).
-
-There is no code signing or notarization yet. macOS may block the DMG until you explicitly allow it.
+Pushing a `v*` tag runs [`.github/workflows/release.yml`](.github/workflows/release.yml): it builds an unsigned arm64 DMG and publishes a GitHub release with the tag annotation as the notes. A hyphenated tag (`v1.1.0-rc.1`) publishes as a pre-release. Code signing, notarisation, and a Homebrew cask wait on the signed-distribution decision ([#11](https://github.com/Nabzx/openstream/issues/11)); until then the DMG is a convenience download and `git clone` is the real install.
 
 ## First-run permissions
 
 OpenStream needs three macOS permissions:
 
-1. Microphone access for Electron.
-2. Input Monitoring for the hotkey helper.
-3. Accessibility for the text-insertion helper.
+1. **Microphone** — for Electron to hear you. macOS prompts the first time you dictate.
+2. **Input Monitoring** — for the hotkey helper to see the push-to-talk key.
+3. **Accessibility** — for the helper that places text at the cursor.
 
-After granting Input Monitoring and Accessibility, quit and restart the app. Click a text field, hold the configured standalone key, speak, and release it. Press `Escape` while the key is held to abort a recording without inserting anything. Existing saved combinations such as `Control+Option+D` remain usable until changed. Fn and Caps Lock depend on keyboard support and may not produce a usable event. A cold start can take 15 to 20 seconds while `whisper-server` loads its Metal shaders.
+On launch the app checks these: if Accessibility or Input Monitoring is missing it opens on a **Permissions** screen with a link straight to each System Settings pane. `npm run doctor` runs the same check from the terminal.
 
-On launch the app checks these grants: if Accessibility or Input Monitoring is missing it opens on a **Permissions** screen with links straight to the right System Settings pane. `npm run doctor` runs the same check from the terminal.
+After granting Input Monitoring and Accessibility, **quit and restart the app** so it picks up the change. Then click a text field, hold your key, speak, and release. Fn and Caps Lock depend on keyboard support and may not produce a usable event. A cold start takes 15–20 seconds while `whisper-server` loads its Metal shaders.
 
-**Because OpenStream runs from source, every rebuild resets the grants** (ad-hoc signing has no stable identity, so macOS re-keys the permission to the new binary). When you re-grant, **remove the old OpenStream entry in System Settings first**, then add the new build — macOS won't let a stale entry and a fresh one coexist.
-
-Source runs can be attributed to Terminal, Electron, or OpenStream in System Settings. Permission identity across rebuilds is still being worked out.
+**Because OpenStream runs from source, every rebuild resets the grants** — ad-hoc signing has no stable identity, so macOS re-keys the permission to the new binary. When you re-grant, **remove the old OpenStream entry in System Settings first**, then add the new build; macOS won't let a stale entry and a fresh one coexist.
 
 ## Startup
 
-- The menu bar icon appears immediately. The window opens only on the very first run, or when you pick **Open Window** from the tray / click the Dock icon.
-- Both model servers start resident at launch and stay up for the app's life — the `whisper-server` Metal warm-up (15–20 s) happens once, not per dictation.
-- **Launch at login** (Settings → Startup) opens OpenStream hidden — straight to the menu bar, no window. Model-server start is held back a few seconds so the warm-up doesn't fight everything else macOS is doing at login.
+- The menu bar icon appears immediately. The window opens on first run, from **Open Window** in the tray, or on a Dock-icon click.
+- Both model servers start resident at launch and stay up for the app's life — the `whisper-server` Metal warm-up happens once, not per dictation.
+- **Launch at login** (Settings → Startup) opens OpenStream hidden, straight to the menu bar. Model-server start is held back a few seconds so the warm-up doesn't fight the rest of login.
 - Closing the window backgrounds the app. Quit from the tray, the app menu, or `⌘Q`.
 
-## Design
+## How it works
 
-- **Electron and React** provide the menu bar shell, hidden capture window, overlay, and renderer.
-- **The transcription model server** is a pinned `whisper.cpp` build using `ggml-base.en`. Electron supervises it for the life of the app.
-- **Rules cleanup** removes fillers, handles spoken punctuation, fixes a small technical vocabulary list, and segments long run-on text. It is deterministic and tested against a sub-millisecond budget.
-- **The rewrite model server** uses `llama-server` with SmolLM2-1.7B-Instruct. It is resident while the app runs and handles paragraph break placement; explicit voice edits are planned, not available.
-- **Native helpers** keep Input Monitoring and Accessibility in separate processes. A blocked Accessibility call cannot disable the global hotkey event tap.
-- **The Dictation intake module** owns the completed-recording flow behind one interface. Transcription, Context detection, break placement, and delivery remain adapters; tray and Push-to-talk overlay state stays in the Electron shell.
+- **Electron + React** — the menu bar shell, the hidden capture window, the push-to-talk overlay, and the desktop window.
+- **Transcription model server** — a pinned `whisper.cpp` build on `ggml-base.en`, supervised for the life of the app.
+- **Rules cleanup** — deterministic: fillers, spoken punctuation, a small technical vocabulary, run-on segmentation. Tested against a sub-millisecond budget. See [ADR-0001](docs/adr/0001-no-llm-in-the-dictation-path.md) and [ADR-0002](docs/adr/0002-no-one-model-dictation-engine.md).
+- **Rewrite model server** — `llama-server` with SmolLM2-1.7B, resident, used only to place paragraph breaks in eligible long dictations. It returns sentence numbers, never text.
+- **Native helpers** — Input Monitoring and Accessibility live in separate Swift processes. A blocked Accessibility call cannot take down the global hotkey.
+- **The dictation intake module** owns the completed-recording flow behind one interface; transcription, context detection, break placement, and delivery are adapters behind it.
 
-See [CONTEXT.md](CONTEXT.md) for the project's terms, [ROADMAP.md](ROADMAP.md) for the longer plan, and the ADRs for the pipeline decisions: [ADR-0001](docs/adr/0001-no-llm-in-the-dictation-path.md) (cleanup is rules-only) and [ADR-0002](docs/adr/0002-no-one-model-dictation-engine.md) (dictation stays a transcription stage plus deterministic cleanup, not one model). For a full walkthrough of the architecture, the trade-offs behind it, and where the project actually stands against the roadmap, see [docs/progress/](docs/progress/) - a dated checkpoint per phase, most recent first: [phase-3-progress.md](docs/progress/phase-3-progress.md), [phase-2-progress.md](docs/progress/phase-2-progress.md), [phase-1-progress.md](docs/progress/phase-1-progress.md).
+See [CONTEXT.md](CONTEXT.md) for the project's vocabulary, [ROADMAP.md](ROADMAP.md) for the plan, and [docs/progress/](docs/progress/) for dated engineering checkpoints — most recent first: [phase-4](docs/progress/phase-4-progress.md), [phase-3](docs/progress/phase-3-progress.md), [phase-2](docs/progress/phase-2-progress.md), [phase-1](docs/progress/phase-1-progress.md).
 
 ## Tests
 
@@ -119,13 +99,11 @@ npm run typecheck
 npm run build
 ```
 
-The global hotkey, macOS permission prompts, microphone capture, and insertion into other applications still need a real Mac and a human check. Run [`scripts/verify-dictation-pipeline.sh`](scripts/verify-dictation-pipeline.sh); the [pipeline notes](docs/testing/hotkey-transcribe-manual-check.md) explain what it measures. The [shortcut verification notes](docs/testing/settings-hotkey-remap-manual-check.md) contain the conditional-key matrix and replacement checks.
+The global hotkey, macOS permission prompts, microphone capture, and insertion into other apps need a real Mac and a human. The checklists in [docs/testing/](docs/testing/) cover the end-to-end dictation pass, the shortcut matrix, voice edits, IDE-terminal dictation, and the break-safe apps setting.
 
-## Project status
+## Status
 
-OpenStream is pre-alpha. The main slice works from source, but installation, permission handling, delivery recovery, and context-aware cleanup are unfinished. The app is not ready for everyday use or outside contributors yet.
-
-Upstream issue history records most of the design work. Changes specific to this fork should target `Zazai840/openstream`, not the upstream repository.
+Feature-complete for 1.0. The pipeline, the settings UI, the permissions gate, and release automation are all in place; the final on-device verification pass ([#228](https://github.com/Nabzx/openstream/issues/228)) is what stands between here and the `v1.0.0` tag.
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -76,14 +76,25 @@ See [docs/progress/phase-3-progress.md](docs/progress/phase-3-progress.md) for t
 
 ## Phase 4 — v1.0: Polish & launch (both, target: 1-2 weeks)
 
-- [ ] Code signing + notarization, Homebrew cask, `electron-updater` auto-update ([#11](https://github.com/Nabzx/openstream/issues/11)) - **moved here from Phase 2.** Signing/distribution choices are cheapest to keep open for as long as possible; committing to them before the app itself is ready to ship just locks in decisions early for no benefit
-- [ ] Permission state check - build script warns when the **Electron host bundle's** code identity changes (not the helpers': #46 measured that all three grants live on the host, so a helper hash is the wrong thing to watch), app tests all three grants at launch by **probing them functionally** (a System Settings toggle can read ON while the binary is denied) and blocks on Accessibility / Input Monitoring (#47, pending #88)
-- [ ] Settings UI complete (hotkey remapping, the user-editable break-safe app list) - **no mode rules** (#45) and **no model choice** (#30)
-- [ ] Release automation (GitHub Releases + Homebrew formula bump on tag, `electron-builder` pipeline)
-- [ ] README demo GIF, short landing page
-- [ ] Public launch (Show HN, r/macapps, etc.)
+- [x] **Permission state check** — the app probes all three grants at launch (functionally, since a System Settings toggle can read ON while the binary is denied) and blocks on Accessibility / Input Monitoring, opening on a Permissions screen; `npm run doctor` runs the same check from the terminal ([#47](https://github.com/Nabzx/openstream/issues/47)). The rebuild/TCC-identity problem ([#46](https://github.com/Nabzx/openstream/issues/46), [#88](https://github.com/Nabzx/openstream/issues/88)) is documented, not solved — it is a source-only fact of life.
+- [x] **Settings UI complete** — hotkey remapping (Zazai's [#218](https://github.com/Nabzx/openstream/issues/218)), the user-editable break-safe app list with a native app picker ([#19](https://github.com/Nabzx/openstream/issues/19)), and launch-at-login ([#135](https://github.com/Nabzx/openstream/issues/135)). No mode rules ([#45](https://github.com/Nabzx/openstream/issues/45)), no model choice ([#30](https://github.com/Nabzx/openstream/issues/30)).
+- [x] **Release automation** — a `v*` tag builds an unsigned arm64 DMG and cuts a GitHub release; hyphenated tags publish as pre-releases ([#20](https://github.com/Nabzx/openstream/issues/20), proven end to end with a `v0.4.0-rc.1` dry run). No Homebrew bump yet — that waits on signing.
+- [x] **Window redesign** — the desktop window got a real visual pass: refreshed tokens, an app mark, a calmer Home page, a proper Permissions gate screen, live dictation activity ([#242](https://github.com/Nabzx/openstream/issues/242), and the app/menu-bar icons in [#244](https://github.com/Nabzx/openstream/issues/244)).
+- [x] **Track-A pipeline fixes** — Escape-to-cancel ([#134](https://github.com/Nabzx/openstream/issues/134)), the AX-readiness fallback so a slow Chromium tree no longer fails a dictation ([#181](https://github.com/Nabzx/openstream/issues/181)), and the IDE-terminal delivery gaps ([#227](https://github.com/Nabzx/openstream/issues/227)).
+- [x] **Short landing page** ([#21](https://github.com/Nabzx/openstream/issues/21)) — `site/index.html`. The demo GIF is still outstanding.
+- [ ] **Pre-launch manual verification pass** ([#228](https://github.com/Nabzx/openstream/issues/228)) — the checks CI cannot drive, against the near-final build: the voice-edit matrix, IDE-terminal dictation, end-to-end dictation + latency, the shortcut matrix, the break-safe apps setting. This is what stands between here and the tag.
+- [ ] **Demo GIF** — a short screen recording of a real dictation, into the README and the landing page.
+- [ ] **Real-dictation eval corpus** ([#171](https://github.com/Nabzx/openstream/issues/171)) — human-recorded clips for the rules-cleanup fixture. Clears the one deliberately-red test; can slip to a point release.
+- [ ] **Public launch** ([#22](https://github.com/Nabzx/openstream/issues/22)) — Show HN, r/macapps, etc.
 
-**Definition of done:** something you'd hand to a stranger without caveats. Tag `v1.0`.
+**Deferred out of v1.0:**
+
+- **Code signing, notarisation, Homebrew cask, auto-update** ([#11](https://github.com/Nabzx/openstream/issues/11)) — v1.0 distributes from source ([#37](https://github.com/Nabzx/openstream/issues/37)), so committing to a signing identity and a cask buys nothing yet. First v1.1 item.
+- **Semantic voice edits** ([#222](https://github.com/Nabzx/openstream/issues/222)) — the deterministic command subset ships; "make this shorter" waits on a capable local rewrite model.
+
+**Definition of done:** something you'd hand to a stranger without caveats. Tag `v1.0.0` once [#228](https://github.com/Nabzx/openstream/issues/228) passes.
+
+See [docs/progress/phase-4-progress.md](docs/progress/phase-4-progress.md) for the full checkpoint.
 
 ---
 
@@ -91,4 +102,13 @@ See [docs/progress/phase-3-progress.md](docs/progress/phase-3-progress.md) for t
 
 Open to outside contributors. Backlog candidates: Linux/Windows ports, per-project config files, custom wake-word-free modes, team-shared vocabulary packs. Not scoped yet — revisit after launch feedback.
 
-- **Codebase vocabulary scanner** ([#16](https://github.com/Nabzx/openstream/issues/16)) - moved here from Phase 3. Built, not shipped: the scanning/caching/pipeline wiring exists and is tested (PR #185), the Settings UI is unhooked. Before re-enabling: confirm a live dictation with a configured project path actually gets the biased prompt end to end (a `vocabulary.promptLength` diagnostic exists for exactly this check and hasn't been read back yet).
+### v1.1 candidates
+
+- **Code signing + notarisation + Homebrew cask + `electron-updater`** ([#11](https://github.com/Nabzx/openstream/issues/11)) — the first thing that makes the DMG a real install path and fixes the rebuild-resets-grants problem ([#46](https://github.com/Nabzx/openstream/issues/46), [#88](https://github.com/Nabzx/openstream/issues/88)) for people who don't build from source.
+- **Parakeet TDT 0.6B v3 as the transcription model server** ([#176](https://github.com/Nabzx/openstream/issues/176), [#204](https://github.com/Nabzx/openstream/issues/204), [#205](https://github.com/Nabzx/openstream/issues/205)) — replace `whisper base.en`. The pipeline shape does not change ([ADR-0002](docs/adr/0002-no-one-model-dictation-engine.md)): Parakeet emits raw text, Rules cleanup still does all cleanup. The gate is proving a local runtime on Apple Silicon (NeMo-Speech.cpp / sherpa-onnx / parakeet-mlx are candidates; none built yet) and measuring latency, memory, and artifact size against the contract. [#178](https://github.com/Nabzx/openstream/issues/178) already rejected Parakeet as a *one-model* engine.
+- **Semantic voice edits** ([#222](https://github.com/Nabzx/openstream/issues/222)) — re-test a spoken rewrite command ("shorter", "fix grammar") against Qwen3-1.7B / Granite-3.3-2B in the rewrite role.
+
+### Backlog
+
+- **Codebase vocabulary scanner** ([#16](https://github.com/Nabzx/openstream/issues/16)) — moved here from Phase 3. Built, not shipped: the scanning/caching/pipeline wiring exists and is tested (PR #185), the Settings UI is unhooked. Before re-enabling: confirm a live dictation with a configured project path actually gets the biased prompt end to end (a `vocabulary.promptLength` diagnostic exists for exactly this check and hasn't been read back yet).
+- **Recording history / replay last transcription** ([#136](https://github.com/Nabzx/openstream/issues/136)), **microphone device selector** ([#137](https://github.com/Nabzx/openstream/issues/137)), **crash reporting** ([#138](https://github.com/Nabzx/openstream/issues/138)).

--- a/docs/progress/phase-4-progress.md
+++ b/docs/progress/phase-4-progress.md
@@ -1,0 +1,173 @@
+# OpenStream — Engineering Deep Dive (Phase 4 checkpoint)
+
+Same purpose as the others: so either of us can explain this project in depth, from memory, in an interview. Not marketing copy — where something is fragile or deferred, it says so.
+
+This is the fourth checkpoint in `docs/progress/` — written with Phase 4 **feature-complete for `v1.0`** and the final on-device verification pass ([#228](https://github.com/Nabzx/openstream/issues/228)) still outstanding. [phase-3-progress.md](phase-3-progress.md) is the previous one. Where a section hasn't materially changed it says so.
+
+**Contents**
+1. [What OpenStream is](#1-what-openstream-is)
+2. [Tech stack, and what changed](#2-tech-stack-and-what-changed)
+3. [Process architecture](#3-process-architecture)
+4. [Walking one dictation, end to end](#4-walking-one-dictation-end-to-end)
+5. [New architectural decisions and findings this phase](#5-new-architectural-decisions-and-findings-this-phase)
+6. [Testing philosophy](#6-testing-philosophy)
+7. [How we work: process and rigor](#7-how-we-work-process-and-rigor)
+8. [Vocabulary](#8-vocabulary)
+9. [War stories worth telling in an interview](#9-war-stories-worth-telling-in-an-interview)
+10. [Where we actually are vs. the roadmap](#10-where-we-actually-are-vs-the-roadmap)
+11. [What's unfinished, fragile, or deliberately deferred](#11-whats-unfinished-fragile-or-deliberately-deferred)
+12. [File map](#12-file-map)
+
+---
+
+## 1. What OpenStream is
+
+Unchanged — a **local-first voice dictation app for Apple Silicon Macs**, aimed at developers, **deny-by-default on line breaks**. See [phase-1-progress.md §1](phase-1-progress.md#1-what-openstream-is).
+
+What's different: nothing about the *product* changed this phase. Phase 4 is polish — the app is now something you could hand to a stranger. Both headline features (dictation, voice editing) shipped in earlier phases; Phase 4 added the launch surface around them: a permission gate, a finished settings screen, a redesigned window with real visual identity, release automation, and the pipeline-robustness fixes that turn "works on my machine" into "works from a VS Code terminal too".
+
+## 2. Tech stack, and what changed
+
+Full table in [phase-1-progress.md §2](phase-1-progress.md#2-tech-stack-and-why-each-piece). This phase:
+
+- **`engines` bumped to Node ≥ 22.12** (was 20). CI runs 22.12.
+- **The renderer grew a third page and real chrome.** `src/pages/Permissions.tsx` (the gate screen #47 opens on), `src/components/Mark.tsx` (the app mark — a caret in a listening ring), a `dictation-state` IPC subscription so Home reflects live activity, a native app picker for the break-safe list (`electron/appBundleId.js` reads `CFBundleIdentifier` via `defaults read`), a `localStorage`-backed disclosure on the System card. `src/index.css` went from the Phase-3 token stub to a considered light/dark system with hairline cards, hover/focus states, and a pulse animation.
+- **Two new pure Electron modules.** `electron/permissions.js` — `evaluatePermissions(raw)`, a pure verdict function (`granted` / `missing` / `unknown` per grant, `blocking` vs `warnings`). `electron/appBundleId.js` — the bundle-id reader, execFile injected for tests.
+- **A release workflow.** `.github/workflows/release.yml` — a `v*` tag builds an unsigned arm64 DMG and cuts a GitHub release; hyphenated tags publish as pre-releases.
+- **An icon toolchain.** `assets/icon.svg` is the source; `scripts/build-icons.sh` rasterises it (rsvg-convert + iconutil) into `assets/icon.icns` and the menu-bar PNGs. Run by hand, not wired into the build.
+- **Testing grew from ~223 to ~248 `node --test` cases plus 116 Vitest** — new suites for the permission verdict, the bundle-id reader, the injection-path retry, and the window redesign paths.
+
+## 3. Process architecture
+
+Unchanged in shape — see [phase-1-progress.md §3](phase-1-progress.md#3-process-architecture--the-eight-things-running-at-once). The accessibility-helper gained:
+
+- a **`permissions` command** (#47) — emits `AXIsProcessTrusted()` and `IOHIDCheckAccess(kIOHIDRequestTypeListenEvent)`, the two grants the pipeline depends on, read from the process macOS actually attributes them to.
+- an **enriched `context` error reply** (#227) — a hard failure now carries `trusted` and an accurate reason (`no frontmost application`, not the old misleading `focused element unavailable`).
+
+`RealFocusResolver` now retries a not-yet-ready AX tree within a budget on **both** paths: context detection (`axReadyBudgetMs`, 250 ms — #181) and the injection path (`axInjectBudgetMs`, 200 ms — #227). The injection engine had no retry before; a slow Electron target lost the dictation even when the tree came good a beat later.
+
+## 4. Walking one dictation, end to end
+
+The path is unchanged from [phase-2-progress.md §4](phase-2-progress.md#4-walking-one-dictation-end-to-end). Two robustness changes this phase:
+
+- **Context detection no longer hard-fails.** If the focused element isn't AX-ready inside the budget, `focusContext` returns `(bundleId, isOneLineField: true, axReady: false)` — an unknown-field context that denies line breaks — and the dictation proceeds, rather than ending as a silent `failed` (#181).
+- **A context read that fails outright now holds the transcript.** Helper down, or nothing frontmost → the words are cleaned with safe defaults and returned as a **Held result** for manual paste, not dropped (#227). And `main.js` logs one `[dictation] outcome: …` line per attempt, so one failed dictation on a real Mac names the stage.
+
+## 5. New architectural decisions and findings this phase
+
+### #47: permission identity across rebuilds is a source-only fact of life, not a bug to fix
+
+The Phase-2 open question was whether the Electron host bundle could keep a TCC-stable code identity across rebuilds (#88). It can't, not without a real signing identity — ad-hoc signing has no stable CDHash, so every `npm install` re-keys the grant to a new binary. Rather than chase that, #47 does the two things that work regardless: the app **probes** all three grants functionally at launch (a System Settings toggle can read ON while the binary is denied), **blocks** on Accessibility / Input Monitoring by opening on the Permissions screen, and ships `npm run doctor` for the same check from the terminal. The honest "remove the stale OpenStream entry in System Settings first, then re-add" workflow is documented in the README and on the Permissions screen. The real fix is signing (#11), deferred to v1.1.
+
+### #181 / #227: the injection path got the retry that context detection already had
+
+#173 (Phase 3) fixed the app-switch tracker. #181 then found context detection still hard-failed when the focused element wasn't AX-ready in time — common for a cold Chromium/Electron tree, measured at 5+ seconds in `prototypes/electron-ax-tree-10`. Fix: a bounded retry, then fall back to an unknown-field context. #227 — "dictation produces no visible text when launched from a VS Code terminal" — turned out to be the same class of problem one layer down: the **injection** path did a single-shot focus read with no retry, so a target whose tree wasn't up on the first read fell straight through to blind-paste-or-hold. It now retries within its own (shorter, latency-sensitive) budget. What remains on #227 is a real-Mac diagnostic pass to confirm nothing else is wrong — folded into #228.
+
+### ADR-0002: the one-model dictation engine was rejected by its own benchmark
+
+The [#176](https://github.com/Nabzx/openstream/issues/176) map asked whether a single local speech model could be OpenStream's whole ordinary-dictation engine — collapsing transcription and Rules cleanup into one model that emits final text. #178 benchmarked the budget-fitting candidates (Parakeet TDT 0.6B v3, Nemotron 3.5 ASR 0.6B; Canary-1B-v2 was already out on size) and **rejected the approach**: they emit literal ASR — fillers, "scratch that", spoken punctuation all pass through — and Nemotron misses the long-dictation latency target. [ADR-0002](../adr/0002-no-one-model-dictation-engine.md) fixes ordinary dictation as two stages (transcription model server + deterministic Rules cleanup), confirming and extending ADR-0001. Using Parakeet *as the transcription model server alone* — keeping the two-stage shape — is a separate, still-open question deferred to v1.1 (#204, #205).
+
+### Release automation, proven before it was needed
+
+#20's workflow was validated with a `v0.4.0-rc.1` dry-run tag, then deleted. The dry run surfaced two real bugs that a first `v1.0.0` tag would otherwise have hit: `npm version` rejects `X.Y-rc` style tags (must be full semver `X.Y.Z-rc.N`), and `softprops/action-gh-release` published every tag as a full release until a `prerelease:` guard was added for hyphenated tags.
+
+### The window redesign
+
+Not a research decision, but the phase's largest single change. The Phase-3 window was a functional System-Settings clone; Phase 4 gave it identity: the **Mark** (a monoline caret-in-a-ring, reused across the window, the menu bar, and the app icon), a calmer Home that leads with a ready state and collapses its detail rows, a proper **Permissions gate screen** (progress line, per-permission cards, footnoted caveats), and **live dictation activity** — Home shows "Listening…" with the Mark pulsing while the key is held. Done as an iterative pass with a preview artifact reviewed between steps rather than one big drop.
+
+## 6. Testing philosophy
+
+Core discipline unchanged — [phase-1-progress.md §6](phase-1-progress.md#6-testing-philosophy).
+
+- **CI runs the build, not the suite.** `build.yml` does `npm ci && npm run build` (which typechecks and bundles the renderer, and `postinstall` compiles all four native pieces). It does **not** run `npm test`. The test suite is a local gate. This is a known gap — a `npm test` step belongs in CI.
+- **#186 cleared the one deterministic Node-22 failure.** `breakPlacementHttpAdapter`'s timeout test leaned on a real `AbortSignal.timeout()` whose unref'd timer trips `node --test`'s completion heuristic on Node 22. Fixed by injecting the timeout signal so the test drives the abort itself.
+- **One test is deliberately red.** `electron/cleanup/realDictation.test.js` fails until #171 adds recorded dictation clips to the fixture corpus. It is a reminder, not a regression.
+- **Manual verification is still the gate.** The voice-edit matrix, IDE-terminal dictation, end-to-end dictation + latency, the shortcut matrix, and the break-safe apps setting all need a real Mac and real apps. Batched into #228, run against the near-final build, before the `v1.0.0` tag.
+
+## 7. How we work: process and rigor
+
+Same foundation — [phase-1-progress.md §7](phase-1-progress.md#7-how-we-work-process-and-rigor). This phase:
+
+- **Prove the release path before you need it.** The `v0.4.0-rc.1` dry run is the pattern — a throwaway tag that exercised `npm ci` → version-from-tag → build → DMG → GitHub release end to end, found two bugs, and was deleted. Cheaper than debugging the real `v1.0.0` tag under launch pressure.
+- **The Zazai / hotkey carve-out held.** The parallel shortcut rewrite (#215–#219) stayed entirely Zazai's; Phase 4 work — including the settings UI (#19) and the window redesign (#242) — did not touch `HotkeySettings.tsx`, `hotkeyHelper.js`, or `pushToTalkShortcutController.js`. `HotkeySettings.tsx` is now styled to match the rest of the page **through CSS only**; its markup is still exactly as the shortcut work left it.
+- **The UI pass was iterative and reviewed.** Six commits, each with a preview artifact, each confirmed before the next. Not a single "here's the redesign" drop.
+- **Decisions recorded as ADRs.** ADR-0002 is the second; the pattern (a `>` supersession note, evidence, a `## Consequences` list) is now established.
+
+## 8. Vocabulary
+
+No additions to `CONTEXT.md` this phase — Phase 3's voice-editing terms and the model-role names all still hold. The one term worth re-stating: the **transcription model server** and the **rewrite model server** are named by role, not by the model in them. ADR-0002 makes that concrete — whisper `base.en` fills the transcription role today, Parakeet is a v1.1 candidate for it, and the two-stage shape is fixed regardless of which model occupies the role.
+
+## 9. War stories worth telling in an interview
+
+- **The release dry-run that found two bugs before the real tag.** A throwaway `v0.4.0-rc.1` tag, cut purely to exercise the pipeline, hit both a semver-format bug in the version step and a missing pre-release flag — either of which would have been a bad first impression on the `v1.0.0` release. Good material for "how do you de-risk a release".
+- **The fix was to give the injection path what context detection already had.** #227's "no visible text from a VS Code terminal" sounded like a new bug. It was the same not-ready-AX-tree problem #181 had already solved for *context detection* — the *injection* path just never got the retry. The fix was 20 lines and a config value, and the lesson is to look for the pattern you've already seen before assuming a new failure mode.
+- **The map's destination was superseded by its own benchmark.** #176 was scoped around choosing a one-model dictation engine. The benchmark it commissioned (#178) concluded no such model qualifies. ADR-0002 records that, and the map now needs re-pointing at a narrower question. "Sometimes the research answers a different question than the one you asked" — and that's a good outcome, not a failure.
+- **See also** the Phase 2 and Phase 3 war stories — the three-layer llama-server path bug, the spike that killed its own feature (voice editing), the `Co-authored-by: Claude` trailer that wouldn't stay removed.
+
+## 10. Where we actually are vs. the roadmap
+
+- **Phases 0–3 — done, tagged** (`v0.1` … `v0.3`). Unchanged.
+- **Phase 4 (v1.0: polish & launch) — feature-complete, not tagged.**
+  - Permission gate + doctor (#47), settings UI complete (#19 + Zazai's #218 + #135), release automation (#20), window redesign (#242 + #244), the Track-A pipeline fixes (#134, #181, #227) — all **done, merged**.
+  - Landing page (#21) done; the **demo GIF** is outstanding.
+  - **#228** (the manual verification pass), **#171** (the eval corpus), and **#22** (the launch itself) are what's left.
+  - **Explicitly deferred to v1.1:** code signing / notarisation / Homebrew / auto-update (#11), Parakeet as the transcription model (#176/#204/#205), semantic voice edits (#222).
+
+The honest one-sentence summary: **the app is code-complete for `v1.0`; what stands between here and the tag is one on-device verification pass and a screen recording.**
+
+## 11. What's unfinished, fragile, or deliberately deferred
+
+Carried forward from [phase-3-progress.md §11](phase-3-progress.md#11-whats-unfinished-fragile-or-deliberately-deferred), still true: no code signing (permission identity across rebuilds unresolved as a consequence), cold start slow, the run-on splitter a known-imperfect heuristic, no automated latency regression test, no `.nvmrc`.
+
+New or changed this phase:
+
+- **CI does not run the test suite** — only the build. A `npm test` step belongs in `build.yml`.
+- **The DMG is ~1.3 GB** — it bundles the compiled `whisper.cpp`, `ggml-base.en` (141 MiB), and the SmolLM2 GGUF (~1 GB). Fine as a convenience download; a lean DMG that fetches models on first run would reopen #30.
+- **Parakeet's runtime is unproven.** #203 called NeMo-Speech.cpp "plausible" for Apple Silicon; nobody has built it, or sherpa-onnx, or parakeet-mlx. The v1.1 transcription-model swap is gated on that spike.
+- **#227 needs a real-Mac confirmation.** The code gaps are fixed; whether anything else is wrong (a lost grant, wrong-app resolution) needs the diagnostic pass in #228.
+- **`HotkeySettings.tsx` markup is still Zazai's** — styled to match via CSS, but a proper restyle into the card system waits on the shortcut work fully settling.
+- **`#171`'s fixture corpus is empty** — one test stays red until it's filled.
+- **The recording/transcribing menu-bar icons are outline glyphs now**, not the old solid dots — slightly quieter in the menu bar. Worth a look during #228.
+
+## 12. File map
+
+Extends [phase-3-progress.md §12](phase-3-progress.md#12-file-map). Additions this phase:
+
+```
+electron/
+  permissions.js               — pure evaluatePermissions(raw) → verdict (granted/missing/unknown, blocking vs warnings) (#47)
+  appBundleId.js               — reads an .app's CFBundleIdentifier via `defaults read`, execFile injected (#19)
+  accessibilityHelper.js       — + getPermissions(); context error carries `trusted` (#47, #227)
+
+native/accessibility-helper/
+  Sources/.../Config.swift      — + axInjectBudgetMs (the injection-path AX retry budget) (#227)
+  Sources/.../InjectionEngine.swift — decide() retries focus resolution within the budget (#227)
+  Sources/.../RealAdapters.swift — focusContext falls back to an unknown-field context on timeout (#181)
+  Sources/accessibility-helper/main.swift — + the `permissions` command (#47)
+
+src/
+  pages/Permissions.tsx        — the gate screen the app opens on when blocked (#47), redesigned (#242)
+  components/Mark.tsx          — the app mark: a caret in a listening ring (#242)
+  index.css                    — the refreshed token system, cards, states, the mark pulse (#242)
+
+scripts/
+  doctor.mjs                   — `npm run doctor`: the launch permission check from the terminal (#47)
+  build-icons.sh               — rasterises assets/icon.svg into the .icns and menu-bar PNGs (#244)
+
+assets/icon.svg                — the app-icon source artwork (#244)
+
+.github/workflows/release.yml   — v* tag → unsigned DMG + GitHub release; hyphenated tags are pre-releases (#20)
+
+docs/
+  adr/0002-no-one-model-dictation-engine.md      — dictation stays two-stage; one-model rejected (#188, #178)
+  testing/ide-terminal-dictation-227.md          — repro + console-reading guide for #227
+  testing/break-safe-apps-settings-19.md          — the break-safe apps manual check
+  progress/phase-4-progress.md                    — this file
+
+site/
+  index.html                   — the launch landing page (#21)
+```
+
+---
+
+*Keep this current as the project moves past what it describes. When `v1.0` ships, this checkpoint gets a short "what the verification pass found" addendum rather than a rewrite.*


### PR DESCRIPTION
The documentation half of pre-launch.

- **README** — rewritten for launch. Accurate feature list (voice edits, the desktop window, the permissions gate, Escape-to-cancel, launch-at-login are all in now), Node 22.12 requirement, clone URL fixed to the origin, the stale "planned, not available" lines corrected, and a Status section that is honest that the v1.0.0 tag waits on #228.
- **ROADMAP** — Phase 4 items checked off with what shipped; a "Deferred out of v1.0" note (#11, #222); an "After v1.0 / v1.1 candidates" section that names the Parakeet transcription-model swap (#176/#204/#205), signing (#11), and semantic voice edits (#222).
- **docs/progress/phase-4-progress.md** — the fourth engineering checkpoint, same 12-section shape as the others: #47 (permission identity is a source-only fact), #181/#227 (the injection path got the retry context detection already had), ADR-0002, the release dry-run, the window redesign, and an honest unfinished list.

Docs only. Renderer build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)