### PR TITLE
Add a Commands tab + broaden the spoken bullet command (#246)

### DIFF
--- a/electron/cleanup/rules.js
+++ b/electron/cleanup/rules.js
@@ -34,7 +34,11 @@ const SPOKEN_PUNCT = [
   // are. Also scoped to bullets only, not numbered lists - a "1. 2. 3."
   // marker needs a running counter across matches, a different shape of
   // transformation than this table's stateless single-token replace.
-  [/\b(bullet point|new bullet)\b/gi, "\n- "],
+  // "bullet point", "bullet points", "new bullet", "next bullet",
+  // "new bullet point" - the natural variants people reach for. All are
+  // explicit list commands, unlikely in ordinary prose; the plural
+  // "bullet points" is the one people say most and was missing.
+  [/\b(?:bullet points?|(?:new|next) bullets?(?: points?)?)\b/gi, "\n- "],
   [/\bfull stop\b/gi, "."],
   [/\bperiod\b/gi, "."],
   [/\bcomma\b/gi, ","],

--- a/electron/cleanup/rules.test.js
+++ b/electron/cleanup/rules.test.js
@@ -188,6 +188,15 @@ test("bullet point / new bullet start a markdown list, break-safe only", () => {
   assert.equal(outAlt, "Shopping list\n- Milk\n- Eggs.");
 });
 
+test("the natural bullet variants all start a list item", () => {
+  for (const phrase of ["bullet points", "next bullet", "new bullet point"]) {
+    const out = cleanup(`list ${phrase} milk ${phrase} eggs`, { breakSafe: true });
+    assert.equal(out, "List\n- Milk\n- Eggs.", `variant: ${phrase}`);
+  }
+  // "bulletin" must not be mistaken for a bullet command.
+  assert.equal(cleanup("the bulletin points to a bug", { breakSafe: true }), "The bulletin points to a bug.");
+});
+
 test("bullet point outside a break-safe app degrades to flowing prose, no dash leaks in", () => {
   const out = cleanup("shopping list bullet point milk bullet point eggs");
   assert.equal(out, "Shopping list milk eggs.");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,14 @@
 import { useEffect, useState } from "react";
 import { coercePage, TAB_PAGES, type Page, type TabPage } from "./nav";
-import { HomeIcon, SettingsIcon } from "./components/Icons";
+import { CommandsIcon, HomeIcon, SettingsIcon } from "./components/Icons";
 import Home from "./pages/Home";
+import Commands from "./pages/Commands";
 import Settings from "./pages/Settings";
 import Permissions from "./pages/Permissions";
 
 const TAB_META: Record<TabPage, { label: string; Icon: (props: { className?: string }) => JSX.Element }> = {
   home: { label: "Home", Icon: HomeIcon },
+  commands: { label: "Commands", Icon: CommandsIcon },
   settings: { label: "Settings", Icon: SettingsIcon },
 };
 
@@ -38,6 +40,7 @@ export default function App() {
         })}
       </nav>
       {page === "settings" && <Settings />}
+      {page === "commands" && <Commands />}
       {page === "permissions" && <Permissions onDone={() => setPage("home")} />}
       {page === "home" && <Home navigate={(next) => setPage(next)} />}
     </div>

--- a/src/commandReference.ts
+++ b/src/commandReference.ts
@@ -1,0 +1,149 @@
+// The spoken commands OpenStream understands, for the Commands page.
+//
+// Source of truth for the behaviour is `electron/cleanup/rules.js`
+// (while dictating) and `electron/voiceEditCommands.js` (editing a
+// selection). This file is the human-facing description of those tables —
+// keep it in step when either changes.
+
+export type Command = {
+  /** what the user says, without quotes — the page adds them */
+  say: string;
+  /** what it produces; `mono` when that is literal output rather than prose */
+  becomes: string;
+  mono?: boolean;
+};
+
+export type CommandGroup = {
+  title: string;
+  note?: string;
+  commands: Command[];
+};
+
+export type CommandSection = {
+  title: string;
+  note: string;
+  groups: CommandGroup[];
+};
+
+export const COMMAND_SECTIONS: CommandSection[] = [
+  {
+    title: "While dictating",
+    note: "Say these as part of a normal dictation.",
+    groups: [
+      {
+        title: "Line breaks & lists",
+        note: "Only in break-safe apps. Everywhere else the words run on, so a stray break can't submit a command or send a message.",
+        commands: [
+          { say: "new paragraph", becomes: "a blank line" },
+          { say: "new line", becomes: "a line break" },
+          { say: "bullet point", becomes: "a “- ” list item", mono: false },
+          { say: "bullet points", becomes: "same — the plural works too" },
+          { say: "tab", becomes: "an indent (at the start of a phrase)" },
+        ],
+      },
+      {
+        title: "Punctuation",
+        commands: [
+          { say: "period  ·  full stop", becomes: ".", mono: true },
+          { say: "comma", becomes: ",", mono: true },
+          { say: "question mark", becomes: "?", mono: true },
+          { say: "exclamation mark  ·  exclamation point", becomes: "!", mono: true },
+          { say: "colon", becomes: ":", mono: true },
+          { say: "semicolon", becomes: ";", mono: true },
+          { say: "open paren  ·  close paren", becomes: "(   )", mono: true },
+          { say: "dash", becomes: "-", mono: true },
+          { say: "slash", becomes: "/", mono: true },
+        ],
+      },
+      {
+        title: "Symbols",
+        commands: [
+          { say: "percent", becomes: "%", mono: true },
+          { say: "dollar sign", becomes: "$", mono: true },
+          { say: "at sign", becomes: "@", mono: true },
+          { say: "hashtag", becomes: "#", mono: true },
+          { say: "open brace  ·  close brace", becomes: "{   }", mono: true },
+          { say: "open bracket  ·  close bracket", becomes: "[   ]", mono: true },
+        ],
+      },
+      {
+        title: "Emoji",
+        note: "Always ends with the word “emoji”, so an ordinary “my heart is racing” never turns into a symbol.",
+        commands: [
+          { say: "smiley face emoji", becomes: "🙂", mono: true },
+          { say: "heart emoji", becomes: "❤️", mono: true },
+          { say: "thumbs up emoji  ·  thumbs down emoji", becomes: "👍   👎", mono: true },
+          { say: "laughing emoji", becomes: "😂", mono: true },
+          { say: "crying emoji", becomes: "😢", mono: true },
+          { say: "fire emoji", becomes: "🔥", mono: true },
+          { say: "hundred emoji", becomes: "💯", mono: true },
+        ],
+      },
+      {
+        title: "Corrections",
+        commands: [
+          {
+            say: "scratch that  ·  delete that",
+            becomes: "removes what you just said — the whole phrase before it, not only these words",
+          },
+        ],
+      },
+      {
+        title: "Quoting, spelling & numbers",
+        commands: [
+          { say: "quote … end quote", becomes: "wraps what's between them in “…”", mono: false },
+          { say: "spell, then the letters", becomes: "“spell J O H N” → John", mono: false },
+          { say: "fifty dollars", becomes: "$50", mono: true },
+          { say: "three dollars and twenty cents", becomes: "$3.20", mono: true },
+        ],
+      },
+      {
+        title: "Automatic",
+        note: "No command needed.",
+        commands: [
+          { say: "um · uh · you know · a leading “so”", becomes: "removed as filler" },
+          { say: "the the problem", becomes: "the problem — repeats collapse" },
+          { say: "a long dictation", becomes: "paragraph breaks placed for you, in break-safe apps" },
+        ],
+      },
+    ],
+  },
+  {
+    title: "Editing selected text",
+    note: "Select text first, then hold the key and say the command. Nothing happens if the selection doesn't fit — an identifier command on a prose sentence is left alone.",
+    groups: [
+      {
+        title: "Change case",
+        commands: [
+          { say: "snake case", becomes: "get_user_name", mono: true },
+          { say: "camel case", becomes: "getUserName", mono: true },
+          { say: "pascal case  ·  upper camel case", becomes: "GetUserName", mono: true },
+          { say: "kebab case  ·  dash case", becomes: "get-user-name", mono: true },
+          { say: "screaming snake case  ·  constant case", becomes: "GET_USER_NAME", mono: true },
+          { say: "title case", becomes: "Get User Name", mono: true },
+          { say: "upper case  ·  all caps", becomes: "GET USER NAME", mono: true },
+          { say: "lower case", becomes: "get user name", mono: true },
+        ],
+      },
+      {
+        title: "Wrap",
+        commands: [
+          { say: "wrap in quotes  ·  quote that", becomes: "“text”", mono: true },
+          { say: "wrap in single quotes", becomes: "'text'", mono: true },
+          { say: "wrap in backticks  ·  wrap in code", becomes: "`text`", mono: true },
+          { say: "wrap in parentheses  ·  wrap in brackets", becomes: "(text)", mono: true },
+          { say: "wrap in square brackets", becomes: "[text]", mono: true },
+          { say: "wrap in braces  ·  wrap in curlies", becomes: "{text}", mono: true },
+        ],
+      },
+      {
+        title: "Lists",
+        note: "Splits the selection on commas and “and”.",
+        commands: [
+          { say: "bullet list  ·  bullet points", becomes: "each item on its own “- ” line" },
+          { say: "numbered list  ·  ordered list", becomes: "each item numbered 1., 2., 3." },
+        ],
+      },
+    ],
+  },
+];

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -70,6 +70,13 @@ export const ClockIcon = svg(
   </>,
 );
 
+export const CommandsIcon = svg(
+  <>
+    <path d="M4 5.5h16v10H8.5L4 20z" />
+    <path d="M8 9.5h8M8 12.5h5" />
+  </>,
+);
+
 export const CheckIcon = svg(<path d="M5 13l4 4L19 7" />, 3);
 
 export const ChevronDownIcon = svg(<path d="M6 9l6 6 6-6" />, 2.5);

--- a/src/index.css
+++ b/src/index.css
@@ -572,6 +572,48 @@ button {
   margin: 6px 2px 0;
 }
 
+/* --- commands page --- */
+
+.cmd-group-note {
+  margin: 2px 2px 6px;
+  font-size: 11.5px;
+  color: var(--text-2);
+  max-width: 62ch;
+}
+
+.cmd-row {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding: 10px 16px;
+  border-top: 1px solid var(--sep);
+}
+
+.cmd-row:first-child {
+  border-top: 0;
+}
+
+.cmd-say {
+  flex: 0 0 42%;
+  font-weight: 500;
+}
+
+.cmd-arrow {
+  flex: 0 0 auto;
+  color: var(--text-3);
+}
+
+.cmd-becomes {
+  flex: 1;
+  color: var(--text-2);
+}
+
+.cmd-becomes.mono {
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 12px;
+  color: var(--text);
+}
+
 /* --- permissions page --- */
 
 .perm-progress {

--- a/src/nav.ts
+++ b/src/nav.ts
@@ -4,11 +4,11 @@
 
 // "permissions" is a reachable view but not a toolbar tab - the app
 // navigates to it (from the tray, from Home) when a grant is missing.
-export type Page = "home" | "settings" | "permissions";
+export type Page = "home" | "commands" | "settings" | "permissions";
 
-export const PAGES = ["home", "settings", "permissions"] as const;
+export const PAGES = ["home", "commands", "settings", "permissions"] as const;
 
-export const TAB_PAGES = ["home", "settings"] as const;
+export const TAB_PAGES = ["home", "commands", "settings"] as const;
 export type TabPage = (typeof TAB_PAGES)[number];
 
 export const DEFAULT_PAGE: Page = "home";

--- a/src/pages/Commands.tsx
+++ b/src/pages/Commands.tsx
@@ -1,0 +1,71 @@
+import { useMemo, useState } from "react";
+import { COMMAND_SECTIONS, type Command } from "../commandReference";
+
+function matches(command: Command, query: string) {
+  const q = query.toLowerCase();
+  return command.say.toLowerCase().includes(q) || command.becomes.toLowerCase().includes(q);
+}
+
+export default function Commands() {
+  const [query, setQuery] = useState("");
+
+  const sections = useMemo(() => {
+    const trimmed = query.trim();
+    if (!trimmed) return COMMAND_SECTIONS;
+    return COMMAND_SECTIONS.map((section) => ({
+      ...section,
+      groups: section.groups
+        .map((group) => ({ ...group, commands: group.commands.filter((c) => matches(c, trimmed)) }))
+        .filter((group) => group.commands.length > 0),
+    })).filter((section) => section.groups.length > 0);
+  }, [query]);
+
+  return (
+    <main className="page">
+      <div className="hero">
+        <div>
+          <h1>Things you can say</h1>
+          <p>
+            Spoken commands OpenStream understands while you dictate, and while you edit a selection. Say them naturally,
+            in the middle of a sentence.
+          </p>
+        </div>
+      </div>
+
+      <input
+        className="field"
+        type="search"
+        placeholder="Filter commands…"
+        value={query}
+        onChange={(event) => setQuery(event.target.value)}
+        style={{ flex: "0 0 auto" }}
+      />
+
+      {sections.length === 0 && <p className="hint">No command matches “{query.trim()}”.</p>}
+
+      {sections.map((section) => (
+        <section key={section.title} className="group">
+          <h2>{section.title}</h2>
+          <p className="group-desc">{section.note}</p>
+          {section.groups.map((group) => (
+            <div key={group.title} style={{ marginTop: 6 }}>
+              <div className="card-label">{group.title}</div>
+              {group.note && <p className="cmd-group-note">{group.note}</p>}
+              <div className="card">
+                {group.commands.map((command) => (
+                  <div className="cmd-row" key={command.say}>
+                    <span className="cmd-say">{command.say}</span>
+                    <span className="cmd-arrow" aria-hidden="true">
+                      →
+                    </span>
+                    <span className={command.mono ? "cmd-becomes mono" : "cmd-becomes"}>{command.becomes}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </section>
+      ))}
+    </main>
+  );
+}


### PR DESCRIPTION
Closes #246.

## Commands tab

A new **Commands** tab lists every spoken phrase OpenStream understands, so people can actually discover them. Two sections — **While dictating** (from `rules.js`) and **Editing selected text** (from `voiceEditCommands.js`) — grouped (line breaks & lists, punctuation, symbols, emoji, corrections, quoting/spelling/numbers; then case/wrap/list for selections), each row `say → becomes`, with a filter box.

- `src/commandReference.ts` — hand-authored data, the human-facing description of the two command tables. Comment points at the source of truth.
- `src/pages/Commands.tsx`, a `CommandsIcon`, `nav.ts` gains `commands`, wired into `App.tsx`.

## Formatting fix (folded in)

The spoken bullet command matched only `bullet point` / `new bullet`. Now: `bullet points` (the plural people actually say), `next bullet`, `new bullet point`. `bulletin` still is not mistaken for it. Test added.

Paragraph-break *placement* tuning and numbered-lists-while-dictating are held until #228 shows what is actually wrong on a real Mac.

## Preview
https://claude.ai/code/artifact/4606f2d3-643e-4517-8803-b698a9442b04 → Commands tab

## Tests
vitest 116/116, `node --test` 249/1 (the 1 is #171's fixture reminder), typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)