### PR TITLE
Cache-bust the README banner image

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The words land at your cursor and never leave your Mac.
 
 </div>
 
-<img src="assets/readme-banner.png" alt="OpenStream" width="100%">
+<img src="assets/readme-banner.png?v=2" alt="OpenStream" width="100%">
 
 <!-- demo.gif goes here once recorded on device (#21) -->
 


### PR DESCRIPTION
The banner PNG was updated to the new stream mark in #324 but GitHub is still serving the cached old image. Appending `?v=2` forces a re-fetch.