### PR TITLE
Stop spoken break commands leaving a stray mark (#320)

### DIFF
--- a/electron/cleanup/rules.js
+++ b/electron/cleanup/rules.js
@@ -23,9 +23,21 @@ const LEADING_FILLERS = [
   "actually", "literally", "anyway", "like",
 ];
 
+// #320: since the transcription engine moved to Parakeet (#204), which
+// punctuates from prosody, a spoken break command said with a pause around
+// it comes through as its own sentence - "... three. New paragraph. Four
+// ..." - and the bare `\bnew paragraph\b` match left the wrapping "." behind
+// as a stray mark at the start of the new line. So the break patterns now
+// also eat: any leading comma/semicolon/colon (a Parakeet artifact - a real
+// sentence-ending . ! ? before the command is left alone, it closed the
+// previous thought), and any single trailing . , ! ? ; : plus the spaces on
+// both sides. Un-punctuated TTS-style input ("first line new line second
+// line") still matches exactly as before.
+const BREAK_LEAD = "[ \\t]*[,;:]?[ \\t]*";
+const BREAK_TAIL = "[.,!?;:]?[ \\t]*";
 const SPOKEN_PUNCT = [
-  [/\bnew paragraph\b/gi, "\n\n"],
-  [/\bnew line\b/gi, "\n"],
+  [new RegExp(`${BREAK_LEAD}\\bnew paragraph\\b${BREAK_TAIL}`, "gi"), "\n\n"],
+  [new RegExp(`${BREAK_LEAD}\\bnew line\\b${BREAK_TAIL}`, "gi"), "\n"],
   // #124: scoped to explicit trigger phrases only, not the ordinal-word
   // heuristic ("first," ... "second," ...) the issue leaves open - that
   // heuristic risks misfiring on ordinary prose ("first, second, and
@@ -38,7 +50,7 @@ const SPOKEN_PUNCT = [
   // "new bullet point" - the natural variants people reach for. All are
   // explicit list commands, unlikely in ordinary prose; the plural
   // "bullet points" is the one people say most and was missing.
-  [/\b(?:bullet points?|(?:new|next) bullets?(?: points?)?)\b/gi, "\n- "],
+  [new RegExp(`${BREAK_LEAD}\\b(?:bullet points?|(?:new|next) bullets?(?: points?)?)\\b${BREAK_TAIL}`, "gi"), "\n- "],
   [/\bfull stop\b/gi, "."],
   [/\bperiod\b/gi, "."],
   [/\bcomma\b/gi, ","],

--- a/electron/cleanup/rules.test.js
+++ b/electron/cleanup/rules.test.js
@@ -209,6 +209,37 @@ test("bullet point in a one-line field also degrades, even if the app is break-s
   assert.equal(out, "Milk eggs");
 });
 
+test("#320: a break command Parakeet wrapped in punctuation leaves no stray mark", () => {
+  // Parakeet punctuates from prosody: a pause around the command makes it
+  // its own sentence.
+  assert.equal(
+    cleanup("testing one two three. New paragraph. Testing four five six.", { breakSafe: true }),
+    "Testing one two three.\n\nTesting four five six.",
+  );
+  assert.equal(
+    cleanup("first line. New line. Second line.", { breakSafe: true }),
+    "First line.\nSecond line.",
+  );
+  // A leading comma is a Parakeet artifact and gets eaten; a leading full
+  // stop closed the previous thought and stays.
+  assert.equal(
+    cleanup("buy milk, new paragraph, buy eggs", { breakSafe: true }),
+    "Buy milk\n\nBuy eggs.",
+  );
+});
+
+test("#320: a Parakeet-punctuated bullet run starts a clean list", () => {
+  const out = cleanup("shopping list. Bullet point. Milk. Bullet point. Eggs.", { breakSafe: true });
+  assert.equal(out, "Shopping list.\n- Milk.\n- Eggs.");
+});
+
+test("#320: the punctuation-eating still degrades to a space outside a break-safe app", () => {
+  assert.equal(
+    cleanup("testing one two three. New paragraph. Testing four.", { breakSafe: false }),
+    "Testing one two three. Testing four.",
+  );
+});
+
 test("converts spoken symbols", () => {
   const cases = [
     ["fifty percent off", "Fifty% off."],


### PR DESCRIPTION
Since Parakeet (#317), which punctuates from prosody, a spoken "new paragraph" said with a pause comes through as `... three. New paragraph. Four ...`. The bare `\bnew paragraph\b` match swapped in the break but left the `.` behind, so the new line started with a stray `.`.

The new-line / new-paragraph / bullet patterns now also consume:
- a leading `,` `;` `:` (a Parakeet artifact - a real `.` `!` `?` before the command closed the previous thought and is left alone)
- one trailing `.` `,` `!` `?` `;` `:`
- the spaces on both sides

Un-punctuated TTS-style input (`first line new line second line`) matches exactly as before. 5 new test cases; 48 rules tests + 266 node + 116 vitest + typecheck all green.

Closes #320

Generated with [Claude Code](https://claude.com/claude-code)