### PR TITLE
Log main-process errors instead of a crash dialog on teardown

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -48,6 +48,37 @@ if (!app.requestSingleInstanceLock()) {
   process.exit(0);
 }
 
+// An uncaught exception in the main process pops Electron's default error
+// dialog - which, on window close or app teardown, reads to a user as "the
+// app crashed" even when nothing important broke. Log the full stack to the
+// terminal instead, and only re-raise the dialog for an error that isn't
+// part of shutdown. See #294/#295 for the class of teardown race this
+// catches; the log line is what a repro needs to pin the next one.
+let quitting = false;
+app.on("before-quit", () => {
+  quitting = true;
+});
+// Launched from an editor's integrated terminal, closing that editor sends
+// the app a signal rather than going through before-quit. Treat it as a
+// quit so teardown races don't surface as a crash dialog.
+for (const signal of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+  process.on(signal, () => {
+    quitting = true;
+    app.quit();
+  });
+}
+process.on("uncaughtException", (error) => {
+  const stack = error && error.stack ? error.stack : String(error);
+  console.error(`[main] uncaught exception${quitting ? " during shutdown" : ""}:\n${stack}`);
+  if (!quitting) {
+    dialog.showErrorBox("OpenStream hit an unexpected error", stack);
+  }
+});
+process.on("unhandledRejection", (reason) => {
+  const stack = reason && reason.stack ? reason.stack : String(reason);
+  console.error(`[main] unhandled promise rejection${quitting ? " during shutdown" : ""}:\n${stack}`);
+});
+
 const isDev = process.env.NODE_ENV === "development";
 
 const TRAY_ICON_FILES = {


### PR DESCRIPTION
During the #228 pass, closing OpenStream while it was running from VS Code's integrated terminal popped a repeating "JavaScript error" dialog.

An uncaught exception in the Electron main process triggers the default error box. On window close or an editor killing the app, that is almost always a benign teardown race (the #294/#295 class - a `.send()` to a webContents mid-destruction) but it reads to the user as a crash.

This change:
- adds a `uncaughtException` handler that logs the full stack with a `[main]` prefix and only re-shows the dialog when the error is **not** part of shutdown
- sets a `quitting` flag on `before-quit` **and** on SIGTERM/SIGINT/SIGHUP - an editor closing its integrated terminal signals the process rather than going through `before-quit`
- logs unhandled promise rejections the same way

It does not fix the underlying race - it makes it non-scary and, crucially, **logs the stack** so the next repro pins the exact cause. Typecheck clean; 266 tests pass (main.js has no unit tests).

Generated with [Claude Code](https://claude.com/claude-code)