### PR TITLE
Fix the glass window not showing (opaque backgroundColor), issue #301

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -152,13 +152,13 @@ function createWindow() {
     titleBarStyle: "hiddenInset",
     title: "OpenStream",
     // #301: the blue-glass window sits on a native "under-window" vibrancy
-    // material so the desktop shows through translucent panels. When macOS
-    // can't render it (Reduce Transparency), the window falls back to this
-    // solid navy so it still looks intentional. index.css keeps every
-    // panel semi-transparent to let the material read.
+    // material so the desktop shows through translucent panels. The window
+    // background MUST be transparent or the opaque fill paints over the
+    // material and the glass never shows. Reduce Transparency then flattens
+    // the material; index.css's body wash keeps that fallback on-brand.
     vibrancy: "under-window",
     visualEffectState: "active",
-    backgroundColor: "#14335F",
+    backgroundColor: "#00000000",
     webPreferences: {
       preload: path.join(__dirname, "preload.js"),
       contextIsolation: true,

--- a/src/index.css
+++ b/src/index.css
@@ -54,12 +54,13 @@
 
 * { box-sizing: border-box; }
 
-/* Transparent so the native "under-window" vibrancy shows; a faint blue
-   wash unifies it and keeps contrast when the desktop behind is bright.
-   With Reduce Transparency on, the window's solid --bg shows instead. */
+/* Semi-transparent so the native "under-window" vibrancy shows through as
+   glass; the blue wash unifies it and holds contrast over a bright
+   desktop. With Reduce Transparency on, the material flattens and this
+   wash (plus --bg behind it) is what keeps the fallback on-brand. */
 body {
   margin: 0;
-  background: linear-gradient(180deg, rgba(32, 74, 132, 0.30), rgba(16, 40, 78, 0.40));
+  background: linear-gradient(180deg, rgba(22, 50, 92, 0.42), rgba(13, 34, 68, 0.5));
   color: var(--fg);
   -webkit-font-smoothing: antialiased;
   font-feature-settings: "liga" 0;


### PR DESCRIPTION
You reported the glass window not looking glassy. Two things:

## 1. The bug (this PR)

`backgroundColor: "#14335F"` was opaque, so it painted over the `NSVisualEffectView` and the vibrancy never showed — the window just looked like a flat navy panel. Fixed: `backgroundColor: "#00000000"` so the material composites through. Bumped the `index.css` body wash slightly so the Reduce-Transparency fallback still reads as a dark blue panel.

## 2. You may also be on a stale build

`npm start` does **not** rebuild the renderer. If you pulled `main` and ran `npm start` without `npm run build`, the main process picked up the new vibrancy call but the renderer served an old `dist/` with the opaque navy CSS — which would also hide the glass. After pulling this:

```
npm run build && npm start
```

or use `npm run dev` (rebuilds live).

## Checks
- `npm run build` / `npx vitest run` (116) / `node --check electron/main.js` clean

Still can't be verified headlessly — this needs your Mac.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
