### PR TITLE
Fix window-close crash and finish the overlay panel border

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -191,7 +191,10 @@ function createWindow() {
       shortcutCaptureSender = null;
       fnShortcutCapture.stop();
     }
-    if (win?.webContents === windowContents) win = null;
+    // Reading win.webContents here throws "Object has been destroyed" - the
+    // window is already gone by "closed". createWindow() only ever has one
+    // win at a time and nothing else reassigns it, so just clear it.
+    win = null;
   });
 }
 
@@ -297,7 +300,7 @@ function createCaptureWindow() {
 // hideHeldResult() below can't drift from createOverlayWindow's initial
 // size the way it did once already (merge artifact: it briefly resized
 // back to the pre-redesign 180x52 instead of this).
-const OVERLAY_RESTING_SIZE = [220, 56];
+const OVERLAY_RESTING_SIZE = [244, 50];
 
 function createOverlayWindow() {
   overlayWin = new BrowserWindow({
@@ -306,14 +309,19 @@ function createOverlayWindow() {
     show: false,
     frame: false,
     transparent: true,
+    // The panel fills the window edge to edge with a 1px phosphor border,
+    // so the native rounded-corner mask must be off or it clips the
+    // border's corners, and the native drop shadow off or it haloes a
+    // hard-edged panel. See #281 / the overlay polish pass.
+    roundedCorners: false,
+    hasShadow: false,
     resizable: false,
     focusable: false,
     alwaysOnTop: true,
     skipTaskbar: true,
     // No vibrancy: the terminal rebrand (#281) wants a solid near-black
-    // panel, not frosted glass. The window stays frameless + transparent so
-    // overlay.css paints the panel (solid --bg, a 1px phosphor border, a
-    // faint scanline) and the transparent margin around it disappears.
+    // panel, not frosted glass. overlay.css paints it (solid --bg, a 1px
+    // phosphor border, a faint scanline).
     webPreferences: {
       preload: path.join(__dirname, "overlay", "overlayPreload.js"),
       contextIsolation: true,
@@ -329,7 +337,7 @@ function showHeldResult(text) {
   if (!overlayWin || overlayWin.isDestroyed()) return;
   overlayWin.setFocusable(true);
   overlayWin.setIgnoreMouseEvents(false);
-  overlayWin.setSize(420, 260, true);
+  overlayWin.setSize(432, 264, true);
   overlayWin.webContents.send("held-result", text);
   overlayWin.showInactive();
 }

--- a/electron/overlay/overlay.css
+++ b/electron/overlay/overlay.css
@@ -38,31 +38,33 @@
 html,
 body {
   margin: 0;
-  min-height: 100%;
+  height: 100%;
   background: transparent;
 }
 
 body {
-  display: grid;
-  place-items: center;
+  display: flex;
 }
 
-/* The overlay window is frameless + transparent with no vibrancy now, so
-   this paints a real panel: solid near-black, a 1px phosphor border, a
-   faint scanline, a soft outer glow. Hard edges - no radius. Shared by the
+/* The overlay window is frameless + transparent with no vibrancy. This
+   paints the panel: solid near-black, a 1px phosphor border, a faint
+   scanline, a hairline inner highlight. Hard edges - no radius. It fills
+   the window exactly (main.js sizes the window to the panel), so the
+   border sits flush on all four sides. No outer glow: the window bounds
+   would clip it and it would read as a broken frame. Shared by the
    recording strip and the held-result panel; the window resizes between
    them rather than swapping. */
 .overlay {
   box-sizing: border-box;
   position: relative;
-  width: 100%;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
   overflow: hidden;
   color: var(--fg);
   background: var(--bg);
   border: 1px solid var(--acc);
-  box-shadow:
-    0 0 22px var(--glow),
-    0 8px 30px rgb(0 0 0 / 55%);
+  box-shadow: inset 0 1px 0 rgb(61 246 90 / 14%);
   font-size: 13px;
 }
 
@@ -78,10 +80,11 @@ body {
 /* --- recording / editing strip --- */
 
 .recording {
+  flex: 1;
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 10px 16px;
+  padding: 0 15px;
   white-space: nowrap;
 }
 .recording::before {
@@ -132,7 +135,9 @@ body {
 
 .held-result {
   display: none;
-  padding: 14px 16px 16px;
+  flex-direction: column;
+  flex: 1;
+  padding: 13px 15px 15px;
 }
 
 .held-result h1 {
@@ -153,7 +158,9 @@ body {
 
 .held-result pre {
   box-sizing: border-box;
-  max-height: 118px;
+  flex: 1;
+  min-height: 56px;
+  max-height: 160px;
   margin: 0;
   overflow: auto;
   padding: 9px 10px;
@@ -196,7 +203,7 @@ button.secondary:hover { color: var(--bg); }
 /* --- state wiring (unchanged behaviour) --- */
 
 body[data-state="held"] .recording { display: none; }
-body[data-state="held"] .held-result { display: block; }
+body[data-state="held"] .held-result { display: flex; }
 
 body[data-state="editing"] .waveform,
 body[data-state="edit-message"] .waveform,


### PR DESCRIPTION
Two issues found after the rebrand landed on `main`.

## 1. Crash on window close / tray "Open Window" (closes #294)

The `win.on("closed")` handler (from 45e84e8) read `win.webContents` to decide whether to null the reference. By `closed` the window is destroyed and that getter throws `Object has been destroyed` — the uncaught **"A JavaScript error occurred in the main process"** dialog on pressing the close button. `win` was left non-null, so the next `createWindow()` called `win.show()` on the dead window and threw again, which broke tray **Open Window** too.

Fix: just clear `win`. `createWindow()` only ever holds one and nothing else reassigns it, so the guard was dead weight.

## 2. Overlay panel border incomplete (follows #281)

The 1px phosphor border looked broken: the native rounded-corner mask clipped its corners, the native drop shadow haloed the hard-edged panel, and the CSS outer glow was clipped by the window bounds into a partial frame.

- `roundedCorners: false` + `hasShadow: false` on the overlay window
- the panel fills the window edge to edge (`.overlay { flex: 1 }`, window sized to the panel), so the border is flush and complete on all four sides
- outer glow dropped; it lives on the text and cursor now, plus a hairline inner top highlight
- window `244×50` resting / `432×264` for the held-result panel; the held-result `<pre>` flexes to fill

## Preview

Overlay states, updated: https://claude.ai/code/artifact/8a0ecb07-d1a8-4623-be10-a7fbb90c6445

## Checks

- `node --check` on `electron/main.js`
- `npx vitest run` — 116 passed
- `node --test` overlay-position / window-state — pass
- `npm run build` clean

## Still needs a real Mac

Both fixes are runtime behaviour — worth confirming in the #228 pass: close/reopen the window a few times, and eyeball the overlay border on `⌥`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
