### PR TITLE
Prototype: measure Parakeet TDT 0.6B v3 (#308)

### DIFF
--- a/prototypes/parakeet-308/README.md
+++ b/prototypes/parakeet-308/README.md
@@ -1,0 +1,48 @@
+# Parakeet prototype (#308)
+
+**Throwaway harness. Not production wiring, not on the build.**
+
+## Question
+
+`large-v3-turbo` was accurate but too slow ([#310](https://github.com/Nabzx/openstream/issues/310), reverted). Is **Parakeet TDT 0.6B v3** accurate enough and fast enough on Apple Silicon to replace `whisper base.en`?
+
+The research so far ([#204](https://github.com/Nabzx/openstream/issues/204), [#205](https://github.com/Nabzx/openstream/issues/205), `docs/competitive/opensuperwhisper.md`): NVIDIA's Parakeet, ~600 MB, very accurate, fast on the ANE. OpenSuperWhisper ships it in production via FluidAudio's Swift/CoreML package. The open question was always "does the local runtime hold up", and nobody had measured it here.
+
+## What this is
+
+`server.py` runs Parakeet via [parakeet-mlx](https://github.com/senstella/parakeet-mlx) and exposes the **same HTTP contract as the bundled `whisper-server`** on `:8178`:
+
+```
+POST /inference   multipart: file=<16kHz mono wav>, response_format=json
+  -> { "text": "..." }
+```
+
+So the app's transcription adapter works against it unchanged.
+
+## Measure it
+
+```bash
+./run.sh                       # venv + model download + serve on :8178
+```
+
+Then either:
+
+**A. Numbers only.** Record a handful of 16 kHz mono WAV clips of yourself dictating (short / one sentence / a paragraph), drop them in a folder, and:
+
+```bash
+./.venv/bin/python bench.py ./clips
+```
+
+Watch the **median and max latency**. The budget is end-of-speech to text-ready under 1 s ([ADR-0001](../../docs/adr/0001-no-llm-in-the-dictation-path.md)); this measures only the model call, so leave headroom for cleanup and delivery. `base.en` was ~0.6 s on a paragraph.
+
+**B. In the app.** Stop the app's own `whisper-server` and run the app pointed at this one instead (they share `:8178`). Quickest hack: comment out `whisperServer.start()` in `electron/main.js`, start `./run.sh`, then `npm start`. Dictate normally and judge accuracy in real use.
+
+## What a real integration looks like
+
+If Parakeet wins here, the production path is **not** this Python server. It is a Swift native helper built on **FluidAudio** (`AsrModels.downloadAndLoad`, CoreML / ANE) that compiles to a binary and is supervised exactly like `whisper-server`, `hotkey-helper` and `accessibility-helper` already are. No Python, no bundled venv. That is the ~1 week of work this prototype is meant to justify or rule out.
+
+Parakeet also emits literal ASR with no punctuation, so the deterministic rules engine stays in front of the cursor either way ([ADR-0002](../../docs/adr/0002-no-one-model-dictation-engine.md)).
+
+## Record the result
+
+Add a `RESULTS.md` here with the latency table and an accuracy read, then decide on #308.

--- a/prototypes/parakeet-308/bench.py
+++ b/prototypes/parakeet-308/bench.py
@@ -1,0 +1,81 @@
+"""Benchmark Parakeet against the numbers OpenStream's budget cares about.
+
+Point it at a folder of 16 kHz mono WAV clips (the same shape the app
+captures). It reports, per clip and in aggregate:
+
+  - warm transcription latency (the number that killed large-v3-turbo in #310)
+  - the transcript, so you can eyeball accuracy against what you said
+
+    ./.venv/bin/python bench.py ./clips
+
+The sub-1s budget is end-of-speech to text-ready (ADR-0001). This measures
+just the model call; add the rules-cleanup pass (~1ms) and delivery on top.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+import time
+import wave
+from pathlib import Path
+
+import numpy as np
+
+MODEL_ID = "mlx-community/parakeet-tdt-0.6b-v3"
+
+
+def load_wav(path: Path) -> tuple[np.ndarray, int]:
+    with wave.open(str(path), "rb") as wav:
+        frames = wav.readframes(wav.getnframes())
+        sr = wav.getframerate()
+        ch = wav.getnchannels()
+        audio = np.frombuffer(frames, dtype=np.int16).astype(np.float32) / 32768.0
+        if ch > 1:
+            audio = audio.reshape(-1, ch).mean(axis=1)
+    return audio, sr
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print(__doc__)
+        raise SystemExit(1)
+
+    clips = sorted(Path(sys.argv[1]).glob("*.wav"))
+    if not clips:
+        raise SystemExit(f"no .wav files in {sys.argv[1]}")
+
+    print(f"loading {MODEL_ID} ...")
+    t0 = time.perf_counter()
+    from parakeet_mlx import from_pretrained
+
+    model = from_pretrained(MODEL_ID)
+    print(f"cold load: {time.perf_counter() - t0:.1f}s\n")
+
+    # one warm-up so the first real timing isn't paying shader compilation
+    warm_audio, warm_sr = load_wav(clips[0])
+    model.transcribe(warm_audio, sample_rate=warm_sr)
+
+    latencies = []
+    for clip in clips:
+        audio, sr = load_wav(clip)
+        secs = len(audio) / sr
+        t0 = time.perf_counter()
+        result = model.transcribe(audio, sample_rate=sr)
+        dt = time.perf_counter() - t0
+        latencies.append((secs, dt))
+        print(f"{clip.name:28s}  {secs:5.1f}s audio  {dt * 1000:6.0f}ms  {(result.text or '').strip()!r}")
+
+    print()
+    print(f"clips: {len(latencies)}")
+    print(f"median latency: {sorted(dt for _, dt in latencies)[len(latencies) // 2] * 1000:.0f}ms")
+    print(f"max latency:    {max(dt for _, dt in latencies) * 1000:.0f}ms")
+    over = [n for (n, (_, dt)) in zip((c.name for c in clips), latencies) if dt > 1.0]
+    if over:
+        print(f"over the 1s budget: {', '.join(over)}")
+    else:
+        print("all clips under 1s")
+
+
+if __name__ == "__main__":
+    main()

--- a/prototypes/parakeet-308/run.sh
+++ b/prototypes/parakeet-308/run.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+# Stand up the Parakeet prototype server on :8178. Needs Python 3.10+ and
+# a network connection on the first run to fetch parakeet-mlx and the model
+# (~600 MB into the Hugging Face cache).
+#
+# With this running, start OpenStream normally: the app's whisper-server
+# supervisor will fail to bind :8178 (it's taken), so instead run the app
+# from source with the transcription server disabled - see README.md.
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+if [ ! -d .venv ]; then
+  python3 -m venv .venv
+  ./.venv/bin/pip install --quiet --upgrade pip
+  ./.venv/bin/pip install --quiet "parakeet-mlx" "fastapi" "uvicorn" "numpy" "python-multipart"
+fi
+
+exec ./.venv/bin/python server.py

--- a/prototypes/parakeet-308/server.py
+++ b/prototypes/parakeet-308/server.py
@@ -1,0 +1,79 @@
+"""Parakeet transcription server - a prototype for issue #308.
+
+Speaks the same HTTP contract as the bundled whisper-server so the Electron
+app's transcription adapter can point at it unchanged:
+
+    POST /inference   multipart form: file=<wav>, response_format=json, [prompt=<str>]
+      -> { "text": "..." }
+    GET  /            -> 200 (health)
+
+This is NOT production wiring. It needs Python + MLX on the machine, which
+the app cannot bundle the way it bundles the C++ whisper-server. A real
+integration would use FluidAudio (Swift + CoreML, compiles to a binary
+like the other native helpers, no Python) - the same package
+OpenSuperWhisper ships. This server exists only to measure whether
+Parakeet is accurate enough and fast enough to be worth that work.
+
+Run:  ./run.sh            (sets up the venv, downloads the model, serves on :8178)
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+import time
+import wave
+
+from fastapi import FastAPI, UploadFile, Form
+from fastapi.responses import JSONResponse
+import numpy as np
+import uvicorn
+
+MODEL_ID = "mlx-community/parakeet-tdt-0.6b-v3"
+HOST = "127.0.0.1"
+PORT = 8178
+
+print(f"loading {MODEL_ID} ...", flush=True)
+_t0 = time.perf_counter()
+from parakeet_mlx import from_pretrained  # noqa: E402
+
+model = from_pretrained(MODEL_ID)
+print(f"model ready in {time.perf_counter() - _t0:.1f}s", flush=True)
+
+app = FastAPI()
+
+
+@app.get("/")
+def health() -> JSONResponse:
+    return JSONResponse({"status": "ok", "model": MODEL_ID})
+
+
+@app.post("/inference")
+async def inference(
+    file: UploadFile,
+    response_format: str = Form("json"),
+    prompt: str = Form(""),  # accepted for contract parity; Parakeet has no initial-prompt hook
+) -> JSONResponse:
+    raw = await file.read()
+
+    # whisper-server accepts 16 kHz mono PCM WAV (see electron/wav*.js). Decode
+    # to float32 the same way parakeet-mlx's own loader would.
+    with wave.open(io.BytesIO(raw), "rb") as wav:
+        frames = wav.readframes(wav.getnframes())
+        sample_rate = wav.getframerate()
+        channels = wav.getnchannels()
+        audio = np.frombuffer(frames, dtype=np.int16).astype(np.float32) / 32768.0
+        if channels > 1:
+            audio = audio.reshape(-1, channels).mean(axis=1)
+
+    t0 = time.perf_counter()
+    result = model.transcribe(audio, sample_rate=sample_rate)
+    dt = time.perf_counter() - t0
+
+    text = (result.text or "").strip()
+    print(f"[inference] {dt * 1000:.0f}ms  {len(audio) / sample_rate:.1f}s audio  ->  {text!r}", flush=True)
+    return JSONResponse({"text": text})
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host=HOST, port=PORT, log_level="warning")


### PR DESCRIPTION
Prototype for #308. **Not for merge as-is** — a harness to measure Parakeet before committing to the integration.

## Why a harness and not the integration

`large-v3-turbo` was the "just swap the model" move and it was too slow on real hardware (#310, reverted). Parakeet is not a `.bin` swap — it needs a different runtime. Two hard facts:

1. **Python can't be bundled** the way the C++ `whisper-server` is. A production Parakeet integration means a **Swift native helper built on FluidAudio** (CoreML / ANE, compiles to a binary, supervised like `hotkey-helper` / `accessibility-helper`). That is what OpenSuperWhisper ships, and it is roughly a week of work.
2. **I can't measure latency headlessly.** The one number that matters — warm transcription time vs the sub-1s budget — needs your Mac.

So this PR is `prototypes/parakeet-308/`: a `parakeet-mlx` server that speaks the exact `/inference` contract of the bundled `whisper-server` on `:8178`, plus a `bench.py`. Run it, get the numbers, and #308 gets a real answer instead of another revert.

## Run it

```bash
prototypes/parakeet-308/run.sh          # venv + ~600 MB model + serve on :8178
prototypes/parakeet-308/.venv/bin/python prototypes/parakeet-308/bench.py ./clips
```

Watch median / max latency. `base.en` was ~0.6 s on a paragraph; the budget is 1 s end-to-end so leave headroom for cleanup + delivery.

## If it wins

Next PR is the FluidAudio Swift helper. Parakeet emits literal ASR with no punctuation, so the rules engine stays in front of the cursor regardless (ADR-0002).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
