### PR TITLE
Shrink the app: download models on first run (#249)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Planned, not yet in the app: codebase-vocabulary biasing (transcription weighted
 
 ## Install
 
-OpenStream installs from source. There is a convenience DMG on the [releases page](https://github.com/Nabzx/openstream/releases), but it is unsigned — Gatekeeper will warn, and every rebuild resets the macOS permission grants (see below) — so `git clone` is the supported path.
+OpenStream installs from source. There is a convenience DMG on the [releases page](https://github.com/Nabzx/openstream/releases) — it downloads the speech models (~1.2 GB) on first run rather than bundling them — but it is unsigned (Gatekeeper will warn) and every rebuild resets the macOS permission grants (see below), so `git clone` is the supported path.
 
 ### Requirements
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -19,6 +19,7 @@ const { performance } = require("node:perf_hooks");
 const { computeBottomCenteredPosition } = require("./overlayPosition");
 const whisperServer = require("./whisperServer");
 const rewriteModelServer = require("./rewriteModelServer");
+const { ensureModels, modelsMissing } = require("./modelStore");
 const hotkeyHelper = require("./hotkeyHelper");
 const accessibilityHelper = require("./accessibilityHelper");
 const { createSettingsStore } = require("./settingsStore");
@@ -62,6 +63,11 @@ let trayState = "idle";
 let captureWin = null;
 let overlayWin = null;
 let hotkeyStarted = false;
+// #249: the hotkey only arms once the capture window is up AND the model
+// weights are in place (a packaged first run downloads them).
+let captureReady = false;
+let modelsReady = false;
+let retryModelDownload = () => {};
 let settingsStore = null;
 let pushToTalkShortcut = null;
 const transcription = createTranscriptionHttpAdapter({ inferenceUrl: whisperServer.inferenceUrl });
@@ -179,6 +185,30 @@ function openWindowTo(page) {
   } else {
     win.webContents.once("did-finish-load", () => win.webContents.send("navigate", page));
   }
+}
+
+// #249: model-download progress for the Setup screen. Latched so the
+// window can re-read the last value when it (or the page) mounts mid-run.
+let lastSetupProgress = null;
+function sendSetupProgress(progress) {
+  lastSetupProgress = progress;
+  if (win && !win.isDestroyed()) {
+    if (win.webContents.isLoading()) {
+      win.webContents.once("did-finish-load", () => win.webContents.send("setup-progress", progress));
+    } else {
+      win.webContents.send("setup-progress", progress);
+    }
+  }
+}
+
+// The hotkey arms only once both the capture window is ready and the model
+// weights are in place.
+function maybeStartHotkey() {
+  if (hotkeyStarted || !captureReady || !modelsReady || !pushToTalkShortcut) return;
+  hotkeyStarted = true;
+  void pushToTalkShortcut.start().catch((error) => {
+    console.error("[hotkey-helper] active shortcut could not start:", error.message);
+  });
 }
 
 // A regular Dock app has a menu bar (issue #209). It's also what makes
@@ -568,11 +598,9 @@ function isCaptureSender(event) {
 }
 
 ipcMain.on("capture-ready", (event) => {
-  if (!isCaptureSender(event) || hotkeyStarted || !pushToTalkShortcut) return;
-  hotkeyStarted = true;
-  void pushToTalkShortcut.start().catch((error) => {
-    console.error("[hotkey-helper] active shortcut could not start:", error.message);
-  });
+  if (!isCaptureSender(event)) return;
+  captureReady = true;
+  maybeStartHotkey();
 });
 
 ipcMain.on("recording-complete", (event, arrayBuffer, timing) => {
@@ -687,6 +715,11 @@ ipcMain.handle("settings:set-break-safe-apps", (event, apps) => {
   return settings;
 });
 
+ipcMain.handle("app:get-setup-progress", () => lastSetupProgress);
+ipcMain.handle("app:retry-model-download", () => {
+  retryModelDownload();
+});
+
 ipcMain.handle("settings:reset-break-safe-apps", () => {
   const settings = settingsStore.setBreakSafeApps([...DEFAULT_BREAK_SAFE_BUNDLE_IDS]);
   setBreakSafeApplications(settings.breakSafeApps);
@@ -784,6 +817,20 @@ app.whenReady().then(() => {
   createOverlayWindow();
   accessibilityHelper.start();
 
+  // #47: if a hard grant is missing, the app silently does nothing on every
+  // push-to-talk - so open the window on the Permissions view and say so.
+  const checkPermissionsAndSurface = () =>
+    checkPermissions()
+      .then((verdict) => {
+        updateTrayForPermissions(verdict);
+        if (!verdict.ok) openWindowTo("permissions");
+        else if (isFirstLaunch && !launchedAtLogin) createWindow();
+      })
+      .catch((error) => {
+        console.error("[permissions] startup check failed:", error);
+        if (isFirstLaunch && !launchedAtLogin) createWindow();
+      });
+
   // #135: the two model servers stay resident for the app's life (#29), so
   // they start here rather than per-dictation. At login, hold them back a
   // few seconds so the ~15-20s Metal warm-up isn't competing with
@@ -792,24 +839,33 @@ app.whenReady().then(() => {
     whisperServer.start();
     rewriteModelServer.start();
   };
-  if (launchedAtLogin) setTimeout(startModelServers, 3000);
-  else startModelServers();
 
-  // #47: if a hard grant is missing, the app silently does nothing on every
-  // push-to-talk - so open the window on the Permissions view and say so,
-  // rather than leaving the user to wonder. Under source-only distribution
-  // every rebuild re-breaks the grant, so this is a normal recurring state,
-  // not just a first-run one.
-  checkPermissions()
-    .then((verdict) => {
-      updateTrayForPermissions(verdict);
-      if (!verdict.ok) openWindowTo("permissions");
-      else if (isFirstLaunch && !launchedAtLogin) createWindow();
-    })
-    .catch((error) => {
-      console.error("[permissions] startup check failed:", error);
-      if (isFirstLaunch && !launchedAtLogin) createWindow();
-    });
+  // #249: a packaged app ships without the model weights and fetches them
+  // on first run. Gate the servers - and the hotkey - on the weights being
+  // in place, and show the download on a Setup screen.
+  const bringUpModels = async () => {
+    try {
+      await ensureModels({ onProgress: sendSetupProgress });
+      modelsReady = true;
+      sendSetupProgress({ phase: "ready" });
+      startModelServers();
+      maybeStartHotkey();
+    } catch (error) {
+      console.error("[setup] model download failed:", error.message);
+      sendSetupProgress({ phase: "error", message: error.message });
+    }
+  };
+  retryModelDownload = bringUpModels;
+
+  if (modelsMissing()) {
+    createWindow();
+    openWindowTo("setup");
+    bringUpModels().then(checkPermissionsAndSurface);
+  } else {
+    if (launchedAtLogin) setTimeout(bringUpModels, 3000);
+    else bringUpModels();
+    checkPermissionsAndSurface();
+  }
 });
 
 app.on("will-quit", () => {

--- a/electron/modelStore.js
+++ b/electron/modelStore.js
@@ -1,0 +1,175 @@
+const fs = require("fs");
+const fsp = require("fs/promises");
+const path = require("path");
+const https = require("https");
+const { createHash } = require("crypto");
+const { resourcesRoot } = require("./paths");
+
+let electron = null;
+try {
+  electron = require("electron");
+} catch {
+  electron = null;
+}
+
+// The model weights the packaged app downloads on first run instead of
+// bundling (#249 - a bundled DMG is ~1.3 GB). Kept in step with
+// scripts/model-artifacts.mjs (transcription) and scripts/fetch-llama.sh
+// (rewrite): those fill <repo>/resources/models for a source install; this
+// fills <userData>/models for the packaged app, which can't write inside
+// its own signed bundle.
+const MODELS = [
+  {
+    role: "transcription",
+    file: "ggml-base.en.bin",
+    url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/5359861c739e955e79d9a303bcbc70fb988958b1/ggml-base.en.bin",
+    sha256: "a03779c86df3323075f5e796cb2ce5029f00ec8869eee3fdfb897afe36c6d002",
+    bytes: 147964211,
+  },
+  {
+    role: "rewrite",
+    file: "smollm2-1.7b-instruct-q4_k_m.gguf",
+    url: "https://huggingface.co/HuggingFaceTB/SmolLM2-1.7B-Instruct-GGUF/resolve/2d4a76a30b4af41ecd395c35725ac11688d4cfe4/smollm2-1.7b-instruct-q4_k_m.gguf",
+    sha256: "decd2598bc2c8ed08c19adc3c8fdd461ee19ed5708679d1c54ef54a5a30d4f33",
+    bytes: 1055609536,
+  },
+];
+
+function userModelsDir() {
+  if (electron && typeof electron === "object" && electron.app && electron.app.getPath) {
+    return path.join(electron.app.getPath("userData"), "models");
+  }
+  return null; // dev / tests
+}
+
+// A source install has the weights under resources/models (postinstall);
+// a packaged install downloads them to userData/models. Return whichever
+// already holds the file, falling back to the bundled path.
+function resolveModelPath(
+  file,
+  { userDir = userModelsDir(), bundledDir = path.join(resourcesRoot(), "models") } = {},
+) {
+  if (userDir) {
+    const inUser = path.join(userDir, file);
+    if (fs.existsSync(inUser)) return inUser;
+  }
+  return path.join(bundledDir, file);
+}
+
+async function sha256Of(filePath) {
+  const hash = createHash("sha256");
+  await new Promise((resolve, reject) => {
+    fs.createReadStream(filePath).on("data", (c) => hash.update(c)).on("error", reject).on("end", resolve);
+  });
+  return hash.digest("hex");
+}
+
+// A weight is "good enough to use" if it exists and its size matches. Full
+// sha256 verification happens once, on the download itself (streamed).
+async function looksIntact(filePath, expectedBytes) {
+  try {
+    const stat = await fsp.stat(filePath);
+    return stat.isFile() && stat.size === expectedBytes;
+  } catch {
+    return false;
+  }
+}
+
+// https.get that follows redirects (Hugging Face resolve/ URLs 302 to a CDN).
+function httpGetFollowing(url, cb, depth = 0) {
+  if (depth > 5) {
+    cb(null, new Error("too many redirects"));
+    return;
+  }
+  https
+    .get(url, (res) => {
+      if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+        res.resume();
+        httpGetFollowing(new URL(res.headers.location, url).toString(), cb, depth + 1);
+        return;
+      }
+      cb(res);
+    })
+    .on("error", (err) => cb(null, err));
+}
+
+async function downloadTo(url, destPath, sha256, onProgress = () => {}, httpGet = httpGetFollowing) {
+  await fsp.mkdir(path.dirname(destPath), { recursive: true });
+  const partPath = `${destPath}.part`;
+  await fsp.rm(partPath, { force: true });
+
+  const hash = createHash("sha256");
+  await new Promise((resolve, reject) => {
+    httpGet(url, (res, err) => {
+      if (err) return reject(err);
+      if (res.statusCode !== 200) return reject(new Error(`download failed: HTTP ${res.statusCode}`));
+      const total = Number(res.headers["content-length"]) || 0;
+      let received = 0;
+      const out = fs.createWriteStream(partPath);
+      res.on("data", (chunk) => {
+        hash.update(chunk);
+        received += chunk.length;
+        onProgress({ received, total });
+      });
+      res.on("error", reject);
+      out.on("error", reject);
+      out.on("finish", resolve);
+      res.pipe(out);
+    });
+  });
+
+  const actual = hash.digest("hex");
+  if (actual !== sha256) {
+    await fsp.rm(partPath, { force: true });
+    throw new Error(`checksum mismatch for ${path.basename(destPath)}: expected ${sha256}, got ${actual}`);
+  }
+  await fsp.rename(partPath, destPath);
+}
+
+// Ensures every weight is present. Skips one that already looks intact
+// (a source install's bundled copy, or a prior download). Otherwise
+// downloads it to userData/models with a streamed checksum.
+//
+// onProgress: ({ role, file, bytes, phase: "check"|"download"|"done"|"error",
+//                received?, total?, message? })
+async function ensureModels({ models = MODELS, onProgress = () => {}, httpGet = httpGetFollowing } = {}) {
+  const userDir = userModelsDir();
+  const results = [];
+  for (const model of models) {
+    onProgress({ ...model, phase: "check" });
+    const existing = resolveModelPath(model.file);
+    if (await looksIntact(existing, model.bytes)) {
+      onProgress({ ...model, phase: "done", received: model.bytes, total: model.bytes });
+      results.push({ ...model, path: existing, downloaded: false });
+      continue;
+    }
+    if (!userDir) {
+      throw new Error(`${model.file} is missing and there is no writable models directory (run \`npm install\` for a source build)`);
+    }
+    const dest = path.join(userDir, model.file);
+    onProgress({ ...model, phase: "download", received: 0, total: model.bytes });
+    try {
+      await downloadTo(
+        model.url,
+        dest,
+        model.sha256,
+        (p) => onProgress({ ...model, phase: "download", received: p.received, total: p.total || model.bytes }),
+        httpGet,
+      );
+    } catch (error) {
+      onProgress({ ...model, phase: "error", message: error.message });
+      throw error;
+    }
+    onProgress({ ...model, phase: "done", received: model.bytes, total: model.bytes });
+    results.push({ ...model, path: dest, downloaded: true });
+  }
+  return results;
+}
+
+// True when at least one weight isn't in place yet - the caller shows the
+// window and a progress screen rather than starting hidden.
+function modelsMissing() {
+  return MODELS.some((model) => !fs.existsSync(resolveModelPath(model.file)));
+}
+
+module.exports = { MODELS, resolveModelPath, ensureModels, modelsMissing, sha256Of, downloadTo };

--- a/electron/modelStore.test.js
+++ b/electron/modelStore.test.js
@@ -1,0 +1,93 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const fsp = require("fs/promises");
+const os = require("os");
+const path = require("path");
+const { createHash } = require("crypto");
+const { Readable } = require("stream");
+
+const { resolveModelPath, ensureModels, downloadTo, MODELS } = require("./modelStore");
+
+async function tmpdir() {
+  return fsp.mkdtemp(path.join(os.tmpdir(), "openstream-modelstore-"));
+}
+
+function sha(buf) {
+  return createHash("sha256").update(buf).digest("hex");
+}
+
+// A fake `httpGet(url, cb)` — the contract is "hand back the final 200
+// response"; redirect following lives in the real httpGetFollowing.
+function fakeHttp(body) {
+  return (_url, cb) => {
+    const res = Readable.from([body]);
+    res.statusCode = 200;
+    res.headers = { "content-length": String(body.length) };
+    cb(res);
+  };
+}
+
+test("resolveModelPath prefers a downloaded copy in userDir over the bundled path", () => {
+  const userDir = fs.mkdtempSync(path.join(os.tmpdir(), "os-user-"));
+  const bundledDir = fs.mkdtempSync(path.join(os.tmpdir(), "os-bundled-"));
+  fs.writeFileSync(path.join(bundledDir, "m.bin"), "bundled");
+
+  assert.equal(resolveModelPath("m.bin", { userDir, bundledDir }), path.join(bundledDir, "m.bin"));
+
+  fs.writeFileSync(path.join(userDir, "m.bin"), "downloaded");
+  assert.equal(resolveModelPath("m.bin", { userDir, bundledDir }), path.join(userDir, "m.bin"));
+});
+
+test("downloadTo verifies the checksum, writes atomically, and cleans up on mismatch", async () => {
+  const dir = await tmpdir();
+  const body = Buffer.from("weights bytes here");
+  const dest = path.join(dir, "w.bin");
+
+  await downloadTo("https://x/w.bin", dest, sha(body), () => {}, fakeHttp(body));
+  assert.equal(fs.readFileSync(dest, "utf8"), "weights bytes here");
+  assert.ok(!fs.existsSync(`${dest}.part`), "the .part file is renamed away, not left behind");
+
+  await assert.rejects(
+    downloadTo("https://x/w.bin", path.join(dir, "bad.bin"), "0".repeat(64), () => {}, fakeHttp(body)),
+    /checksum mismatch/,
+  );
+  assert.ok(!fs.existsSync(path.join(dir, "bad.bin.part")), "a mismatched download leaves nothing behind");
+});
+
+test("ensureModels skips a weight that is already the right size", async () => {
+  const dir = await tmpdir();
+  const body = Buffer.from("x".repeat(20));
+  const model = { role: "t", file: "t.bin", url: "https://x/t.bin", sha256: sha(body), bytes: body.length };
+  // Pre-place it where resolveModelPath will find it (bundled path == dir here
+  // because there's no electron userDir in tests).
+  const { resourcesRoot } = require("./paths");
+  await fsp.mkdir(path.join(resourcesRoot(), "models"), { recursive: true });
+  const bundled = path.join(resourcesRoot(), "models", "t.bin");
+  await fsp.writeFile(bundled, body);
+  try {
+    let downloaded = false;
+    const results = await ensureModels({
+      models: [model],
+      httpGet: () => {
+        downloaded = true;
+      },
+    });
+    assert.equal(downloaded, false);
+    assert.equal(results[0].downloaded, false);
+    assert.equal(results[0].path, bundled);
+  } finally {
+    await fsp.rm(bundled, { force: true });
+  }
+});
+
+test("ensureModels throws a clear error when a weight is missing and nothing is writable", async () => {
+  const model = { role: "t", file: "does-not-exist.bin", url: "https://x", sha256: "0".repeat(64), bytes: 1 };
+  await assert.rejects(ensureModels({ models: [model] }), /npm install.*source build/s);
+});
+
+test("the model list matches what the servers expect", () => {
+  const files = MODELS.map((m) => m.file);
+  assert.ok(files.includes("ggml-base.en.bin"));
+  assert.ok(files.includes("smollm2-1.7b-instruct-q4_k_m.gguf"));
+});

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -16,6 +16,13 @@ function onDictationState(callback) {
   return () => ipcRenderer.removeListener("dictation-state", listener);
 }
 
+// #249: first-run model-download progress for the Setup screen.
+function onSetupProgress(callback) {
+  const listener = (_event, progress) => callback(progress);
+  ipcRenderer.on("setup-progress", listener);
+  return () => ipcRenderer.removeListener("setup-progress", listener);
+}
+
 // The renderer's only route to the main process, per contextIsolation - see
 // the settings window's webPreferences in main.js. First surface: settings
 // (#19). This will grow to cover the hotkey helper, the accessibility
@@ -27,6 +34,8 @@ contextBridge.exposeInMainWorld("openstream", {
     setLoginItem: (enabled) => ipcRenderer.invoke("app:set-login-item", enabled),
     checkPermissions: () => ipcRenderer.invoke("app:check-permissions"),
     openPrivacySettings: (key) => ipcRenderer.invoke("app:open-privacy-settings", key),
+    getSetupProgress: () => ipcRenderer.invoke("app:get-setup-progress"),
+    retryModelDownload: () => ipcRenderer.invoke("app:retry-model-download"),
   },
   settings: {
     get: () => ipcRenderer.invoke("settings:get"),
@@ -43,4 +52,5 @@ contextBridge.exposeInMainWorld("openstream", {
   },
   onNavigate,
   onDictationState,
+  onSetupProgress,
 });

--- a/electron/rewriteModelServer.js
+++ b/electron/rewriteModelServer.js
@@ -1,35 +1,42 @@
 const path = require("path");
 const { resourcesRoot } = require("./paths");
+const { resolveModelPath } = require("./modelStore");
 const { createModelSupervisor } = require("./modelSupervisor");
 
 const HOST = "127.0.0.1";
 const PORT = 8179;
 const CONTEXT_SIZE = 2048;
+const MODEL_FILE = "smollm2-1.7b-instruct-q4_k_m.gguf";
 
 function createRewriteModelServer(options = {}) {
-  const {
-    root = resourcesRoot(),
-    createSupervisor = createModelSupervisor,
-  } = options;
+  const { root = resourcesRoot(), createSupervisor = createModelSupervisor } = options;
   // llama-server links its dylibs with an @loader_path rpath (see
   // fetch-llama.sh), so it has to run from inside the directory it was
   // extracted into, not just anywhere on disk.
   const binaryPath = path.join(root, "bin", "llama", "llama-server");
-  const modelPath = path.join(root, "models", "SmolLM2-1.7B-Instruct-Q4_K_M.gguf");
-  const supervisor = createSupervisor({
-    roleName: "rewrite model server",
-    command: binaryPath,
-    args: [
-      "--model", modelPath,
-      "--host", HOST,
-      "--port", String(PORT),
-      "--ctx-size", String(CONTEXT_SIZE),
-    ],
-  });
+
+  let supervisor = null;
+
+  // The weight path is resolved at start(): a packaged app downloads it to
+  // userData on first run (#249), so it may not be in place at module load.
+  function ensureSupervisor() {
+    if (supervisor) return supervisor;
+    supervisor = createSupervisor({
+      roleName: "rewrite model server",
+      command: binaryPath,
+      args: [
+        "--model", resolveModelPath(MODEL_FILE, { bundledDir: path.join(root, "models") }),
+        "--host", HOST,
+        "--port", String(PORT),
+        "--ctx-size", String(CONTEXT_SIZE),
+      ],
+    });
+    return supervisor;
+  }
 
   return {
-    start: () => supervisor.start(),
-    stop: () => supervisor.stop(),
+    start: () => ensureSupervisor().start(),
+    stop: () => supervisor?.stop(),
     healthUrl: () => `http://${HOST}:${PORT}/health`,
     chatCompletionsUrl: () => `http://${HOST}:${PORT}/v1/chat/completions`,
   };

--- a/electron/rewriteModelServer.test.js
+++ b/electron/rewriteModelServer.test.js
@@ -5,7 +5,7 @@ const path = require("node:path");
 const rewriteModelServer = require("./rewriteModelServer");
 
 const BIN_PATH = path.join(__dirname, "..", "resources", "bin", "llama", "llama-server");
-const MODEL_PATH = path.join(__dirname, "..", "resources", "models", "SmolLM2-1.7B-Instruct-Q4_K_M.gguf");
+const MODEL_PATH = path.join(__dirname, "..", "resources", "models", "smollm2-1.7b-instruct-q4_k_m.gguf");
 const hasFetchedAssets = fs.existsSync(BIN_PATH) && fs.existsSync(MODEL_PATH);
 
 test("configures the resident rewrite model server on loopback with a 2048-token context", () => {
@@ -28,7 +28,7 @@ test("configures the resident rewrite model server on loopback with a 2048-token
   assert.equal(supervisorOptions.roleName, "rewrite model server");
   assert.equal(supervisorOptions.command, "/tmp/openstream-resources/bin/llama/llama-server");
   assert.deepEqual(supervisorOptions.args, [
-    "--model", "/tmp/openstream-resources/models/SmolLM2-1.7B-Instruct-Q4_K_M.gguf",
+    "--model", "/tmp/openstream-resources/models/smollm2-1.7b-instruct-q4_k_m.gguf",
     "--host", "127.0.0.1",
     "--port", "8179",
     "--ctx-size", "2048",

--- a/electron/whisperServer.js
+++ b/electron/whisperServer.js
@@ -1,5 +1,6 @@
 const path = require("path");
 const { resourcesRoot } = require("./paths");
+const { resolveModelPath } = require("./modelStore");
 const { createModelSupervisor } = require("./modelSupervisor");
 
 // Transcription model server: resident for the life of the app, supervised
@@ -8,20 +9,25 @@ const HOST = "127.0.0.1";
 const PORT = 8178;
 
 const BIN_PATH = path.join(resourcesRoot(), "bin", "whisper-server");
-const MODEL_PATH = path.join(resourcesRoot(), "models", "ggml-base.en.bin");
 
-const supervisor = createModelSupervisor({
-  roleName: "transcription model server",
-  command: BIN_PATH,
-  args: ["--model", MODEL_PATH, "--host", HOST, "--port", String(PORT)],
-});
+let supervisor = null;
 
+// The weight path is resolved at start(), not at module load: a packaged
+// app downloads it to userData on first run (#249), so it may not exist
+// when this module is first required.
 function start() {
+  if (!supervisor) {
+    supervisor = createModelSupervisor({
+      roleName: "transcription model server",
+      command: BIN_PATH,
+      args: ["--model", resolveModelPath("ggml-base.en.bin"), "--host", HOST, "--port", String(PORT)],
+    });
+  }
   supervisor.start();
 }
 
 function stop() {
-  supervisor.stop();
+  supervisor?.stop();
 }
 
 function inferenceUrl() {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
       "package.json"
     ],
     "extraResources": [
-      { "from": "resources", "to": "resources" }
+      { "from": "resources/bin", "to": "resources/bin" }
     ],
     "mac": {
       "category": "public.app-category.productivity",

--- a/scripts/model-artifacts.mjs
+++ b/scripts/model-artifacts.mjs
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
-import { mkdir, rm, copyFile } from "node:fs/promises";
+import { mkdir, rm, copyFile, readdir, lstat, readlink, symlink } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { execFile as execFileCallback } from "node:child_process";
@@ -156,7 +156,37 @@ export async function buildPinnedSource(source, tools = { run }, log = console.l
   await tools.run("cmake", ["--build", source.buildDirectory, "-j", "--config", "Release", "--target", source.target]);
   await mkdir(path.dirname(source.binary), { recursive: true });
   await copyFile(source.builtBinary, source.binary);
+  await stageDylibs(source, tools, log);
   log(`    built: ${source.binary}`);
+}
+
+// whisper-server links its dylibs by @rpath, and cmake bakes an absolute
+// build-dir rpath that only resolves on this machine. Stage the dylibs next
+// to the staged binary and add an @loader_path rpath, so resources/bin is
+// self-contained - the packaged app (#249) has no vendor/ tree to fall back
+// to. llama-server already ships this way (fetch-llama.sh).
+async function stageDylibs(source, tools, log) {
+  const builtDir = path.dirname(source.builtBinary);
+  const stagedDir = path.dirname(source.binary);
+  let count = 0;
+  for (const entry of await readdir(builtDir)) {
+    // Skip file-sync conflicted copies ("libggml 2.dylib") and non-dylibs.
+    if (!entry.endsWith(".dylib") || entry.includes(" ")) continue;
+    const from = path.join(builtDir, entry);
+    const to = path.join(stagedDir, entry);
+    await rm(to, { force: true });
+    const info = await lstat(from);
+    if (info.isSymbolicLink()) await symlink(await readlink(from), to);
+    else await copyFile(from, to);
+    count += 1;
+  }
+  try {
+    await tools.run("install_name_tool", ["-add_rpath", "@loader_path", source.binary]);
+  } catch (error) {
+    // A rebuild over an already-patched binary: @loader_path is present.
+    if (!/would duplicate path|already has|LC_RPATH/i.test(error.message ?? "")) throw error;
+  }
+  log(`    staged ${count} dylibs alongside ${path.basename(source.binary)}`);
 }
 
 export async function prepareModelArtifacts({ root, roles = modelRoles, tools = { run, sha256: fileSha256 }, log = console.log, build = true } = {}) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import Home from "./pages/Home";
 import Commands from "./pages/Commands";
 import Settings from "./pages/Settings";
 import Permissions from "./pages/Permissions";
+import Setup from "./pages/Setup";
 
 const TAB_META: Record<TabPage, { label: string; Icon: (props: { className?: string }) => JSX.Element }> = {
   home: { label: "Home", Icon: HomeIcon },
@@ -41,6 +42,7 @@ export default function App() {
       </nav>
       {page === "settings" && <Settings />}
       {page === "commands" && <Commands />}
+      {page === "setup" && <Setup onDone={() => setPage("home")} />}
       {page === "permissions" && <Permissions onDone={() => setPage("home")} />}
       {page === "home" && <Home navigate={(next) => setPage(next)} />}
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -572,6 +572,63 @@ button {
   margin: 6px 2px 0;
 }
 
+/* --- setup page --- */
+
+.setup-item {
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.setup-item__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-weight: 500;
+}
+
+.setup-item__head .mono {
+  color: var(--text-2);
+}
+
+.setup-item__meta {
+  color: var(--text-3);
+  font-size: 11px;
+}
+
+.progress {
+  height: 6px;
+  border-radius: 999px;
+  background: var(--surface-2);
+  overflow: hidden;
+}
+
+.progress__fill {
+  height: 100%;
+  border-radius: 999px;
+  background: var(--accent);
+  transition: width 0.3s ease;
+}
+
+.progress__fill--indeterminate {
+  width: 35%;
+  animation: progress-slide 1.3s ease-in-out infinite;
+}
+
+@keyframes progress-slide {
+  0% { margin-left: -35%; }
+  100% { margin-left: 100%; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .progress__fill--indeterminate {
+    animation: none;
+    width: 100%;
+    opacity: 0.5;
+  }
+}
+
 /* --- commands page --- */
 
 .cmd-group-note {

--- a/src/nav.ts
+++ b/src/nav.ts
@@ -2,11 +2,11 @@
 // shell and its test share one source of truth, and so a `navigate`
 // message from the main process can be validated before it's trusted.
 
-// "permissions" is a reachable view but not a toolbar tab - the app
-// navigates to it (from the tray, from Home) when a grant is missing.
-export type Page = "home" | "commands" | "settings" | "permissions";
+// "permissions" and "setup" are reachable views but not toolbar tabs - the
+// app navigates to them when a grant is missing / a model is downloading.
+export type Page = "home" | "commands" | "settings" | "permissions" | "setup";
 
-export const PAGES = ["home", "commands", "settings", "permissions"] as const;
+export const PAGES = ["home", "commands", "settings", "permissions", "setup"] as const;
 
 export const TAB_PAGES = ["home", "commands", "settings"] as const;
 export type TabPage = (typeof TAB_PAGES)[number];

--- a/src/openstreamBridge.d.ts
+++ b/src/openstreamBridge.d.ts
@@ -33,6 +33,12 @@ export type AppHealth = {
   rewriteModel: ModelHealth;
 };
 
+// #249: first-run model download.
+export type SetupProgress =
+  | { phase: "check" | "download" | "done"; role: string; file: string; bytes: number; received?: number; total?: number }
+  | { phase: "ready" }
+  | { phase: "error"; message: string };
+
 export type VocabularyStatus = {
   path: string | null;
   termCount: number;
@@ -53,6 +59,8 @@ declare global {
         setLoginItem(enabled: boolean): Promise<boolean>;
         checkPermissions(): Promise<PermissionVerdict>;
         openPrivacySettings(key: PermissionKey): Promise<void>;
+        getSetupProgress(): Promise<SetupProgress | null>;
+        retryModelDownload(): Promise<void>;
       };
       settings: {
         get(): Promise<StoredSettings>;
@@ -71,6 +79,7 @@ declare global {
       };
       onNavigate(callback: (page: string) => void): () => void;
       onDictationState(callback: (state: "idle" | "recording" | "transcribing") => void): () => void;
+      onSetupProgress(callback: (progress: SetupProgress) => void): () => void;
     };
   }
 }

--- a/src/pages/Setup.tsx
+++ b/src/pages/Setup.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useState } from "react";
+import type { SetupProgress } from "../openstreamBridge";
+import Mark from "../components/Mark";
+
+const ROLE_LABEL: Record<string, string> = {
+  transcription: "Transcription model",
+  rewrite: "Rewrite model",
+};
+
+function mib(bytes: number) {
+  return `${Math.round(bytes / 1_048_576)} MB`;
+}
+
+export default function Setup({ onDone }: { onDone: () => void }) {
+  const [progress, setProgress] = useState<SetupProgress | null>(null);
+  const [retrying, setRetrying] = useState(false);
+
+  useEffect(() => {
+    window.openstream.app.getSetupProgress().then((p) => p && setProgress(p));
+    return window.openstream.onSetupProgress(setProgress);
+  }, []);
+
+  useEffect(() => {
+    if (progress?.phase === "ready") {
+      const t = setTimeout(onDone, 600);
+      return () => clearTimeout(t);
+    }
+  }, [progress, onDone]);
+
+  const error = progress?.phase === "error" ? progress.message : null;
+  const downloading = progress && "role" in progress ? progress : null;
+  const pct =
+    downloading && downloading.total
+      ? Math.min(100, Math.round(((downloading.received ?? 0) / downloading.total) * 100))
+      : null;
+
+  return (
+    <main className="page">
+      <div className="hero">
+        <Mark tile state={error ? "attention" : "idle"} />
+        <div>
+          <h1>{error ? "Setup couldn’t finish" : "Setting up OpenStream"}</h1>
+          <p>
+            {error
+              ? "The model download failed. Check your connection and try again."
+              : "Downloading the local speech models — a one-time step of about 1.2 GB. Everything runs on your Mac after this."}
+          </p>
+        </div>
+      </div>
+
+      {error ? (
+        <>
+          <p className="error-text">{error}</p>
+          <div className="row-actions">
+            <button
+              type="button"
+              className="btn btn--primary"
+              disabled={retrying}
+              onClick={() => {
+                setRetrying(true);
+                setProgress(null);
+                window.openstream.app.retryModelDownload().finally(() => setRetrying(false));
+              }}
+            >
+              {retrying ? "Retrying…" : "Try again"}
+            </button>
+          </div>
+        </>
+      ) : (
+        <div className="card">
+          {downloading ? (
+            <div className="setup-item">
+              <div className="setup-item__head">
+                <span>{ROLE_LABEL[downloading.role] ?? downloading.role}</span>
+                <span className="mono">
+                  {downloading.phase === "download" && pct !== null
+                    ? `${pct}%`
+                    : downloading.phase === "done"
+                      ? "Ready"
+                      : "Checking…"}
+                </span>
+              </div>
+              <div className="progress">
+                <div className="progress__fill" style={{ width: `${pct ?? (downloading.phase === "done" ? 100 : 4)}%` }} />
+              </div>
+              {downloading.phase === "download" && (
+                <div className="setup-item__meta mono">
+                  {mib(downloading.received ?? 0)} / {mib(downloading.total ?? downloading.bytes)}
+                </div>
+              )}
+            </div>
+          ) : (
+            <div className="setup-item">
+              <div className="setup-item__head">
+                <span>Preparing…</span>
+              </div>
+              <div className="progress">
+                <div className="progress__fill progress__fill--indeterminate" />
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      <p className="hint">You can close this window; the download continues in the background.</p>
+    </main>
+  );
+}


### PR DESCRIPTION
Closes #249. Top pre-launch priority — our DMG is ~1.3 GB, OpenSuperWhisper's is 11 MB.

## What changes

**The packaged app no longer bundles the model weights.**
- `extraResources` ships only `resources/bin` — the DMG drops by ~1.15 GB (weights) to roughly the Electron shell + the two compiled servers.
- New `electron/modelStore.js`: `resolveModelPath(file)` (a downloaded copy in `userData/models` wins over the bundled path) and `ensureModels({ onProgress })` — checks each weight (size), and downloads + streams-a-checksum any that's missing, into `userData/models`, atomically. Follows Hugging Face redirects. 5 unit tests.
- `whisperServer` / `rewriteModelServer` resolve their `--model` path lazily at `start()`, so a first run can fetch it after the module loads. The SmolLM2 filename is aligned to the lowercase name `fetch-llama.sh` actually produces (was only working on a case-insensitive filesystem).
- `main.js` gates the model servers **and the hotkey** on `ensureModels()` finishing. If a weight is missing, the window opens on a **Setup** screen with a per-model progress bar; on failure, an error + Try again.

**`whisper-server` is now self-contained** (`scripts/model-artifacts.mjs`).
The build linked its `libwhisper` / `libggml*` dylibs by `@rpath`, and cmake baked an **absolute build-dir rpath** — so `resources/bin/whisper-server` only ran on the machine that built it, and the packaged DMG's transcription was silently broken. The build now stages the dylibs next to the binary and adds an `@loader_path` rpath (the way `fetch-llama.sh` already ships `llama-server`). Verified locally: `otool` shows `@loader_path`, and `whisper-server --help` runs from `resources/bin`.

## Tests

- `npm test` — vitest 116/116; `node --test` 253 pass, 1 fail (the #171 fixture reminder, unrelated).
- `npm run typecheck`, `npm run build` — clean.
- **Source install is unaffected** — `postinstall` still fills `resources/models`, and `resolveModelPath` finds them there.

## Needs a real-Mac check (folds into #228)

- `npm run dist` → the DMG size, and a first launch: the Setup screen, the ~1.2 GB download, then dictation working end to end against the downloaded weights.
- The `@loader_path` fix means the DMG's `whisper-server` should now actually run — this has never been true before.

## ⚠️ Conflict warning

There is an **unmerged Zazai commit** — `45e84e8 "fix: capture standalone Fn shortcut in settings"` — sitting on the branch `feat/models-on-first-run-249` (mis-named; no PR). It touches `electron/main.js`, `electron/preload.js`, `src/openstreamBridge.d.ts` — the same files this PR touches. Whichever lands second will conflict. That commit needs its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
