### PR TITLE
Add the beta-release label across the app and public surfaces, issue #288

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,8 @@ jobs:
         run: |
           {
             echo 'body<<EOF'
+            echo '**Beta release.**'
+            echo
             git tag -l --format='%(contents)' "${GITHUB_REF_NAME}"
             echo
             echo '---'

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # OpenStream
 
-Local-first voice dictation for Apple Silicon, built for developers. Hold a key, talk, let go. The text lands in whatever app is frontmost. Audio and every model request stay on the machine.
+**Beta release.** Local-first voice dictation for Apple Silicon, built for developers. Hold a key, talk, let go. The text lands in whatever app is frontmost. Audio and every model request stay on the machine.
 
 It has one firm opinion: **a spoken line break is denied by default.** A newline can submit a half-typed terminal command or send an unfinished message, so OpenStream checks the frontmost app and the focused field before it turns "new paragraph" into a real break. It survives only in apps you have allow-listed.
 
@@ -28,7 +28,7 @@ Planned, not yet in the app: codebase-vocabulary biasing (transcription weighted
 
 ## Install
 
-OpenStream installs from source. There is a convenience DMG on the [releases page](https://github.com/Nabzx/openstream/releases) — it downloads the speech models (~1.2 GB) on first run rather than bundling them — but it is unsigned (Gatekeeper will warn) and every rebuild resets the macOS permission grants (see below), so `git clone` is the supported path.
+OpenStream installs from source. Each GitHub [release](https://github.com/Nabzx/openstream/releases) is a **beta release** with a convenience DMG — it downloads the speech models (~1.2 GB) on first run rather than bundling them — but the DMG is unsigned (Gatekeeper will warn) and every rebuild resets the macOS permission grants (see below), so `git clone` is the supported path.
 
 ### Requirements
 
@@ -112,7 +112,7 @@ The global hotkey, macOS permission prompts, microphone capture, and insertion i
 
 ## Status
 
-Feature-complete for 1.0. The pipeline, the settings UI, the permissions gate, and release automation are all in place; the final on-device verification pass ([#228](https://github.com/Nabzx/openstream/issues/228)) is what stands between here and the `v1.0.0` tag.
+**Beta release**, feature-complete for 1.0. The pipeline, the settings UI, the permissions gate, and release automation are all in place; the final on-device verification pass ([#228](https://github.com/Nabzx/openstream/issues/228)) is what stands between here and the `v1.0.0` tag.
 
 ## License
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -245,7 +245,9 @@ function createApplicationMenu() {
   app.setAboutPanelOptions({
     applicationName: "OpenStream",
     applicationVersion: app.getVersion(),
-    copyright: "Local-first voice dictation. MIT (app) / Apache-2.0 (models). No telemetry.",
+    // #288: "Beta release" sits on the copyright line, right under the
+    // version - the version metadata itself is left untouched.
+    copyright: "Beta release. Local-first voice dictation. MIT (app) / Apache-2.0 (models). No telemetry.",
   });
 
   const template = [

--- a/site/index.html
+++ b/site/index.html
@@ -72,6 +72,10 @@ a:hover { background: var(--acc); color: var(--bg); }
 .top .brand { color: var(--fg-hi); font-size: 18px; letter-spacing: -0.01em; }
 .top .brand b { color: var(--acc); text-shadow: 0 0 16px var(--glow); }
 .top .brand .cur { width: 0.5em; height: 1em; }
+.top .brand .beta {
+  margin-left: 8px; padding: 1px 6px; border: 1px solid var(--line-hi);
+  color: var(--muted); font-size: 11px; letter-spacing: 0.04em; vertical-align: 2px;
+}
 .top a.gh { color: var(--muted); }
 .top a.gh:hover { color: var(--acc); background: none; }
 
@@ -220,7 +224,7 @@ footer a:hover { color: var(--acc); background: none; }
 <body>
 <div class="top">
   <div class="wrap">
-    <span class="brand">~ <b>openstream</b><span class="cur"></span></span>
+    <span class="brand">~ <b>openstream</b><span class="cur"></span><span class="beta">beta release</span></span>
     <a class="gh" href="https://github.com/Nabzx/openstream">github &#8599;</a>
   </div>
 </div>
@@ -313,7 +317,7 @@ footer a:hover { color: var(--acc); background: none; }
     <div class="wrap">
       <div class="rule">status<span class="x"></span></div>
       <ul>
-        <li><b>pre-1.0.</b> the core path runs from source today.</li>
+        <li><b>beta release.</b> pre-1.0; the core path runs from source today.</li>
         <li>source install for now. the DMG is unsigned; signing is next.</li>
         <li>no account, no cloud, no telemetry, and that won't change.</li>
       </ul>
@@ -335,6 +339,7 @@ footer a:hover { color: var(--acc); background: none; }
   <span class="s">openstream(1)</span>
   <span class="s d opt">dictation</span>
   <span class="fill"></span>
+  <span class="s opt">beta release</span>
   <span class="s opt">local-first</span>
   <span class="s opt">MIT</span>
   <span class="s d">&#8997; to talk</span>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -132,6 +132,9 @@ export default function Home({ navigate }: { navigate: (page: Page) => void }) {
           }
         />
         <div>
+          <div style={{ marginBottom: 8 }}>
+            <span className="tag">Beta release</span>
+          </div>
           <h1>
             {activity === "recording"
               ? "Listening…"


### PR DESCRIPTION
Implements #288's settled decisions. "Beta release" is the one label everywhere; no longer explanation added; version metadata and tag mechanics untouched.

## Placements (per #289 / #290 / #291 / #292)

| Surface | Change |
|---|---|
| **Home** (`src/pages/Home.tsx`) | small `Beta release` tag above the hero title |
| **Native About panel** (`electron/main.js`) | "Beta release." leads the copyright line, under the version |
| **README** | intro leads with **Beta release.**; releases framed as beta releases in Install; Status section reconciled with "feature-complete for 1.0" |
| **Landing page** (`site/index.html`) | `beta release` by the wordmark, a status-bar segment, and the status section's first line |
| **GitHub release notes** (`.github/workflows/release.yml`) | body leads with **Beta release.** |

Not touched, per the decisions: Permissions, Setup, the push-to-talk overlay, `package.json` version, tag/prerelease mechanics.

## Preview

Landing page with the marker: https://claude.ai/code/artifact/e0f97134-c70c-49e7-8f39-b8fb56c184e1

## Checks

- `npm run typecheck` / `npm run build` clean
- `npx vitest run` — 116 passed
- `node --check electron/main.js`
- `release.yml` parses as valid YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)
