### PR TITLE
Honour a spoken break command when AX isn't ready in a break-safe app (#307)

### DIFF
--- a/docs/testing/break-safe-apps-settings-19.md
+++ b/docs/testing/break-safe-apps-settings-19.md
@@ -19,6 +19,10 @@ line break actually landing (or not) in the chosen app.
    app you added — the break lands. Also try "bullet point". Do the same in
    Terminal — both are dropped, the text runs on, and the console shows a
    `[dictation] context.breakCommandDropped: <bundleId>` line (#307).
+   Then dictate straight into a just-opened Notes document (before the body
+   is AX-ready): the break still lands, and the console shows
+   `[dictation] context.oneLineGuessOverridden: com.apple.Notes` — the
+   one-line guess was overridden because Notes is break-safe (#307).
 6. **Remove** an app, then **Restore defaults** — the list returns to the
    defaults.
 7. Quit and relaunch OpenStream. The list (minus anything removed, plus

--- a/electron/dictationCoordinator.js
+++ b/electron/dictationCoordinator.js
@@ -104,6 +104,21 @@ function createDictationIntake(options) {
     emitDiagnostic("context.breakSafe", breakSafe);
     emitDiagnostic("context.oneLineField", focusContext.isOneLineField);
 
+    // #307: when the focused element wasn't AX-ready, isOneLineField is a
+    // guess, not a real role read - and the guess is "one-line" (#181). In a
+    // break-safe app that guess is almost always wrong: the frontmost thing
+    // is the document body, not a search box. Letting a wrong guess suppress
+    // a spoken "new paragraph" / "bullet point" is exactly the Notes bug -
+    // the command silently degrades to a space and the words vanish. So in a
+    // break-safe app, don't let an AX *guess* stand in for a one-line field.
+    // A real role read (axReady true) is still honoured either way, and
+    // automatic break placement below stays on the raw guess - conservative.
+    const oneLineGuessed = focusContext.isOneLineField && focusContext.axReady === false;
+    const treatAsOneLine = focusContext.isOneLineField && !(breakSafe && oneLineGuessed);
+    if (focusContext.isOneLineField && !treatAsOneLine) {
+      emitDiagnostic("context.oneLineGuessOverridden", focusContext.bundleId);
+    }
+
     // #307: a spoken "new paragraph" / "new line" / "bullet point" in an app
     // that isn't on the break-safe allow-list is degraded to a space by
     // cleanup() and looks, to the user, like the command was ignored. Name
@@ -115,7 +130,7 @@ function createDictationIntake(options) {
     }
 
     let finishedText = cleanup(rawText, {
-      oneLineBox: focusContext.isOneLineField,
+      oneLineBox: treatAsOneLine,
       breakSafe,
     });
     if (!finishedText) {

--- a/electron/dictationCoordinator.test.js
+++ b/electron/dictationCoordinator.test.js
@@ -153,12 +153,51 @@ test("a not-AX-ready context (#181) delivers as one paragraph and records the fa
 
   const result = await harness.intake.complete(completedWav);
 
-  // isOneLineField:true (the safe default when axReady is false) means no
-  // break-placement call and no line breaks - just deliver the text.
+  // isOneLineField:true is only a guess when axReady is false, so it no
+  // longer drives automatic break placement - that stays off (breakCalls
+  // 0) - and with no spoken break command in the transcript there are no
+  // line breaks to emit anyway.
   assert.equal(breakCalls, 0);
   assert.equal(result.status, "delivered");
   assert.ok(!result.text.includes("\n"));
   assert.ok(harness.diagnostics.some(([name, value]) => name === "context.axReady" && value === false));
+});
+
+test("#307: a spoken break command survives an AX guess in a break-safe app", async () => {
+  const harness = createIntake({
+    // The Notes repro: the body isn't AX-ready yet, so isOneLineField is a
+    // guessed "true". Notes is break-safe, so an explicit spoken command
+    // must still land rather than degrade to a space.
+    transcript: "hi my name is Nabil new paragraph my name is Bob",
+    getFocusContext: async () => ({ bundleId: "com.apple.Notes", isOneLineField: true, axReady: false }),
+  });
+
+  const result = await harness.intake.complete(completedWav);
+
+  assert.equal(result.status, "delivered");
+  assert.ok(result.text.includes("\n\n"), `expected a paragraph break, got ${JSON.stringify(result.text)}`);
+  assert.ok(
+    harness.diagnostics.some(
+      ([name, value]) => name === "context.oneLineGuessOverridden" && value === "com.apple.Notes",
+    ),
+  );
+});
+
+test("#307: a real one-line field (axReady) still strips a spoken break command", async () => {
+  const harness = createIntake({
+    // axReady true means isOneLineField is a real role read, not a guess -
+    // a genuine single-line box, so the break must not land.
+    transcript: "hi my name is Nabil new paragraph my name is Bob",
+    getFocusContext: async () => ({ bundleId: "com.apple.Notes", isOneLineField: true, axReady: true }),
+  });
+
+  const result = await harness.intake.complete(completedWav);
+
+  assert.equal(result.status, "delivered");
+  assert.ok(!result.text.includes("\n"));
+  assert.ok(
+    !harness.diagnostics.some(([name]) => name === "context.oneLineGuessOverridden"),
+  );
 });
 
 test("eligible long dictation sends cleaned sentences once and applies returned break indices", async () => {


### PR DESCRIPTION
## What

The Notes repro: dictating "Hi my name is Nabil, *new paragraph*, my name is Bob" drops the `new paragraph` entirely, so the words either side run together.

## Why

`electron/dictationCoordinator.js` passes `focusContext.isOneLineField` straight into `cleanup()` as `oneLineBox`. When the focused element wasn't AX-ready, that flag is a **guess** and the guess is always "one-line" (#181). Notes' body is WebKit-backed and often isn't AX-ready on the first dictation, so:

- `oneLineBox: true` -> `allowNewlines` false -> the literal `\n\n` from "new paragraph" degrades to a single space in `applySpokenPunct`, and
- `hasExplicitBreakCommand` is true, so automatic break placement is skipped too.

Nothing produces the paragraph. To the user the command "just disappears".

## Fix

In a **break-safe** app, don't let a *guessed* one-line field (`axReady === false`) suppress the newline. The frontmost surface in a document app is the body, not a search box, so the guess is almost always wrong there. A real role read (`axReady` true) is still honoured, and automatic break placement still keys off the raw guess so that path stays conservative.

Adds a `context.oneLineGuessOverridden` diagnostic so an on-device repro is conclusive.

## Tests

- `node --test electron/**/*.test.js` - 258 pass, 1 pre-existing skip
- `npx vitest run` - 116 pass
- `npm run typecheck` - clean
- Two new coordinator tests: the guess is overridden in a break-safe app; a real one-line field still strips the command.

Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)