### PR TITLE
Make the app window a glass panel (option C), issue #301

### DIFF
--- a/docs/design/visual-identity.md
+++ b/docs/design/visual-identity.md
@@ -8,14 +8,14 @@ This identity has moved twice. Phase 4's window pass (#242) gave the app a macOS
 
 ## The direction in one line
 
-OpenStream is a dictation tool whose whole thesis is that **a spoken line break should never submit your command**. The identity is calm, precise, and a little bit luminous: white text on a deep navy ground, blue and aqua accents that glow, soft-cornered panels, and one genuinely translucent surface — the push-to-talk bar.
+OpenStream is a dictation tool whose whole thesis is that **a spoken line break should never submit your command**. The identity is calm, precise, and a little bit luminous: white text, blue and aqua accents that glow, soft-cornered panels, and glass — both the app window and the push-to-talk bar sit on a native macOS vibrancy material, so the desktop tints through translucent panels. The landing page is its own thing (see per-surface).
 
 ## Why navy + blue-glow needs care
 
 This palette sits right next to a look that reads as generated: *the cyberpunk dashboard* — navy background, bright cyan accent, glow on everything, a grid or scanline. It's the same trap the phosphor green fell into (near-black + a lone acid pop). Blue glass avoids it the same way: by being a coherent, restrained world rather than a dark theme with a loud accent.
 
 - **Glow is a highlight, not a coat of paint.** It belongs on the live state (the mark, the listening text), the primary action, and headings — not on every border and every label. If everything glows, nothing reads.
-- **One translucent surface.** The overlay is glass because it floats over the desktop and wants to feel light. The window is opaque navy. Do not glass the window.
+- **Glass is a material, not a filter.** Both the window and the overlay use native `vibrancy`; panels are translucent so the desktop reads through, but every panel keeps a `backdrop-filter` and enough tint that text sits on frost, never on bare wallpaper. Text carries a hairline shadow for the bright-wallpaper case. Reduce Transparency falls back to a solid navy.
 - **Hierarchy is shades of blue-grey**, not blue-vs-grey. `--fg` is a warm off-white; `--muted` and `--faint` step down through blue-greys; the two accents (`--acc`, `--acc-2`) are the only saturated colour.
 - **Soft, not round.** `10px` radius, `7px` on small controls, pill on toggles and tags. Not pronounced, not pill-shaped buttons.
 - **Terse, man-page copy.** `SYNOPSIS / SAFETY / INSTALL`. No marketing throat-clearing. The `> ` prompt prefix and `──` rule marks survive as quiet nods to where this tool lives.
@@ -28,23 +28,26 @@ Animated grid / "tron" lines · a full glow on every element · gradient-mesh ba
 
 ### Colour
 
-| Token | Hex | Use |
-|---|---|---|
-| `--bg` | `#0B1D3A` | navy ground; the window paints a soft top glow over it (`--bg-hi` `#163A6B` → `--bg` → `#0A1730`) |
-| `--screen` | `#12294A` | panels, cards, fields (the app renders cards as a faint gradient over this) |
-| `--screen-2` | `#17335A` | keycaps, icon tiles, insets |
-| `--acc` | `#5CB8FF` | primary: headings' glow, prompts, the live state, primary button |
-| `--acc-2` | `#4FE0D4` | secondary: "starting" / pending state, small tags, the DMG arrow |
-| `--err` | `#F0503C` | genuine errors only: a missing permission, a dead server. Never decoration. |
-| `--fg` | `#DCE8FA` | body text — warm off-white |
-| `--fg-hi` | `#FFFFFF` | headings, active labels |
-| `--muted` | `#8AA3C4` | captions, secondary text, disabled |
-| `--faint` | `#5B76A0` | rule marks, prompt glyphs, empty-state text |
-| `--line` | `#1E3A5F` | hairlines between rows |
-| `--line-hi` | `#2E4E7A` | visible borders |
-| `--glow` | `rgba(92, 184, 255, 0.40)` | box-shadow / text-shadow bloom on the accent |
+The app window runs on `vibrancy: "under-window"`, so its surfaces are `rgba` over the material, not solid.
 
-**Overlay tokens differ** — the glass panel works against a native vibrancy material, so its surface is `rgba` and its text is white with a strong shadow for legibility over any wallpaper. See the overlay section.
+| Token | Value | Use |
+|---|---|---|
+| `--bg` | `#14335F` | solid navy — the Reduce-Transparency fallback; `body` is a translucent wash over the vibrancy |
+| `--screen` | `rgba(30,62,112,0.5)` | panels, cards |
+| `--screen-2` | `rgba(20,45,85,0.55)` | keycaps, fields, icon tiles, insets |
+| `--acc` | `#7FCBFF` | primary: headings' glow, prompts, the live state, primary button |
+| `--acc-2` | `#52E6D6` | secondary: "starting" / pending state, small tags, the DMG arrow |
+| `--err` | `#FF6B54` | genuine errors only: a missing permission, a dead server. Never decoration. |
+| `--fg` | `#EAF2FF` | body text |
+| `--fg-hi` | `#FFFFFF` | headings, active labels |
+| `--muted` | `#AEC5E2` | captions, secondary text, disabled |
+| `--faint` | `#7C97BE` | rule marks, prompt glyphs, empty-state text |
+| `--line` | `rgba(150,195,245,0.16)` | hairlines between rows |
+| `--line-hi` | `rgba(165,205,250,0.34)` | visible borders |
+| `--glow` | `rgba(127,203,255,0.45)` | box-shadow / text-shadow bloom on the accent |
+| `--shadow-text` | `0 1px 3px rgba(0,0,0,0.35)` | on every text run — legibility over a bright wallpaper |
+
+Cards and panels also carry `backdrop-filter: blur(20px) saturate(1.4)`. The **overlay** uses a lighter set again (whiter text, a brighter rim) — see its section. The **landing page** has its own palette entirely and is not glass.
 
 ### Type
 
@@ -73,9 +76,9 @@ The caret-in-a-ring **mark** is the glyph (icon, tray, the app's Home hero), rec
 
 ## Per-surface
 
-### 1. App window — `src/index.css` — **done** ([#300](https://github.com/Nabzx/openstream/issues/300))
+### 1. App window — `src/index.css` + `electron/main.js` — **done** ([#300](https://github.com/Nabzx/openstream/issues/300), glass in [#301](https://github.com/Nabzx/openstream/issues/301))
 
-The token ramp recoloured to white-on-navy with blue/aqua accents and glow; `--r` / `--r-sm` radius added across cards, buttons, fields, keycaps, the mark; pills, the toggle and tags go full-round. Cards get a faint gradient fill and a soft drop shadow. The navtab bracket glyphs give way to a tinted rounded pill on the active tab. The scanline is dialled to `rgba(0,0,0,0.05)`. Every class name kept — no `.tsx` churn. The macOS window structure (traffic lights, hidden-inset title bar) stays.
+`createWindow` runs on `vibrancy: "under-window"` + `visualEffectState: "active"` + `backgroundColor: "#14335F"` (the Reduce-Transparency fallback). `index.css` keeps `body` a translucent wash and every card/panel `rgba` + `backdrop-filter` so the desktop tints through frost. White-on-blue with blue/aqua accents and glow; `--r` / `--r-sm` radius across cards, buttons, fields, keycaps, the mark; pills, the toggle and tags full-round; the navtab active tab is a tinted rounded pill (brackets dropped). Every text run gets `--shadow-text`. The scanline is gone. Every class name kept — no `.tsx` churn. The macOS chrome (traffic lights, hidden-inset title bar) stays.
 
 ### 2. Push-to-talk overlay — `electron/overlay/` + `electron/main.js` — **done** ([#300](https://github.com/Nabzx/openstream/issues/300) / [#301](https://github.com/Nabzx/openstream/issues/301))
 
@@ -102,7 +105,8 @@ Can't theme the OS chrome. Copy matches the voice: tray tooltip `openstream — 
 ## Decisions
 
 - **Reference direction**: *(Aug 30 2026)* blue glass — calm, luminous, soft-cornered. Supersedes the terminal / phosphor direction settled two weeks earlier, which itself superseded the macOS-native look. Each pivot was the maintainer's call, made against prototypes.
-- **Colour**: `#5CB8FF` primary blue + `#4FE0D4` aqua secondary on a `#0B1D3A` navy ground, white text. One ANSI red `#F0503C` for genuine errors. No second bright hue. **Dark-only** — no light variant.
+- **Colour**: `#7FCBFF` primary blue + `#52E6D6` aqua secondary, white text, navy `#14335F` fallback ground. One red `#FF6B54` for genuine errors. No second bright hue. **Dark-only** — no light variant.
+- **Glass window** *(#301, pre-launch)*: the app window runs on `vibrancy: "under-window"`, panels translucent, text shadowed, solid-navy fallback. The overlay is the same idea at a lighter setting. True Liquid Glass (`NSGlassEffectView`, macOS 26) is still a native rewrite and still out of scope.
 - **Font**: JetBrains Mono, bundled locally for the app and overlay (one variable woff2), Google Fonts on the landing page. No separate display face.
 - **Geometry**: `10px` / `7px` / pill radius. Soft, not round.
 - **Overlay**: native `vibrancy: "hud"` + rounded + shadow; CSS glass on top at the "level 2" translucency point. True Liquid Glass is a post-launch native rewrite ([#301](https://github.com/Nabzx/openstream/issues/301)), not blocking v1.0.

--- a/electron/main.js
+++ b/electron/main.js
@@ -151,6 +151,14 @@ function createWindow() {
     // paints its own toolbar strip behind them (issue #211).
     titleBarStyle: "hiddenInset",
     title: "OpenStream",
+    // #301: the blue-glass window sits on a native "under-window" vibrancy
+    // material so the desktop shows through translucent panels. When macOS
+    // can't render it (Reduce Transparency), the window falls back to this
+    // solid navy so it still looks intentional. index.css keeps every
+    // panel semi-transparent to let the material read.
+    vibrancy: "under-window",
+    visualEffectState: "active",
+    backgroundColor: "#14335F",
     webPreferences: {
       preload: path.join(__dirname, "preload.js"),
       contextIsolation: true,

--- a/src/index.css
+++ b/src/index.css
@@ -1,8 +1,9 @@
-/* OpenStream desktop window - blue-glass identity, matching the landing
-   page (docs/design/visual-identity.md). JetBrains Mono, white text on a
-   navy ground, blue + aqua accents with glow, 10px radius. Dark only. The
-   macOS window chrome (traffic lights, hidden-inset title bar) stays;
-   everything inside it is recoloured. */
+/* OpenStream desktop window - blue-glass identity (docs/design/visual-identity.md).
+   JetBrains Mono, white text, blue + aqua accents with glow, 10px radius.
+   The window itself is a native "under-window" vibrancy material (#301):
+   panels are translucent so the desktop tints through, with a solid navy
+   fallback (main.js backgroundColor) when macOS can't render it. The macOS
+   chrome (traffic lights, hidden-inset title bar) stays. Dark only. */
 
 /* JetBrains Mono is bundled, not fetched - the app is local-first and runs
    offline. One variable woff2 (latin subset) covers the whole weight
@@ -18,24 +19,23 @@
 :root {
   color-scheme: dark;
 
-  --bg: #0B1D3A;           /* navy ground */
-  --bg-hi: #163A6B;        /* top of the page glow */
-  --bg-lo: #0A1730;        /* bottom of the page */
-  --screen: #12294A;       /* panels, cards, fields */
-  --screen-2: #17335A;     /* icon tiles, keycaps, insets */
-  --acc: #5CB8FF;          /* primary: headings, prompts, live state, primary button */
-  --acc-2: #4FE0D4;        /* secondary: pending / secondary state, small tags */
-  --err: #F0503C;          /* genuine errors only: missing permission, dead server */
-  --fg: #DCE8FA;           /* body text */
+  --bg: #14335F;           /* solid navy - the Reduce-Transparency fallback */
+  --screen: rgba(30, 62, 112, 0.5);        /* panels, cards - translucent over the vibrancy */
+  --screen-2: rgba(20, 45, 85, 0.55);      /* keycaps, fields, icon tiles, insets */
+  --acc: #7FCBFF;          /* primary: headings, prompts, live state, primary button */
+  --acc-2: #52E6D6;        /* secondary: pending / secondary state, small tags */
+  --err: #FF6B54;          /* genuine errors only: missing permission, dead server */
+  --fg: #EAF2FF;           /* body text */
   --fg-hi: #FFFFFF;        /* headings, active labels */
-  --muted: #8AA3C4;        /* captions, disabled */
-  --faint: #5B76A0;        /* labels, dividers-as-text */
-  --line: #1E3A5F;         /* hairlines */
-  --line-hi: #2E4E7A;      /* visible borders */
-  --acc-tint: rgba(92, 184, 255, 0.14);
-  --acc2-tint: rgba(79, 224, 212, 0.12);
-  --err-tint: rgba(240, 80, 60, 0.14);
-  --glow: rgba(92, 184, 255, 0.40);
+  --muted: #AEC5E2;        /* captions, disabled */
+  --faint: #7C97BE;        /* labels, dividers-as-text */
+  --line: rgba(150, 195, 245, 0.16);       /* hairlines */
+  --line-hi: rgba(165, 205, 250, 0.34);    /* visible borders */
+  --acc-tint: rgba(127, 203, 255, 0.16);
+  --acc2-tint: rgba(82, 230, 214, 0.14);
+  --err-tint: rgba(255, 107, 84, 0.16);
+  --glow: rgba(127, 203, 255, 0.45);
+  --shadow-text: 0 1px 3px rgba(0, 0, 0, 0.35);
 
   --r: 10px;               /* cards, panels, the mark */
   --r-sm: 7px;             /* buttons, fields, keycaps, tabs */
@@ -54,25 +54,26 @@
 
 * { box-sizing: border-box; }
 
+/* Transparent so the native "under-window" vibrancy shows; a faint blue
+   wash unifies it and keeps contrast when the desktop behind is bright.
+   With Reduce Transparency on, the window's solid --bg shows instead. */
 body {
   margin: 0;
-  background: radial-gradient(135% 90% at 30% -8%, var(--bg-hi) 0%, var(--bg) 44%, var(--bg-lo) 100%);
+  background: linear-gradient(180deg, rgba(32, 74, 132, 0.30), rgba(16, 40, 78, 0.40));
   color: var(--fg);
   -webkit-font-smoothing: antialiased;
   font-feature-settings: "liga" 0;
 }
 
-/* faint scanline; dialled almost to nothing - a texture cue, not a CRT */
-body::before {
-  content: "";
-  position: fixed;
-  inset: 0;
-  z-index: 9000;
-  pointer-events: none;
-  background: repeating-linear-gradient(0deg, transparent 0 2px, rgba(0, 0, 0, 0.05) 3px, transparent 4px);
-}
-
 button { font: inherit; }
+
+/* Text sits over a translucent panel over the desktop - a hairline shadow
+   keeps it readable when the wallpaper behind is bright or busy. */
+.hero h1, .hero p, .group > h2, .group-desc, .row-label, .row-label small,
+.card-label, .perm-item__title, .perm-item__why, .cmd-say, .cmd-becomes,
+.hint, .setting h2, .setting-guidance, .setup-item__head, .empty {
+  text-shadow: var(--shadow-text);
+}
 
 :focus-visible {
   outline: 1px solid var(--acc);
@@ -93,7 +94,7 @@ button { font: inherit; }
   align-items: center;
   gap: var(--space-2);
   padding: 0 var(--space-4) 0 92px; /* room for the inset traffic lights */
-  background: rgba(8, 20, 42, 0.55);
+  background: rgba(10, 26, 52, 0.28);
   border-bottom: 1px solid var(--line-hi);
   -webkit-app-region: drag;
 }
@@ -136,11 +137,13 @@ button { font: inherit; }
 /* --- building blocks --- */
 
 .card {
-  background: linear-gradient(180deg, rgba(30, 60, 105, 0.5), rgba(18, 41, 74, 0.5));
+  background: linear-gradient(180deg, rgba(92, 142, 208, 0.16), rgba(38, 78, 140, 0.24));
+  -webkit-backdrop-filter: blur(20px) saturate(1.4);
+  backdrop-filter: blur(20px) saturate(1.4);
   border: 1px solid var(--line-hi);
   border-radius: var(--r);
   overflow: hidden;
-  box-shadow: 0 8px 24px -14px rgba(0, 0, 0, 0.55), inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  box-shadow: 0 10px 30px -16px rgba(0, 0, 0, 0.5), inset 0 1px 0 rgba(255, 255, 255, 0.12);
 }
 
 .card-label {
@@ -190,7 +193,7 @@ button { font: inherit; }
   color: var(--muted);
 }
 
-.row-label { flex: 1; color: var(--fg-hi); }
+.row-label { flex: 1; color: var(--fg-hi); text-shadow: var(--shadow-text); }
 
 .row-label small {
   display: block;
@@ -399,7 +402,7 @@ button { font: inherit; }
   font-weight: 700;
   letter-spacing: -0.01em;
   color: var(--fg-hi);
-  text-shadow: 0 0 26px rgba(92, 184, 255, 0.35);
+  text-shadow: 0 0 26px rgba(127, 203, 255, 0.35), var(--shadow-text);
 }
 
 .hero p {
@@ -562,10 +565,12 @@ button { font: inherit; }
   align-items: flex-start;
   gap: 12px;
   padding: 14px 16px;
-  background: linear-gradient(180deg, rgba(30, 60, 105, 0.5), rgba(18, 41, 74, 0.5));
+  background: linear-gradient(180deg, rgba(92, 142, 208, 0.16), rgba(38, 78, 140, 0.24));
+  -webkit-backdrop-filter: blur(20px) saturate(1.4);
+  backdrop-filter: blur(20px) saturate(1.4);
   border: 1px solid var(--line-hi);
   border-radius: var(--r);
-  box-shadow: 0 8px 24px -14px rgba(0, 0, 0, 0.55), inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  box-shadow: 0 10px 30px -16px rgba(0, 0, 0, 0.5), inset 0 1px 0 rgba(255, 255, 255, 0.12);
 }
 .perm-item[data-granted="true"] { opacity: 0.6; }
 


### PR DESCRIPTION
Option C from the prototype: the app window becomes a native macOS glass panel. Closes #301.

## Preview (CSS mock over a fake desktop)
https://claude.ai/code/artifact/e7e1f8d8-2940-4421-8e7d-2891daa27589 — shown over a calm and a bright wallpaper so you can see where legibility sits.

## What changed

- **`electron/main.js`** — `createWindow` gets `vibrancy: "under-window"`, `visualEffectState: "active"`, and `backgroundColor: "#14335F"` (a solid navy that shows when macOS can't render the material — Reduce Transparency).
- **`src/index.css`** — `body` is a translucent wash; `.card`, `.perm-item` and `.toolbar` go `rgba` + `backdrop-filter: blur(20px)` so the desktop tints through frost. Palette lightens for the variable ground (`#7FCBFF` accent, `#EAF2FF` text, translucent borders). Scanline dropped. Every text run gets `--shadow-text` (`0 1px 3px rgba(0,0,0,.35)`) for the bright-wallpaper case. Class names unchanged — no `.tsx`.
- **`docs/design/visual-identity.md`** — the window is glass now, not opaque navy; new token values; "glass is a material, not a filter" note.

## Needs a real Mac (folds into #228)

- Confirm the vibrancy renders under `titleBarStyle: "hiddenInset"` and the toolbar strip behind the traffic lights still reads.
- The **bright-wallpaper legibility** — the mock suggests the toolbar and the `.hint` are the thinnest points. If they read too thin, bump the card tint alpha (0.24 → ~0.35); it's a dial, not a redesign.
- Reduce Transparency falls back to the solid navy sanely.

## Not this PR

- The landing page (white / cream + neon blue — you're picking between two artifacts).
- True Liquid Glass (`NSGlassEffectView`, macOS 26) — still needs a native overlay rewrite; spinning that off to its own issue.

## Checks
- `typecheck` / `build` clean · `vitest` 116 · `node --test` window/overlay-position pass · `node --check electron/main.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
