### PR TITLE
Landing page rebrand: terminal / phosphor (#278)

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -1,8 +1,11 @@
 # site/
 
 A single self-contained landing page for OpenStream. No build step, no
-dependencies — `index.html` inlines its own CSS and JS and pulls only
-Google Fonts over the network.
+dependencies; `index.html` inlines its own CSS and JS and pulls only Space
+Mono from Google Fonts.
+
+Design direction: `docs/design/visual-identity.md`. Terminal / phosphor;
+Space Mono, two greens on near-black, a looping boot demo in the hero.
 
 ## Preview locally
 
@@ -10,25 +13,15 @@ Google Fonts over the network.
 open site/index.html
 ```
 
-Or serve the folder if you want the fonts to load without a file:// warning:
-
-```bash
-python3 -m http.server -d site 4173
-```
-
 ## The demo GIF
 
-Issue #21 also wants a short screen recording of a real dictation. Once
-it exists:
-
-1. Drop it at `site/demo.gif` (keep it under ~4 MB — trim to ~8 seconds,
-   960px wide is plenty).
-2. In `index.html`, replace the `.gif-slot` placeholder in the
-   `#demo-gif` section with `<img src="demo.gif" alt="OpenStream dictating into an editor" width="960">`.
-3. Reuse the same GIF in the top-level `README.md`.
+Issue #21 also wants a short screen recording of a real dictation. Once it
+exists, drop it at `site/demo.gif` and add a `DEMO` block near the foot of
+the page with `<img src="demo.gif" alt="OpenStream dictating" width="960">`,
+then reuse it in the top-level `README.md`.
 
 ## Publishing
 
-The page is static, so any host works. For GitHub Pages, either move
-`index.html` to a `gh-pages` branch or point Pages at this folder with a
-small workflow — deferred until we actually want a public URL.
+Static, so any host works. For a public URL, either move `index.html` to a
+`gh-pages` branch or point GitHub Pages at this folder with a small
+workflow. Deferred until we want one.

--- a/site/index.html
+++ b/site/index.html
@@ -64,10 +64,14 @@ a:hover { background: var(--acc); color: var(--bg); }
 @media (prefers-reduced-motion: reduce) { .cur { animation: none; } }
 
 /* ---- top strip ---- */
-.top { position: fixed; top: 0; left: 0; right: 0; z-index: 100; }
-.top .wrap { display: flex; justify-content: space-between; align-items: center; height: 50px; font-size: 14px; }
-.top .brand { color: var(--fg-hi); }
-.top .brand b { color: var(--acc); }
+.top {
+  position: fixed; top: 0; left: 0; right: 0; z-index: 100;
+  background: linear-gradient(180deg, var(--bg) 45%, rgba(2, 4, 2, 0.7) 78%, transparent);
+}
+.top .wrap { display: flex; justify-content: space-between; align-items: center; height: 60px; font-size: 13px; }
+.top .brand { color: var(--fg-hi); font-size: 18px; letter-spacing: -0.01em; }
+.top .brand b { color: var(--acc); text-shadow: 0 0 16px var(--glow); }
+.top .brand .cur { width: 0.5em; height: 1em; }
 .top a.gh { color: var(--muted); }
 .top a.gh:hover { color: var(--acc); background: none; }
 
@@ -117,10 +121,10 @@ a:hover { background: var(--acc); color: var(--bg); }
 @media (prefers-reduced-motion: reduce) { .term .body .l::before { animation: none; } }
 
 .hero h1 {
-  margin: 34px 0 26px; font-weight: 400; font-size: clamp(1.1rem, 2.7vw, 1.35rem);
-  color: var(--fg-hi); line-height: 1.7; max-width: 44ch;
+  margin: 0 0 34px; font-weight: 700; font-size: clamp(1.7rem, 5vw, 2.6rem);
+  color: var(--fg-hi); line-height: 1.2; letter-spacing: -0.02em;
 }
-.hero h1 .acc { font-weight: 700; }
+.hero h1 .acc { text-shadow: 0 0 26px var(--glow); }
 
 .cta { display: flex; gap: 18px; align-items: center; justify-content: center; font-size: 14px; }
 .cta .btn { border: 1px solid var(--acc); color: var(--acc); padding: 9px 22px; }
@@ -225,13 +229,13 @@ footer a:hover { color: var(--acc); background: none; }
 
   <section class="hero">
     <span class="k">local-first voice dictation</span>
+    <h1>press a key. talk. <span class="acc">let go.</span></h1>
     <div class="termwrap">
       <div class="term" aria-hidden="true">
-        <div class="bar"><i></i><i></i><i></i><span>zsh</span></div>
+        <div class="bar"><i></i><i></i><i></i><span>openstream</span></div>
         <div class="body" id="demo"></div>
       </div>
     </div>
-    <h1>speak. it lands at your cursor.<br>a spoken line break <span class="acc">won't</span> run your command.</h1>
     <div class="cta">
       <a class="btn" href="#install">install</a>
       <a class="plain" href="#hook">why &#8595;</a>
@@ -346,8 +350,8 @@ footer a:hover { color: var(--acc); background: none; }
     el.innerHTML =
       '<span class="p">$</span> openstream\n' +
       '<span class="l">listening</span>\n' +
-      '<span class="p">$</span> git commit -m "fix the null deref"\n' +
-      '  <span class="h">&#8627; newline held, not a safe target</span>\n' +
+      'the parser throws on an empty file and on a null path too.\n' +
+      '  <span class="h">&#8627; "new line" held here, a shell prompt is not a safe target</span>\n' +
       '<span class="p">$</span> <span class="cur"></span>';
   }
   if (el) {
@@ -356,10 +360,10 @@ footer a:hover { color: var(--acc); background: none; }
       var lines = [], i = 0;
       var render = function () { el.innerHTML = lines.join("\n"); };
       var q = [
-        { t: "l", h: '<span class="p">$</span> openstream', a: 320 },
+        { t: "l", h: '<span class="p">$</span> openstream', a: 340 },
         { t: "l", h: '<span class="l">listening</span>', a: 900 },
-        { t: "ty", pre: '<span class="p">$</span> ', txt: 'git commit -m "fix the null deref"', s: 34, a: 480 },
-        { t: "l", h: '  <span class="h">&#8627; newline held, not a safe target</span>', a: 460 },
+        { t: "ty", pre: '', txt: 'the parser throws on an empty file and on a null path too.', s: 30, a: 620 },
+        { t: "l", h: '  <span class="h">&#8627; "new line" held here, a shell prompt is not a safe target</span>', a: 560 },
         { t: "l", h: '<span class="p">$</span> <span class="cur"></span>', a: 0 }
       ];
       var next = function () {

--- a/site/index.html
+++ b/site/index.html
@@ -350,8 +350,8 @@ footer a:hover { color: var(--acc); background: none; }
     el.innerHTML =
       '<span class="p">$</span> openstream\n' +
       '<span class="l">listening</span>\n' +
-      'the parser throws on an empty file and on a null path too.\n' +
-      '  <span class="h">&#8627; "new line" held here, a shell prompt is not a safe target</span>\n' +
+      'I find your lack of faith disturbing.\n' +
+      '  <span class="h">&#8627; transcribed on-device, nothing left your mac</span>\n' +
       '<span class="p">$</span> <span class="cur"></span>';
   }
   if (el) {
@@ -362,8 +362,8 @@ footer a:hover { color: var(--acc); background: none; }
       var q = [
         { t: "l", h: '<span class="p">$</span> openstream', a: 340 },
         { t: "l", h: '<span class="l">listening</span>', a: 900 },
-        { t: "ty", pre: '', txt: 'the parser throws on an empty file and on a null path too.', s: 30, a: 620 },
-        { t: "l", h: '  <span class="h">&#8627; "new line" held here, a shell prompt is not a safe target</span>', a: 560 },
+        { t: "ty", pre: '', txt: 'I find your lack of faith disturbing.', s: 34, a: 640 },
+        { t: "l", h: '  <span class="h">&#8627; transcribed on-device, nothing left your mac</span>', a: 560 },
         { t: "l", h: '<span class="p">$</span> <span class="cur"></span>', a: 0 }
       ];
       var next = function () {

--- a/site/index.html
+++ b/site/index.html
@@ -3,604 +3,399 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>OpenStream</title>
-<meta name="description" content="Local-first voice dictation for Apple Silicon Macs. Hold a key, speak, release. Nothing leaves the machine, and a spoken line break never submits your terminal command.">
-<meta property="og:title" content="OpenStream">
-<meta property="og:description" content="Local-first voice dictation for Apple Silicon Macs. Deny-by-default on line breaks.">
+<meta name="description" content="OpenStream is a local-first, open-source voice dictation app for Apple Silicon Macs. Wispr Flow, but free, MIT, and it never leaves your machine. A spoken line break will not run your command.">
+<meta property="og:title" content="openstream">
+<meta property="og:description" content="Local-first voice dictation for people who live in a terminal. Open source, free, on-device.">
 <meta property="og:type" content="website">
+<meta name="theme-color" content="#020402">
+<title>openstream: local-first voice dictation</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,600;12..96,700&family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500&display=swap">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Mono:ital,wght@0,400;0,700;1,400&display=swap">
 <style>
-/* ---- tokens: light is the base ---------------------------------- */
 :root {
-  --paper: #f4f6f2;
-  --surface: #ffffff;
-  --surface-2: #eef1ec;
-  --fg: #16201b;
-  --muted: #586460;
-  --line: #dde2db;
-  --accent: #2f9d75;
-  --accent-ink: #1c6e50;
-  --warn: #b1742b;
-  --danger: #c1524a;
-  --shadow: 0 1px 2px rgba(22, 32, 27, .06), 0 8px 30px rgba(22, 32, 27, .07);
-  --radius: 12px;
-}
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) {
-    --paper: #0e1512;
-    --surface: #151d19;
-    --surface-2: #1b241f;
-    --fg: #e6ebe6;
-    --muted: #9aa8a1;
-    --line: #26302b;
-    --accent: #54c79b;
-    --accent-ink: #8fe0c1;
-    --warn: #d69a55;
-    --danger: #e07a72;
-    --shadow: 0 1px 2px rgba(0, 0, 0, .3), 0 12px 40px rgba(0, 0, 0, .35);
-  }
-}
-:root[data-theme="dark"] {
-  --paper: #0e1512;
-  --surface: #151d19;
-  --surface-2: #1b241f;
-  --fg: #e6ebe6;
-  --muted: #9aa8a1;
-  --line: #26302b;
-  --accent: #54c79b;
-  --accent-ink: #8fe0c1;
-  --warn: #d69a55;
-  --danger: #e07a72;
-  --shadow: 0 1px 2px rgba(0, 0, 0, .3), 0 12px 40px rgba(0, 0, 0, .35);
+  --bg: #020402;
+  --screen: #050805;
+  --acc: #3DF65A;
+  --acc-2: #1ED89A;
+  --fg: #9FB89F;
+  --fg-hi: #D2E6D2;
+  --muted: #4C614B;
+  --line: #16241 4;
+  --line: #16241A;
+  --line-hi: #24382A;
+  --glow: rgba(61, 246, 90, 0.14);
+  --bar: 28px;
 }
 
-* { box-sizing: border-box; margin: 0; }
-
-html { -webkit-text-size-adjust: 100%; }
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html { -webkit-text-size-adjust: 100%; scroll-behavior: smooth; }
 
 body {
-  background: var(--paper);
+  background: var(--bg);
   color: var(--fg);
-  font-family: "IBM Plex Sans", ui-sans-serif, system-ui, -apple-system, sans-serif;
-  font-size: 17px;
-  line-height: 1.65;
+  font-family: "Space Mono", ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 13px;
+  line-height: 1.75;
   -webkit-font-smoothing: antialiased;
+  padding-bottom: var(--bar);
 }
 
-.wrap {
-  max-width: 720px;
-  margin: 0 auto;
-  padding: 0 24px;
+body::before {
+  content: ""; position: fixed; inset: 0; z-index: 300; pointer-events: none;
+  background: repeating-linear-gradient(0deg, transparent 0 2px, rgba(0,0,0,0.13) 3px, transparent 4px);
 }
 
-/* ---- type ------------------------------------------------------- */
-h1, h2, h3 {
-  font-family: "Bricolage Grotesque", "IBM Plex Sans", sans-serif;
-  font-weight: 700;
-  line-height: 1.12;
-  letter-spacing: -0.02em;
-  text-wrap: balance;
-}
-h1 { font-size: clamp(2.4rem, 6vw, 3.5rem); }
-h2 { font-size: clamp(1.5rem, 3.4vw, 1.9rem); letter-spacing: -0.015em; }
-h3 { font-size: 1.06rem; font-weight: 600; letter-spacing: -0.01em; }
+.wrap { max-width: 720px; margin: 0 auto; padding: 0 24px; }
 
-.eyebrow {
-  font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 0.78rem;
-  font-weight: 500;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--accent-ink);
-}
+a { color: var(--acc); text-decoration: none; }
+a:hover { background: var(--acc); color: var(--bg); }
 
-a { color: var(--accent-ink); text-decoration-thickness: 1px; text-underline-offset: 2px; }
-a:hover { text-decoration: none; }
+.acc { color: var(--acc); }
+.acc2 { color: var(--acc-2); }
+.mut { color: var(--muted); }
+.hi { color: var(--fg-hi); }
 
-code, kbd, .mono {
-  font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
-}
-
-kbd {
-  display: inline-block;
-  padding: 2px 7px;
-  font-size: 0.85em;
-  line-height: 1.4;
-  background: var(--surface);
-  border: 1px solid var(--line);
-  border-bottom-width: 2px;
-  border-radius: 6px;
-  color: var(--fg);
-  white-space: nowrap;
-}
-
-:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 3px;
-  border-radius: 3px;
-}
-
-/* ---- layout rhythm -------------------------------------------- */
-main > section {
-  padding: 56px 0;
-  border-top: 1px solid var(--line);
-}
-main > section:first-child { border-top: 0; }
-.section-body { display: flex; flex-direction: column; gap: 20px; margin-top: 22px; }
-
-/* ---- hero ----------------------------------------------------- */
-.hero { padding: 88px 0 60px; }
-.hero p.lede {
-  font-size: 1.2rem;
-  color: var(--muted);
-  max-width: 34ch;
-  margin-top: 20px;
-}
-.hero .cta-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-  align-items: center;
-  margin-top: 32px;
-}
-.btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 11px 18px;
-  border-radius: 9px;
-  font-weight: 500;
-  font-size: 0.95rem;
-  text-decoration: none;
-  border: 1px solid transparent;
-  transition: transform .12s ease, background .12s ease;
-}
-.btn-primary { background: var(--accent); color: #06110c; }
-.btn-primary:hover { transform: translateY(-1px); }
-.btn-ghost { border-color: var(--line); color: var(--fg); background: var(--surface); }
-.btn-ghost:hover { border-color: var(--accent); }
-
-.keyline {
-  margin-top: 18px;
-  font-family: "IBM Plex Mono", monospace;
-  font-size: 0.9rem;
-  color: var(--muted);
-}
-.keyline kbd { margin: 0 2px; }
-
-/* ---- demo windows ------------------------------------------- */
-.demo {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 16px;
-  margin-top: 44px;
-}
-@media (max-width: 620px) { .demo { grid-template-columns: 1fr; } }
-
-.win {
-  background: var(--surface);
-  border: 1px solid var(--line);
-  border-radius: var(--radius);
-  box-shadow: var(--shadow);
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-}
-.win-bar {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 9px 12px;
-  border-bottom: 1px solid var(--line);
-  background: var(--surface-2);
-}
-.dot { width: 9px; height: 9px; border-radius: 50%; background: var(--line); }
-.win-title {
-  font-family: "IBM Plex Mono", monospace;
-  font-size: 0.72rem;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: var(--muted);
-  margin-left: 4px;
-}
-.win-body {
-  padding: 16px;
-  font-family: "IBM Plex Mono", monospace;
-  font-size: 0.86rem;
-  line-height: 1.7;
-  flex: 1;
-  min-height: 128px;
-  white-space: pre-wrap;
-  word-break: break-word;
-}
-.win-body .prompt { color: var(--accent-ink); }
-.caret {
-  display: inline-block;
-  width: 2px;
-  height: 1.05em;
-  background: var(--accent);
-  vertical-align: -0.18em;
-  animation: blink 1s steps(1) infinite;
+.cur {
+  display: inline-block; width: 0.6em; height: 1.05em; background: var(--acc);
+  vertical-align: -0.14em; margin-left: 1px; animation: blink 1.1s steps(1) infinite;
 }
 @keyframes blink { 50% { opacity: 0; } }
+@media (prefers-reduced-motion: reduce) { .cur { animation: none; } }
 
-.verdict {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 10px 12px;
-  border-top: 1px solid var(--line);
-  font-family: "IBM Plex Mono", monospace;
-  font-size: 0.74rem;
-  letter-spacing: 0.02em;
-  min-height: 40px;
-}
-.verdict .tag {
-  padding: 2px 7px;
-  border-radius: 5px;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  font-size: 0.68rem;
-}
-.verdict.ok .tag { background: color-mix(in srgb, var(--accent) 22%, transparent); color: var(--accent-ink); }
-.verdict.drop .tag { background: color-mix(in srgb, var(--warn) 22%, transparent); color: var(--warn); }
-.verdict span:last-child { color: var(--muted); }
+/* ---- top strip ---- */
+.top { position: fixed; top: 0; left: 0; right: 0; z-index: 100; }
+.top .wrap { display: flex; justify-content: space-between; align-items: center; height: 50px; font-size: 14px; }
+.top .brand { color: var(--fg-hi); }
+.top .brand b { color: var(--acc); }
+.top a.gh { color: var(--muted); }
+.top a.gh:hover { color: var(--acc); background: none; }
 
-@media (prefers-reduced-motion: reduce) {
-  .caret { animation: none; }
+/* ---- status bar ---- */
+.status {
+  position: fixed; left: 0; right: 0; bottom: 0; z-index: 100; height: var(--bar);
+  background: var(--acc); color: var(--bg);
+  display: flex; align-items: center; font-weight: 700; font-size: 11px; letter-spacing: 0.02em;
 }
+.status .s { padding: 0 12px; }
+.status .s.d { background: rgba(0,0,0,0.3); color: var(--acc); }
+.status .fill { flex: 1; }
+@media (max-width: 560px) { .status .s.opt { display: none; } }
 
-/* ---- break table ------------------------------------------- */
-.table-scroll { overflow-x: auto; }
-table {
-  border-collapse: collapse;
-  width: 100%;
-  font-size: 0.92rem;
+/* ---- hero ---- */
+.hero {
+  min-height: 100vh;
+  display: flex; flex-direction: column; justify-content: center; align-items: center;
+  text-align: center; padding: 80px 24px 60px;
 }
-th, td {
-  text-align: left;
-  padding: 11px 14px;
-  border-bottom: 1px solid var(--line);
+.hero .k {
+  font-size: 12px; letter-spacing: 0.24em; text-transform: uppercase; color: var(--acc-2);
+  margin-bottom: 30px;
 }
-thead th {
-  font-family: "IBM Plex Mono", monospace;
-  font-size: 0.72rem;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--muted);
-  font-weight: 500;
+.termwrap { width: 100%; max-width: 680px; position: relative; }
+.termwrap::after {
+  content: ""; position: absolute; inset: -56px; z-index: -1;
+  background: radial-gradient(ellipse at center, var(--glow), transparent 70%);
 }
-tbody td:first-child { font-family: "IBM Plex Mono", monospace; font-size: 0.86rem; }
-.pill {
-  display: inline-block;
-  padding: 2px 9px;
-  border-radius: 20px;
-  font-family: "IBM Plex Mono", monospace;
-  font-size: 0.74rem;
-  font-weight: 500;
+.term { border: 1px solid var(--line-hi); background: var(--screen); text-align: left; }
+.term .bar {
+  display: flex; align-items: center; gap: 7px; padding: 10px 14px;
+  border-bottom: 1px solid var(--line); font-size: 12px; color: var(--muted);
 }
-.pill.keep { background: color-mix(in srgb, var(--accent) 20%, transparent); color: var(--accent-ink); }
-.pill.drop { background: color-mix(in srgb, var(--warn) 20%, transparent); color: var(--warn); }
+.term .bar i { width: 9px; height: 9px; border-radius: 50%; background: var(--line-hi); display: block; }
+.term .bar i:first-child { background: var(--acc); }
+.term .bar span { margin-left: 6px; }
+.term .body {
+  padding: 22px 20px 26px; font-size: 15px; line-height: 2.05;
+  white-space: pre-wrap; word-break: break-word; min-height: 230px; color: var(--fg);
+}
+.term .body .p { color: var(--acc); }
+.term .body .l { color: var(--acc); }
+.term .body .l::before { content: "\25CF  "; animation: pulse 1.5s ease-in-out infinite; }
+@keyframes pulse { 50% { opacity: 0.3; } }
+.term .body .h { color: var(--acc-2); }
+@media (prefers-reduced-motion: reduce) { .term .body .l::before { animation: none; } }
 
-/* ---- facts grid ------------------------------------------- */
-.facts { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; margin-top: 22px; }
-@media (max-width: 620px) { .facts { grid-template-columns: 1fr; } }
-.fact {
-  background: var(--surface);
-  border: 1px solid var(--line);
-  border-radius: 10px;
-  padding: 16px;
+.hero h1 {
+  margin: 34px 0 26px; font-weight: 400; font-size: clamp(1.1rem, 2.7vw, 1.35rem);
+  color: var(--fg-hi); line-height: 1.7; max-width: 44ch;
 }
-.fact .n {
-  font-family: "Bricolage Grotesque", sans-serif;
-  font-weight: 700;
-  font-size: 1.5rem;
-  letter-spacing: -0.02em;
-  font-variant-numeric: tabular-nums;
+.hero h1 .acc { font-weight: 700; }
+
+.cta { display: flex; gap: 18px; align-items: center; justify-content: center; font-size: 14px; }
+.cta .btn { border: 1px solid var(--acc); color: var(--acc); padding: 9px 22px; }
+.cta .btn::before { content: "> "; color: var(--muted); }
+.cta .btn:hover { background: var(--acc); color: var(--bg); }
+.cta .btn:hover::before { color: var(--bg); }
+.cta a.plain { color: var(--muted); }
+.cta a.plain:hover { color: var(--acc); background: none; }
+
+.scroll { margin-top: 50px; color: var(--muted); font-size: 16px; animation: bob 2s ease-in-out infinite; }
+@keyframes bob { 50% { transform: translateY(4px); } }
+@media (prefers-reduced-motion: reduce) { .scroll { animation: none; } }
+
+/* ---- sections ---- */
+.sec { padding: 80px 0; border-top: 1px solid var(--line); }
+.rule {
+  color: var(--muted); font-size: 11px; letter-spacing: 0.16em; text-transform: uppercase;
+  margin-bottom: 24px; display: flex; align-items: center; gap: 10px; white-space: nowrap;
 }
-.fact .l { color: var(--muted); font-size: 0.88rem; margin-top: 4px; }
+.rule::before { content: "\2500\2500"; color: var(--line-hi); }
+.rule .x { flex: 1; height: 1px; background: var(--line-hi); }
 
-/* ---- steps ------------------------------------------------ */
-ol.steps { list-style: none; counter-reset: s; padding: 0; display: flex; flex-direction: column; gap: 14px; }
-ol.steps li { counter-increment: s; display: grid; grid-template-columns: 26px 1fr; gap: 12px; }
-ol.steps li::before {
-  content: counter(s);
-  font-family: "IBM Plex Mono", monospace;
-  font-size: 0.8rem;
-  color: var(--accent-ink);
-  border: 1px solid var(--line);
-  border-radius: 6px;
-  width: 26px;
-  height: 26px;
-  display: grid;
-  place-items: center;
+/* hook */
+.hook h2 {
+  font-weight: 700; font-size: clamp(1.6rem, 5vw, 2.6rem); line-height: 1.15;
+  letter-spacing: -0.02em; color: var(--fg-hi); margin-bottom: 6px; text-wrap: balance;
 }
-ol.steps li b { font-weight: 600; }
-ol.steps li span { color: var(--muted); }
+.hook h2 .acc { text-shadow: 0 0 24px var(--glow); }
+.hook .sub { color: var(--muted); margin-bottom: 26px; }
+.bars { font-size: 12px; }
+.bars .b { display: grid; grid-template-columns: 8ch 1fr 8ch; gap: 12px; align-items: center; padding: 4px 0; }
+.bars .b .name { color: var(--fg); }
+.bars .b .track { height: 12px; background: var(--screen); border: 1px solid var(--line-hi); position: relative; overflow: hidden; }
+.bars .b .track i { position: absolute; left: 0; top: 0; bottom: 0; width: var(--w, 0%); background: var(--acc); transition: width 1.1s cubic-bezier(.2,.8,.2,1); }
+.bars .b.slow .track i { background: var(--line-hi); }
+.bars .b .n { color: var(--acc); text-align: right; }
+.bars .b.slow .n { color: var(--muted); }
 
-/* ---- feature list --------------------------------------- */
-.feature { display: flex; flex-direction: column; gap: 4px; }
-.feature p { color: var(--muted); }
-
-/* ---- code block ---------------------------------------- */
-pre {
-  background: var(--surface);
-  border: 1px solid var(--line);
-  border-radius: 10px;
-  padding: 16px;
-  overflow-x: auto;
-  font-family: "IBM Plex Mono", monospace;
-  font-size: 0.86rem;
-  line-height: 1.7;
+/* what */
+.what pre {
+  font-size: 13px; line-height: 2; color: var(--fg);
+  border-left: 1px solid var(--line-hi); padding-left: 16px;
 }
-pre .c { color: var(--muted); }
+.what pre .p { color: var(--acc); }
+.what pre .g { color: var(--acc-2); }
+.what pre .m { color: var(--muted); }
 
-.note {
-  border-left: 3px solid var(--warn);
-  padding: 4px 0 4px 16px;
-  color: var(--muted);
-  font-size: 0.95rem;
+/* safe */
+.safe .grid { display: grid; grid-template-columns: 1fr 1fr; border: 1px solid var(--line-hi); }
+@media (max-width: 520px) { .safe .grid { grid-template-columns: 1fr; } }
+.safe .col { padding: 16px; }
+.safe .col + .col { border-left: 1px solid var(--line); }
+@media (max-width: 520px) { .safe .col + .col { border-left: 0; border-top: 1px solid var(--line); } }
+.safe .col .t { font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; margin-bottom: 10px; }
+.safe .col.y .t { color: var(--acc); }
+.safe .col.n .t { color: var(--acc-2); }
+.safe .col .r { color: var(--muted); font-size: 12px; }
+.safe .col .r b { color: var(--fg); font-weight: 400; }
+.safe .col .out { margin-top: 10px; font-size: 12px; }
+.safe .col.y .out { color: var(--acc); }
+.safe .col.n .out { color: var(--acc-2); }
+
+/* local */
+.local .big { display: flex; align-items: baseline; gap: 16px; flex-wrap: wrap; margin-bottom: 18px; }
+.local .big .n { font-size: clamp(2.6rem, 9vw, 4.4rem); font-weight: 700; color: var(--acc); line-height: 1; letter-spacing: -0.04em; text-shadow: 0 0 34px var(--glow); }
+.local .big .l { color: var(--muted); max-width: 30ch; font-size: 12px; }
+.local .kv { font-size: 12px; }
+.local .kv .r { display: grid; grid-template-columns: 16ch 1fr; gap: 14px; padding: 5px 0; border-bottom: 1px solid var(--line); }
+.local .kv .r .k { color: var(--acc); }
+.local .kv .r .v { color: var(--muted); }
+
+/* install */
+.install pre {
+  border: 1px solid var(--line-hi); background: var(--screen); padding: 16px;
+  font-size: 12.5px; line-height: 1.9; overflow-x: auto;
 }
-.note b { color: var(--fg); font-weight: 600; }
+.install pre .p { color: var(--acc); }
+.install pre .c { color: var(--muted); }
 
-ul.plain { padding-left: 1.1rem; color: var(--muted); }
-ul.plain li { margin: 4px 0; }
-ul.plain li::marker { color: var(--accent); }
+/* status */
+.st ul { list-style: none; font-size: 12.5px; }
+.st li { padding: 4px 0 4px 16px; position: relative; color: var(--muted); }
+.st li::before { content: "\00B7"; position: absolute; left: 4px; color: var(--acc); }
+.st li b { color: var(--fg); font-weight: 400; }
 
-/* ---- footer ------------------------------------------- */
-footer {
-  border-top: 1px solid var(--line);
-  padding: 40px 0 64px;
-  color: var(--muted);
-  font-size: 0.9rem;
-}
-footer .links { display: flex; flex-wrap: wrap; gap: 18px; margin-bottom: 14px; }
-footer a { color: var(--fg); }
+footer { padding: 40px 0 30px; font-size: 11px; color: var(--muted); border-top: 1px solid var(--line); }
+footer a { color: var(--muted); padding: 0 4px; }
+footer a:hover { color: var(--acc); background: none; }
 
-/* GIF placeholder */
-.gif-slot {
-  margin-top: 44px;
-  border: 1px dashed var(--line);
-  border-radius: var(--radius);
-  background: var(--surface);
-  aspect-ratio: 16 / 9;
-  display: grid;
-  place-items: center;
-  text-align: center;
-  color: var(--muted);
-  font-family: "IBM Plex Mono", monospace;
-  font-size: 0.82rem;
-  padding: 24px;
-}
+:focus-visible { outline: 1px solid var(--acc); outline-offset: 2px; }
 </style>
 </head>
 <body>
-<main class="wrap">
+<div class="top">
+  <div class="wrap">
+    <span class="brand">~ <b>openstream</b><span class="cur"></span></span>
+    <a class="gh" href="https://github.com/Nabzx/openstream">github &#8599;</a>
+  </div>
+</div>
+
+<main>
 
   <section class="hero">
-    <p class="eyebrow">Local-first voice dictation &middot; Apple Silicon</p>
-    <h1>Speak into any app. Your words land where the cursor is.</h1>
-    <p class="lede">Hold a key, talk, release. Nothing leaves the Mac &mdash; and a spoken line break never submits your terminal command by accident.</p>
-
-    <div class="cta-row">
-      <a class="btn btn-primary" href="https://github.com/Nabzx/openstream">Get it on GitHub</a>
-      <a class="btn btn-ghost" href="#install">How to run it</a>
-    </div>
-    <p class="keyline">Push-to-talk on a key you choose &mdash; standalone <kbd>&#8997; Option</kbd> out of the box. <kbd>esc</kbd> aborts a recording.</p>
-
-    <div class="demo" id="demo" aria-hidden="true">
-      <div class="win">
-        <div class="win-bar"><span class="dot"></span><span class="dot"></span><span class="dot"></span><span class="win-title">Notes &mdash; break-safe</span></div>
-        <div class="win-body" data-role="prose"></div>
-        <div class="verdict ok" data-role="prose-verdict"><span class="tag">break kept</span><span>a newline here is harmless</span></div>
+    <span class="k">local-first voice dictation</span>
+    <div class="termwrap">
+      <div class="term" aria-hidden="true">
+        <div class="bar"><i></i><i></i><i></i><span>zsh</span></div>
+        <div class="body" id="demo"></div>
       </div>
-      <div class="win">
-        <div class="win-bar"><span class="dot"></span><span class="dot"></span><span class="dot"></span><span class="win-title">Terminal</span></div>
-        <div class="win-body" data-role="term"></div>
-        <div class="verdict drop" data-role="term-verdict"><span class="tag">break dropped</span><span>a newline would run the command</span></div>
+    </div>
+    <h1>speak. it lands at your cursor.<br>a spoken line break <span class="acc">won't</span> run your command.</h1>
+    <div class="cta">
+      <a class="btn" href="#install">install</a>
+      <a class="plain" href="#hook">why &#8595;</a>
+    </div>
+    <div class="scroll" aria-hidden="true">&#9662;</div>
+  </section>
+
+  <section class="sec hook" id="hook">
+    <div class="wrap">
+      <div class="rule">throughput<span class="x"></span></div>
+      <h2>you type at 40. you talk at <span class="acc">150</span>.</h2>
+      <p class="sub">words per minute. dictation is roughly four times faster, if it lands clean.</p>
+      <div class="bars">
+        <div class="b slow"><span class="name">typing</span><span class="track"><i data-w="27"></i></span><span class="n">40</span></div>
+        <div class="b"><span class="name">talking</span><span class="track"><i data-w="100"></i></span><span class="n">150</span></div>
       </div>
     </div>
   </section>
 
-  <section id="safety">
-    <p class="eyebrow">The idea</p>
-    <h2>Deny-by-default on line breaks</h2>
-    <div class="section-body">
-      <p>Most dictation tools treat every target the same. That is fine in a document and dangerous in a shell, where one newline submits a half-typed command or fires off an unfinished message.</p>
-      <p>OpenStream checks the frontmost app and the focused field before it turns a spoken &ldquo;new paragraph&rdquo; into a real break. A break only survives in apps you have put on the allow-list. Everywhere else it is dropped and the words run on.</p>
-      <div class="table-scroll">
-        <table>
-          <thead><tr><th>Where you are</th><th>&ldquo;new paragraph&rdquo; becomes</th></tr></thead>
-          <tbody>
-            <tr><td>iA Writer, Notes, a text editor</td><td><span class="pill keep">a real line break</span></td></tr>
-            <tr><td>Terminal, a shell prompt</td><td><span class="pill drop">dropped &mdash; text runs on</span></td></tr>
-            <tr><td>Slack, a chat box</td><td><span class="pill drop">dropped &mdash; text runs on</span></td></tr>
-            <tr><td>A single-line field</td><td><span class="pill drop">dropped &mdash; text runs on</span></td></tr>
-          </tbody>
-        </table>
-      </div>
-      <p class="note">If a result <b>needs</b> its line breaks &mdash; a bullet list, say &mdash; and the target cannot take them, OpenStream holds the text for you to paste rather than flattening it into nonsense.</p>
+  <section class="sec what">
+    <div class="wrap">
+      <div class="rule">what<span class="x"></span></div>
+<pre><span class="p">$</span> openstream --what
+
+<span class="g">wispr flow, but:</span>
+  open source   <span class="m">MIT, all of it</span>
+  free          <span class="m">no plan, no seats, no trial</span>
+  local         <span class="m">whisper on your machine, nothing leaves it</span>
+  yours         <span class="m">clone it, read it, change it</span></pre>
     </div>
   </section>
 
-  <section id="local">
-    <p class="eyebrow">Privacy by construction</p>
-    <h2>Nothing leaves the machine</h2>
-    <div class="section-body">
-      <p>Transcription and text handling run in local model servers that stay resident while the app is open. There is no account, no cloud endpoint, and no network call on the path from your voice to the cursor.</p>
-      <div class="facts">
-        <div class="fact"><div class="n">0</div><div class="l">network calls in the dictation path</div></div>
-        <div class="fact"><div class="n">&lt;1&nbsp;ms</div><div class="l">deterministic cleanup budget</div></div>
-        <div class="fact"><div class="n">2</div><div class="l">local model servers, kept warm</div></div>
+  <section class="sec safe">
+    <div class="wrap">
+      <div class="rule">safety<span class="x"></span></div>
+      <div class="grid">
+        <div class="col y">
+          <div class="t">safe target</div>
+          <div class="r"><b>iA Writer</b>, <b>Notes</b>, an editor</div>
+          <div class="out">"new line"  &#8594;  \n</div>
+        </div>
+        <div class="col n">
+          <div class="t">everywhere else</div>
+          <div class="r">a <b>terminal</b>, <b>Slack</b>, a one-line field</div>
+          <div class="out">"new line"  &#8594;  dropped</div>
+        </div>
       </div>
+      <p style="color:var(--muted);font-size:12px;margin-top:14px">a newline can submit a half-typed command. openstream checks where the cursor is first.</p>
     </div>
   </section>
 
-  <section id="do">
-    <p class="eyebrow">What it does today</p>
-    <h2>Dictate, edit, cancel &mdash; all by voice</h2>
-    <div class="section-body">
-      <div class="feature">
-        <h3>Push-to-talk dictation</h3>
-        <p>Hold the key, speak, release. The transcript is cleaned of fillers and spoken punctuation by deterministic rules &mdash; no model rewriting your words &mdash; then placed at the cursor.</p>
-      </div>
-      <div class="feature">
-        <h3>Voice edits on a selection</h3>
-        <p>Select text, hold the key, and say a command from a fixed set: &ldquo;snake case&rdquo;, &ldquo;camel case&rdquo;, &ldquo;wrap in backticks&rdquo;, &ldquo;bullet list&rdquo;. The transform is a plain string operation, so it is instant and never surprises you.</p>
-      </div>
-      <div class="feature">
-        <h3>Formatting you speak</h3>
-        <p>&ldquo;New paragraph&rdquo;, &ldquo;bullet points&rdquo;, &ldquo;smiley face emoji&rdquo;, &ldquo;scratch that&rdquo; to undo what you just said &mdash; deterministic rules, no model guessing at intent. The full list lives in a Commands tab in the app.</p>
-      </div>
-      <div class="feature">
-        <h3>Escape to abort</h3>
-        <p>Press <kbd>esc</kbd> while the key is held and the audio is discarded. Nothing is transcribed, nothing is inserted.</p>
+  <section class="sec local">
+    <div class="wrap">
+      <div class="rule">local<span class="x"></span></div>
+      <div class="big"><span class="n">0</span><span class="l">network calls between your voice and the cursor</span></div>
+      <div class="kv">
+        <div class="r"><span class="k">speech</span><span class="v">whisper.cpp, on the GPU, resident</span></div>
+        <div class="r"><span class="k">cleanup</span><span class="v">deterministic rules, sub-1ms, no model rewrites your words</span></div>
+        <div class="r"><span class="k">account</span><span class="v">none. nothing phones home.</span></div>
       </div>
     </div>
   </section>
 
-  <section id="how">
-    <p class="eyebrow">Under the hood</p>
-    <h2>How one dictation works</h2>
-    <div class="section-body">
-      <ol class="steps">
-        <li><b>Capture.</b> <span>A native helper watches for the push-to-talk key; audio records only while it is held.</span></li>
-        <li><b>Transcribe.</b> <span>A resident <code>whisper.cpp</code> server turns the audio into text on the Mac's GPU.</span></li>
-        <li><b>Clean.</b> <span>Deterministic rules strip fillers, resolve spoken punctuation, and segment long run-on speech.</span></li>
-        <li><b>Check the target.</b> <span>A separate Accessibility helper reads the frontmost app and focused field to decide what a line break means here.</span></li>
-        <li><b>Deliver.</b> <span>Text is written into the field, with clipboard paste and synthesised keystrokes as fallbacks.</span></li>
-      </ol>
-      <p>The two helpers run as separate processes on purpose: a blocked Accessibility call can never take down the global hotkey.</p>
+  <section class="sec install" id="install">
+    <div class="wrap">
+      <div class="rule">install<span class="x"></span></div>
+<pre><span class="c"># apple silicon, macOS 13+, node 22.12+, xcode CLT</span>
+<span class="p">$</span> git clone https://github.com/Nabzx/openstream.git
+<span class="p">$</span> cd openstream && npm install && npm start</pre>
+      <p style="color:var(--muted);font-size:12px;margin-top:12px">models download on first launch, about 1.2 GB. <span class="acc">npm run doctor</span> checks the permissions.</p>
     </div>
   </section>
 
-  <section id="install">
-    <p class="eyebrow">Run it</p>
-    <h2>Build from source</h2>
-    <div class="section-body">
-      <p>OpenStream installs from source. You need an Apple Silicon Mac on macOS 13+, Node 22.12+, and Xcode Command Line Tools.</p>
-<pre><span class="c"># clone and install &mdash; this also compiles whisper.cpp and</span>
-<span class="c"># downloads the transcription + rewrite models (~1.3 GiB)</span>
-git clone https://github.com/Nabzx/openstream.git
-cd openstream
-npm install
-npm start</pre>
-      <p>OpenStream needs Microphone, Input Monitoring, and Accessibility permission. It opens on a Permissions screen with a link straight to each System Settings pane; <code>npm run doctor</code> runs the same check from the terminal.</p>
-      <p class="note"><b>Because it runs from source, every rebuild resets the macOS permission grants.</b> When you re-grant, remove the old OpenStream entry in System Settings first, then add the new build.</p>
-    </div>
-  </section>
-
-  <section id="demo-gif">
-    <p class="eyebrow">See it move</p>
-    <h2>The tool, working</h2>
-    <div class="section-body">
-      <p>A short screen recording of a real dictation &mdash; hotkey held, words appearing at the cursor, a line break dropped in the terminal.</p>
-      <div class="gif-slot">[ demo.gif goes here &mdash; drop the recording at <span class="mono">site/demo.gif</span> and swap this box for an &lt;img&gt; ]</div>
-    </div>
-  </section>
-
-  <section id="status">
-    <p class="eyebrow">Where it stands</p>
-    <h2>Honest status</h2>
-    <div class="section-body">
-      <ul class="plain">
-        <li>The full path runs from source today &mdash; hotkey, transcription, deterministic cleanup, break-safety, voice edits, delivery, and a real desktop window with a permissions gate and settings.</li>
-        <li>Distributes from source. The DMG is a convenience download; it is not signed or notarised yet, and a rebuild resets the macOS permission grants until it is &mdash; so <code>git clone</code> is the supported path.</li>
-        <li>Codebase-aware vocabulary and semantic edits (&ldquo;make this shorter&rdquo;) are on the roadmap, not in the app.</li>
+  <section class="sec st">
+    <div class="wrap">
+      <div class="rule">status<span class="x"></span></div>
+      <ul>
+        <li><b>pre-1.0.</b> the core path runs from source today.</li>
+        <li>source install for now. the DMG is unsigned; signing is next.</li>
+        <li>no account, no cloud, no telemetry, and that won't change.</li>
       </ul>
     </div>
   </section>
 
+  <footer>
+    <div class="wrap">
+      <a href="https://github.com/Nabzx/openstream">github</a> ·
+      <a href="https://github.com/Nabzx/openstream/blob/main/ROADMAP.md">roadmap</a> ·
+      <a href="https://github.com/Nabzx/openstream/tree/main/docs/progress">notes</a>
+      &nbsp;&nbsp;<span class="mut">~ a spoken newline is a suggestion, not a command.</span>
+    </div>
+  </footer>
+
 </main>
 
-<footer class="wrap">
-  <div class="links">
-    <a href="https://github.com/Nabzx/openstream">GitHub</a>
-    <a href="https://github.com/Nabzx/openstream/blob/main/CONTEXT.md">Vocabulary</a>
-    <a href="https://github.com/Nabzx/openstream/blob/main/ROADMAP.md">Roadmap</a>
-    <a href="https://github.com/Nabzx/openstream/tree/main/docs/progress">Engineering notes</a>
-  </div>
-  <p>MIT licensed. Local-first &mdash; no account, no cloud, no telemetry.</p>
-</footer>
+<div class="status" aria-hidden="true">
+  <span class="s">openstream(1)</span>
+  <span class="s d opt">dictation</span>
+  <span class="fill"></span>
+  <span class="s opt">local-first</span>
+  <span class="s opt">MIT</span>
+  <span class="s d">&#8997; to talk</span>
+</div>
 
 <script>
 (function () {
-  var demo = document.getElementById("demo");
-  if (!demo) return;
+  var reduce = matchMedia("(prefers-reduced-motion: reduce)").matches;
 
-  var prose = demo.querySelector('[data-role="prose"]');
-  var term = demo.querySelector('[data-role="term"]');
-  var proseV = demo.querySelector('[data-role="prose-verdict"]');
-  var termV = demo.querySelector('[data-role="term-verdict"]');
-
-  var reduce = window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-
-  // Each step: [element, text-to-append, newline-after]
-  var proseFinal = "Met the team this morning.\nShipping the parser fix today.";
-  var termFinal = "$ git commit -m \"fix the parser\" and then push to main";
-
-  function caret(el) {
-    var c = document.createElement("span");
-    c.className = "caret";
-    el.appendChild(c);
+  // hero demo
+  var el = document.getElementById("demo");
+  function endState() {
+    el.innerHTML =
+      '<span class="p">$</span> openstream\n' +
+      '<span class="l">listening</span>\n' +
+      '<span class="p">$</span> git commit -m "fix the null deref"\n' +
+      '  <span class="h">&#8627; newline held, not a safe target</span>\n' +
+      '<span class="p">$</span> <span class="cur"></span>';
   }
-  function clearCaret(el) {
-    var c = el.querySelector(".caret");
-    if (c) c.remove();
-  }
-
-  function typeInto(el, text, done) {
-    if (reduce) {
-      el.textContent = text;
-      caret(el);
-      done && done();
-      return;
+  if (el) {
+    if (reduce) { endState(); }
+    else {
+      var lines = [], i = 0;
+      var render = function () { el.innerHTML = lines.join("\n"); };
+      var q = [
+        { t: "l", h: '<span class="p">$</span> openstream', a: 320 },
+        { t: "l", h: '<span class="l">listening</span>', a: 900 },
+        { t: "ty", pre: '<span class="p">$</span> ', txt: 'git commit -m "fix the null deref"', s: 34, a: 480 },
+        { t: "l", h: '  <span class="h">&#8627; newline held, not a safe target</span>', a: 460 },
+        { t: "l", h: '<span class="p">$</span> <span class="cur"></span>', a: 0 }
+      ];
+      var next = function () {
+        if (i >= q.length) {
+          setTimeout(function () { lines = []; i = 0; render(); next(); }, 4200);
+          return;
+        }
+        var st = q[i];
+        if (st.t === "l") { lines.push(st.h); render(); i++; setTimeout(next, st.a); return; }
+        var idx = lines.push(st.pre) - 1, j = 0;
+        (function tick() {
+          lines[idx] = st.pre + st.txt.slice(0, j) + '<span class="cur"></span>';
+          render(); j++;
+          if (j <= st.txt.length) setTimeout(tick, st.s);
+          else { lines[idx] = st.pre + st.txt; render(); i++; setTimeout(next, st.a); }
+        })();
+      };
+      next();
     }
-    var i = 0;
-    clearCaret(el);
-    (function tick() {
-      el.textContent = text.slice(0, i);
-      caret(el);
-      i++;
-      if (i <= text.length) {
-        setTimeout(tick, text[i - 2] === " " ? 34 : 22);
-      } else {
-        done && done();
-      }
-    })();
   }
 
-  function run() {
-    prose.textContent = "";
-    term.textContent = "";
-    proseV.style.opacity = ".3";
-    termV.style.opacity = ".3";
-
-    typeInto(prose, proseFinal, function () {
-      proseV.style.opacity = "1";
-    });
-    setTimeout(function () {
-      typeInto(term, termFinal, function () {
-        termV.style.opacity = "1";
+  // wpm bars fill once on view
+  if ("IntersectionObserver" in window) {
+    var io = new IntersectionObserver(function (es) {
+      es.forEach(function (e) {
+        if (!e.isIntersecting) return;
+        e.target.querySelectorAll("i[data-w]").forEach(function (b) {
+          b.style.setProperty("--w", reduce ? b.dataset.w + "%" : b.dataset.w + "%");
+        });
+        io.unobserve(e.target);
       });
-    }, reduce ? 0 : 900);
+    }, { threshold: 0.4 });
+    document.querySelectorAll(".bars").forEach(function (n) { io.observe(n); });
+  } else {
+    document.querySelectorAll("i[data-w]").forEach(function (b) { b.style.setProperty("--w", b.dataset.w + "%"); });
   }
-
-  var started = false;
-  function maybeStart() {
-    if (started) return;
-    var r = demo.getBoundingClientRect();
-    if (r.top < window.innerHeight && r.bottom > 0) {
-      started = true;
-      run();
-      if (!reduce) setInterval(run, 11000);
-    }
-  }
-  maybeStart();
-  window.addEventListener("scroll", maybeStart, { passive: true });
 })();
 </script>
 </body>


### PR DESCRIPTION
Closes #278.

Full rewrite of site/index.html to the terminal/phosphor identity (docs/design/visual-identity.md), taking cues from wisprflow.ai for polish and pacing while keeping it terminal-native.

- **Hero owns the first screen** - a looping boot demo: openstream boots, listens, a git commit types itself, then the amber-free green note "newline held, not a safe target" and the command sits un-submitted. Loops every ~4s.
- **Space Mono** throughout. Two greens (#3DF65A neon, #1ED89A secondary) on near-black #020402. No amber.
- **The 4x hook** below the fold: "you type at 40. you talk at 150." with ASCII wpm bars that fill on scroll.
- **Positioning** as terminal output: `$ openstream --what` -> "wispr flow, but: open source / free / local / yours".
- Minimal copy, British, no dashes: safety split, `0` network calls, the git clone block, a 3-line status.
- tmux-style status bar pinned to the foot.

GIF slot deferred to #21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)