### PR TITLE
Salvage the #173 NSWorkspace probe from the stale PR #229

### DIFF
--- a/prototypes/ax-notification-terminal-173/README.md
+++ b/prototypes/ax-notification-terminal-173/README.md
@@ -1,0 +1,43 @@
+# NSWorkspace notification-delivery prototype — issue #173
+
+**Throwaway measurement harness. It is not production helper code.**
+
+## Question
+
+`RealAppSwitchTracker` (in `native/accessibility-helper`) registers `NSWorkspace.didActivateApplicationNotification` on a background thread with a pumped run loop - the same pattern this harness uses. Running the real app from VS Code's integrated terminal instead of a plain Terminal window reproducibly left it stuck on whatever was frontmost at launch, no matter what real app was switched to afterward (see the issue body for the full reproduction).
+
+The working theory, from this project's own prior research (`prototypes/tcc-attribution-46/RESULTS.md`, issue #46): launching from an IDE-integrated terminal changes how macOS attributes the spawned process tree, and the same attribution quirk might mean the distributed `NSWorkspace` notification never reaches an observer registered by a process launched this way.
+
+This harness isolates exactly that question, stripped down from the full app: does a minimal process, launched from each terminal type, actually *receive* the notification when a real app switch happens - independent of Accessibility permissions, AX tree state, or anything else the full app also has going on.
+
+## Before running
+
+Have 2-3 real apps open and ready to switch between (Notes, Safari, whatever's convenient).
+
+## Running a trial
+
+One trial = one terminal type, ~35 seconds, switching apps a few times while it runs:
+
+```bash
+cd prototypes/ax-notification-terminal-173
+
+# from a normal Terminal.app window:
+./run.sh plain-terminal
+
+# from VS Code's integrated terminal panel (Terminal > New Terminal, or Ctrl+`):
+./run.sh vscode-terminal
+```
+
+Switch between your 2-3 apps a few times during each ~35 second run - at least 3-4 real switches, spaced out rather than all at once. Each run writes its own timestamped log to `logs/`, so running each label multiple times is fine and just adds more data.
+
+## Analyze
+
+```bash
+./analyze.py logs/*.jsonl
+```
+
+For each run, this reports the process ancestry (what this process was actually launched under - hard evidence, not an assumption from which window you typed the command into), how many real app transitions happened (from the periodic direct poll, the ground truth), and how many notification events the observer actually received. A run with real transitions but zero notification events is the bug, reproduced in isolation.
+
+## Capture
+
+Keep this harness and raw logs on the throwaway `prototype/ax-notification-terminal-173` branch, same convention as `../injection-thresholds-74` and `../electron-ax-tree-10`. The resolution comment on issue #173 holds the answer.

--- a/prototypes/ax-notification-terminal-173/RESULTS.md
+++ b/prototypes/ax-notification-terminal-173/RESULTS.md
@@ -1,0 +1,34 @@
+Status: **complete — the working theory is disproven, and the real root cause is found.**
+
+## The three runs
+
+| Log | Ancestry (immediate parent) | Real transitions | Notifications received | Verdict |
+|---|---|---|---|---|
+| `smoke-validation` | `claude.exe` (this CLI's shell) | 2 | 2 | delivered correctly |
+| `plain-terminal` | `herdr` (Terminal.app login shell) | 7 | 8 | delivered correctly |
+| `vscode-terminal` | `Code Helper` → `Code` | 5 | 5 | delivered correctly |
+
+The `vscode-terminal` run is genuinely parented under VS Code's process tree, and it received **every** app switch — the notification observer fired for each one and the periodic direct poll matched immediately after.
+
+## Conclusion
+
+**`NSWorkspace.didActivateApplicationNotification` delivery is not the problem.** A minimal process that registers the observer exactly the way `RealAppSwitchTracker` does — `queue: nil`, on a background thread, with `RunLoop.current.run()` — receives every notification, from all three launch contexts including VS Code's integrated terminal. The `#46` TCC-attribution quirk does not extend to `NSWorkspace` notification delivery.
+
+The bug is something the probe does **not** replicate: the probe also runs `RunLoop.main.run()` on its main thread. The real `accessibility-helper` never does — its main thread is parked in `readLine()` for the stdin command loop. `NSWorkspace` notifications are posted on the **main thread's run loop**; with `queue: nil` the observer block runs on that thread. The helper's background thread pumps its *own* run loop, but `NSWorkspace` never posts there, so the observer block **never fires** and the cached frontmost app stays frozen at the `init()` value.
+
+It was broken from *every* terminal, not just VS Code — VS Code just made the staleness obvious (full-screening Notes while the tracker stayed stuck on "Code").
+
+If the probe's `RunLoop.main.run()` line is removed, it reproduces the bug identically.
+
+## Fix
+
+`RealAppSwitchTracker.startObserving()` now schedules a 250ms `Timer` on the observing thread's run loop that reads `NSWorkspace.shared.frontmostApplication` directly and updates the cache on change — the exact read this probe's `directPoll` performed, which was accurate on every poll of every run. The main-thread notification is dropped entirely. See `fix/app-switch-tracker-runloop-173` / the resolution comment on #173.
+
+## Reproducing
+
+```bash
+cd prototypes/ax-notification-terminal-173
+./run.sh plain-terminal      # from a Terminal.app window, switch apps a few times
+./run.sh vscode-terminal     # from VS Code's integrated terminal, same
+./analyze.py logs/*.jsonl
+```

--- a/prototypes/ax-notification-terminal-173/analyze.py
+++ b/prototypes/ax-notification-terminal-173/analyze.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# PROTOTYPE — summarise issue #173 notification-delivery probe logs.
+# Usage: ./analyze.py logs/*.jsonl
+import json
+import sys
+
+
+def analyze(path):
+    events = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                events.append(json.loads(line))
+
+    polls = [e for e in events if e["event"] == "directPoll"]
+    notifications = [e for e in events if e["event"] == "notificationReceived"]
+    ancestry = next((e for e in events if e["event"] == "processAncestry"), None)
+
+    # A "real transition" is a change in what directPoll observed between
+    # consecutive polls - the ground truth for whether the app actually
+    # switched during this run, independent of whether the notification
+    # observer saw it.
+    transitions = 0
+    for prev, cur in zip(polls, polls[1:]):
+        if prev["appName"] != cur["appName"]:
+            transitions += 1
+
+    print(f"=== {path} ===")
+    if ancestry:
+        chain = " -> ".join(f"{p['name']}({p['pid']})" for p in ancestry["chain"])
+        print(f"  process ancestry: {chain}")
+    print(f"  polls: {len(polls)}, real app transitions observed: {transitions}")
+    print(f"  notification events received: {len(notifications)}")
+    if transitions > 0 and len(notifications) == 0:
+        print("  VERDICT: BUG REPRODUCED - real transitions happened but the observer never fired.")
+    elif transitions == 0:
+        print("  VERDICT: inconclusive - no app switching happened during this run, re-run and actually switch apps.")
+    elif transitions > 0 and len(notifications) > 0:
+        print("  VERDICT: notifications delivered correctly for this run.")
+    print()
+
+
+def main():
+    paths = sys.argv[1:]
+    if not paths:
+        print("usage: ./analyze.py logs/*.jsonl", file=sys.stderr)
+        sys.exit(2)
+    for path in paths:
+        analyze(path)
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/ax-notification-terminal-173/logs/plain-terminal-20260828-175110.jsonl
+++ b/prototypes/ax-notification-terminal-173/logs/plain-terminal-20260828-175110.jsonl
@@ -1,0 +1,23 @@
+{"chain":[{"name":".probe","pid":22785},{"name":"bash","pid":22765},{"name":"bash","pid":21823},{"name":"herdr","pid":45911}],"elapsedMs":1,"event":"processAncestry"}
+{"appName":"Terminal","elapsedMs":1012,"event":"directPoll","matchesNotificationCache":false}
+{"appName":"Terminal","elapsedMs":2010,"event":"directPoll","matchesNotificationCache":false}
+{"appName":"Terminal","elapsedMs":3012,"event":"directPoll","matchesNotificationCache":false}
+{"appName":"Google Chrome","bundleId":"com.google.Chrome","elapsedMs":3390,"event":"notificationReceived"}
+{"appName":"Google Chrome","elapsedMs":4011,"event":"directPoll","matchesNotificationCache":true}
+{"appName":"Google Chrome","elapsedMs":5012,"event":"directPoll","matchesNotificationCache":true}
+{"appName":"Code","bundleId":"com.microsoft.VSCode","elapsedMs":5424,"event":"notificationReceived"}
+{"appName":"Code","elapsedMs":6012,"event":"directPoll","matchesNotificationCache":true}
+{"appName":"Code","elapsedMs":7012,"event":"directPoll","matchesNotificationCache":true}
+{"appName":"Code","elapsedMs":8012,"event":"directPoll","matchesNotificationCache":true}
+{"appName":"Google Chrome","bundleId":"com.google.Chrome","elapsedMs":8030,"event":"notificationReceived"}
+{"appName":"Terminal","bundleId":"com.apple.Terminal","elapsedMs":8745,"event":"notificationReceived"}
+{"appName":"Terminal","elapsedMs":9010,"event":"directPoll","matchesNotificationCache":true}
+{"appName":"Finder","bundleId":"com.apple.finder","elapsedMs":9780,"event":"notificationReceived"}
+{"appName":"Finder","elapsedMs":10010,"event":"directPoll","matchesNotificationCache":true}
+{"appName":"Finder","elapsedMs":11010,"event":"directPoll","matchesNotificationCache":true}
+{"appName":"Notes","bundleId":"com.apple.Notes","elapsedMs":11097,"event":"notificationReceived"}
+{"appName":"Notes","elapsedMs":12011,"event":"directPoll","matchesNotificationCache":true}
+{"appName":"Finder","bundleId":"com.apple.finder","elapsedMs":12697,"event":"notificationReceived"}
+{"appName":"Finder","elapsedMs":13013,"event":"directPoll","matchesNotificationCache":true}
+{"appName":"Terminal","bundleId":"com.apple.Terminal","elapsedMs":13278,"event":"notificationReceived"}
+{"appName":"Terminal","elapsedMs":14012,"event":"directPoll","matchesNotificationCache":true}

--- a/prototypes/ax-notification-terminal-173/logs/smoke-validation-20260827-160520.jsonl
+++ b/prototypes/ax-notification-terminal-173/logs/smoke-validation-20260827-160520.jsonl
@@ -1,0 +1,39 @@
+{"chain":[{"name":".probe","pid":46910},{"name":"bash","pid":46885},{"name":"bash","pid":46883},{"name":"claude.exe","pid":6689},{"name":"claude.exe","pid":6670}],"elapsedMs":1,"event":"processAncestry"}
+{"appName":"Terminal","elapsedMs":1017,"event":"directPoll","matchesNotificationCache":false}
+{"appName":"Terminal","elapsedMs":2017,"event":"directPoll","matchesNotificationCache":false}
+{"appName":"Terminal","elapsedMs":3017,"event":"directPoll","matchesNotificationCache":false}
+{"appName":"Terminal","elapsedMs":4017,"event":"directPoll","matchesNotificationCache":false}
+{"appName":"Terminal","elapsedMs":5018,"event":"directPoll","matchesNotificationCache":false}
+{"appName":"Terminal","elapsedMs":6015,"event":"directPoll","matchesNotificationCache":false}
+{"appName":"Terminal","elapsedMs":7016,"event":"directPoll","matchesNotificationCache":false}
+{"appName":"Terminal","elapsedMs":8017,"event":"directPoll","matchesNotificationCache":false}
+{"appName":"Terminal","elapsedMs":9013,"event":"directPoll","matchesNotificationCache":false}
+{"appName":"Terminal","elapsedMs":10016,"event":"directPoll","matchesNotificationCache":false}
+{"appName":"Terminal","elapsedMs":11017,"event":"directPoll","matchesNotificationCache":false}
+{"appName":"Terminal","elapsedMs":12017,"event":"directPoll","matchesNotificationCache":false}
+{"appName":"Terminal","elapsedMs":13017,"event":"directPoll","matchesNotificationCache":false}
+{"appName":"Terminal","elapsedMs":14013,"event":"directPoll","matchesNotificationCache":false}
+{"appName":"Terminal","elapsedMs":15012,"event":"directPoll","matchesNotificationCache":false}
+{"appName":"Terminal","elapsedMs":16014,"event":"directPoll","matchesNotificationCache":false}
+{"appName":"Terminal","elapsedMs":17015,"event":"directPoll","matchesNotificationCache":false}
+{"appName":"Terminal","elapsedMs":18015,"event":"directPoll","matchesNotificationCache":false}
+{"appName":"Terminal","elapsedMs":19017,"event":"directPoll","matchesNotificationCache":false}
+{"appName":"Terminal","elapsedMs":20014,"event":"directPoll","matchesNotificationCache":false}
+{"appName":"Terminal","elapsedMs":21012,"event":"directPoll","matchesNotificationCache":false}
+{"appName":"Terminal","elapsedMs":22015,"event":"directPoll","matchesNotificationCache":false}
+{"appName":"Terminal","elapsedMs":23017,"event":"directPoll","matchesNotificationCache":false}
+{"appName":"Terminal","elapsedMs":24017,"event":"directPoll","matchesNotificationCache":false}
+{"appName":"Terminal","elapsedMs":25016,"event":"directPoll","matchesNotificationCache":false}
+{"appName":"Terminal","elapsedMs":26016,"event":"directPoll","matchesNotificationCache":false}
+{"appName":"Code","bundleId":"com.microsoft.VSCode","elapsedMs":26873,"event":"notificationReceived"}
+{"appName":"Code","elapsedMs":27016,"event":"directPoll","matchesNotificationCache":true}
+{"appName":"Code","elapsedMs":28016,"event":"directPoll","matchesNotificationCache":true}
+{"appName":"Google Chrome","bundleId":"com.google.Chrome","elapsedMs":28114,"event":"notificationReceived"}
+{"appName":"Google Chrome","elapsedMs":29013,"event":"directPoll","matchesNotificationCache":true}
+{"appName":"Google Chrome","elapsedMs":30016,"event":"directPoll","matchesNotificationCache":true}
+{"appName":"Google Chrome","elapsedMs":31016,"event":"directPoll","matchesNotificationCache":true}
+{"appName":"Google Chrome","elapsedMs":32016,"event":"directPoll","matchesNotificationCache":true}
+{"appName":"Google Chrome","elapsedMs":33016,"event":"directPoll","matchesNotificationCache":true}
+{"appName":"Google Chrome","elapsedMs":34016,"event":"directPoll","matchesNotificationCache":true}
+{"appName":"Google Chrome","elapsedMs":35016,"event":"directPoll","matchesNotificationCache":true}
+{"elapsedMs":35017,"event":"done"}

--- a/prototypes/ax-notification-terminal-173/logs/vscode-terminal-20260828-175242.jsonl
+++ b/prototypes/ax-notification-terminal-173/logs/vscode-terminal-20260828-175242.jsonl
@@ -1,0 +1,22 @@
+{"chain":[{"name":".probe","pid":23556},{"name":"bash","pid":23534},{"name":"bash","pid":22737},{"name":"Code Helper","pid":20812},{"name":"Code","pid":20435}],"elapsedMs":1,"event":"processAncestry"}
+{"appName":"Code","elapsedMs":1013,"event":"directPoll","matchesNotificationCache":false}
+{"appName":"Code","elapsedMs":2013,"event":"directPoll","matchesNotificationCache":false}
+{"appName":"Code","elapsedMs":3013,"event":"directPoll","matchesNotificationCache":false}
+{"appName":"Code","elapsedMs":4012,"event":"directPoll","matchesNotificationCache":false}
+{"appName":"Code","elapsedMs":5013,"event":"directPoll","matchesNotificationCache":false}
+{"appName":"Google Chrome","bundleId":"com.google.Chrome","elapsedMs":5897,"event":"notificationReceived"}
+{"appName":"Google Chrome","elapsedMs":6014,"event":"directPoll","matchesNotificationCache":true}
+{"appName":"Google Chrome","elapsedMs":7013,"event":"directPoll","matchesNotificationCache":true}
+{"appName":"Google Chrome","elapsedMs":8014,"event":"directPoll","matchesNotificationCache":true}
+{"appName":"Terminal","bundleId":"com.apple.Terminal","elapsedMs":8496,"event":"notificationReceived"}
+{"appName":"Terminal","elapsedMs":9012,"event":"directPoll","matchesNotificationCache":true}
+{"appName":"Finder","bundleId":"com.apple.finder","elapsedMs":9707,"event":"notificationReceived"}
+{"appName":"Finder","elapsedMs":10012,"event":"directPoll","matchesNotificationCache":true}
+{"appName":"Notes","bundleId":"com.apple.Notes","elapsedMs":10295,"event":"notificationReceived"}
+{"appName":"Notes","elapsedMs":11012,"event":"directPoll","matchesNotificationCache":true}
+{"appName":"Notes","elapsedMs":12012,"event":"directPoll","matchesNotificationCache":true}
+{"appName":"Code","bundleId":"com.microsoft.VSCode","elapsedMs":12913,"event":"notificationReceived"}
+{"appName":"Code","elapsedMs":13014,"event":"directPoll","matchesNotificationCache":true}
+{"appName":"Code","elapsedMs":14013,"event":"directPoll","matchesNotificationCache":true}
+{"appName":"Code","elapsedMs":15009,"event":"directPoll","matchesNotificationCache":true}
+{"appName":"Code","elapsedMs":16010,"event":"directPoll","matchesNotificationCache":true}

--- a/prototypes/ax-notification-terminal-173/probe.swift
+++ b/prototypes/ax-notification-terminal-173/probe.swift
@@ -1,0 +1,107 @@
+// PROTOTYPE — throwaway measurement harness for issue #173.
+// Registers NSWorkspace.didActivateApplicationNotification exactly the way
+// RealAppSwitchTracker does (background thread, pumped run loop) and logs
+// every event it actually receives, alongside a periodic direct poll of
+// NSWorkspace.shared.frontmostApplication from the same thread as ground
+// truth. Run this once from a plain Terminal window and once from VS
+// Code's integrated terminal, switch apps a few times during each run,
+// and compare - if the notification-driven log stays silent while the
+// periodic poll shows real transitions, that's the bug reproduced with a
+// minimal, isolated repro instead of the full app.
+import AppKit
+import Foundation
+
+let start = Date()
+func elapsedMs() -> Int { Int(Date().timeIntervalSince(start) * 1000) }
+
+final class EventLog {
+    private let handle: FileHandle
+    init(path: String) {
+        FileManager.default.createFile(atPath: path, contents: nil)
+        guard let handle = FileHandle(forWritingAtPath: path) else {
+            fputs("Cannot open output: \(path)\n", stderr)
+            exit(2)
+        }
+        self.handle = handle
+    }
+    func emit(_ event: String, _ fields: [String: Any] = [:]) {
+        var row = fields
+        row["event"] = event
+        row["elapsedMs"] = elapsedMs()
+        guard JSONSerialization.isValidJSONObject(row),
+              let data = try? JSONSerialization.data(withJSONObject: row, options: [.sortedKeys]) else { return }
+        handle.write(data)
+        handle.write(Data([0x0a]))
+        print("[\(elapsedMs())ms] \(event) \(fields)")
+    }
+}
+
+let outputPath = CommandLine.arguments.count > 1 ? CommandLine.arguments[1] : "probe.jsonl"
+let log = EventLog(path: outputPath)
+
+// Walk the parent process chain so we have hard evidence of what this
+// process was actually launched under, not just an assumption from which
+// terminal window we typed the command into.
+func processName(pid: pid_t) -> String {
+    var buffer = [CChar](repeating: 0, count: 4096)
+    let len = proc_name(pid, &buffer, UInt32(buffer.count))
+    return len > 0 ? String(cString: buffer) : "?"
+}
+func parentPid(of pid: pid_t) -> pid_t {
+    var info = kinfo_proc()
+    var size = MemoryLayout<kinfo_proc>.stride
+    var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, pid]
+    sysctl(&mib, UInt32(mib.count), &info, &size, nil, 0)
+    return info.kp_eproc.e_ppid
+}
+
+var chain: [[String: Any]] = []
+var pid = getpid()
+for _ in 0..<8 {
+    chain.append(["pid": Int(pid), "name": processName(pid: pid)])
+    let parent = parentPid(of: pid)
+    if parent <= 1 || parent == pid { break }
+    pid = parent
+}
+log.emit("processAncestry", ["chain": chain])
+
+print("PROTOTYPE #173 - NSWorkspace notification delivery probe")
+print("Run this from a plain Terminal window in one pass, VS Code's integrated terminal in another.")
+print("Switch between 2-3 real apps a few times over the next 30s while this runs.")
+print("Writing \(outputPath)")
+
+var lastKnownFrontmost: String? = nil
+
+// Same pattern as RealAppSwitchTracker: register + pump from the same
+// background thread, per the documented reason real reads of
+// NSWorkspace.shared.frontmostApplication go stale on a thread that never
+// pumps a run loop.
+Thread {
+    let notificationCenter = NSWorkspace.shared.notificationCenter
+    _ = notificationCenter.addObserver(
+        forName: NSWorkspace.didActivateApplicationNotification,
+        object: nil,
+        queue: nil
+    ) { note in
+        let app = note.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication
+        lastKnownFrontmost = app?.localizedName
+        log.emit("notificationReceived", [
+            "appName": app?.localizedName ?? "?",
+            "bundleId": app?.bundleIdentifier ?? "?",
+        ])
+    }
+
+    let pollTimer = Timer(timeInterval: 1.0, repeats: true) { _ in
+        let direct = NSWorkspace.shared.frontmostApplication
+        log.emit("directPoll", [
+            "appName": direct?.localizedName ?? "?",
+            "matchesNotificationCache": (direct?.localizedName ?? "?") == (lastKnownFrontmost ?? "?"),
+        ])
+    }
+    RunLoop.current.add(pollTimer, forMode: .common)
+    RunLoop.current.run(until: Date().addingTimeInterval(35))
+    log.emit("done", [:])
+    exit(0)
+}.start()
+
+RunLoop.main.run(until: Date().addingTimeInterval(36))

--- a/prototypes/ax-notification-terminal-173/run.sh
+++ b/prototypes/ax-notification-terminal-173/run.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# PROTOTYPE — build and run the issue #173 notification-delivery probe.
+#
+# Usage: type this in the terminal you're testing (plain Terminal.app, or
+# VS Code's integrated terminal panel), then switch between 2-3 real apps
+# a few times over the next 30 seconds while it runs.
+#
+#   ./run.sh plain-terminal   # run from a normal Terminal.app window
+#   ./run.sh vscode-terminal  # run from VS Code's integrated terminal panel
+set -euo pipefail
+cd "$(dirname "$0")"
+
+LABEL="${1:-}"
+if [[ -z "$LABEL" ]]; then
+  echo "usage: ./run.sh <label, e.g. plain-terminal or vscode-terminal>"
+  exit 2
+fi
+
+mkdir -p logs
+OUTPUT="logs/${LABEL}-$(date +%Y%m%d-%H%M%S).jsonl"
+
+swiftc probe.swift -o .probe
+trap 'rm -f .probe' EXIT
+
+./.probe "$OUTPUT"
+echo
+echo "Wrote $OUTPUT"
+echo "Analyze with: ./analyze.py logs/*.jsonl"


### PR DESCRIPTION
Docs/prototype only. Lifts `prototypes/ax-notification-terminal-173/` out of the stale PR #229 so it can be closed.

## Why not just resolve #229

`prototype/ax-notification-terminal-173` branched from a pre-Phase-3 main and never had main merged back into it. GitHub computes the merge base as an ancient commit, so its diff is `+3301 / -76` across 59 files — almost entirely **already-merged main history** (the `docs/PROGRESS.md` → `phase-1-progress.md` rename, the `src/dictation/*` → `electron/*.js` consolidation, the vocabulary cache, etc.) showing up as "conflicts". The branch has exactly **two real new commits**, and the fix they led to (`RealAppSwitchTracker` polling the frontmost app on its own thread) already shipped in **PR #226**. Resolving ~20 conflicted core files to recover one prototype directory is not worth it.

## What this preserves

The probe that **disproved** the working theory (that an IDE-terminal launch breaks `NSWorkspace` notification delivery, by analogy with the #46 TCC quirk) and found the real cause: the helper's main thread is parked in `readLine()`, so a `queue: nil` observer block posted to the main run loop never runs. Three instrumented runs (plain Terminal, VS Code terminal, smoke), the analysis script, and `RESULTS.md`.

## After this merges

Close #229 and delete `prototype/ax-notification-terminal-173`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
