### PR TITLE
Add a 'help spread the word' doc for users

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Every PR gets a review before it merges, and CI (`npm run build`) has to pass. R
 
 Before a change that touches how the pipeline behaves, read the matching doc: `CONTEXT.md` is the glossary, `docs/adr/` records the decisions and why they went that way, `docs/progress/` is the running history. `AGENTS.md` lists the few hard invariants.
 
+Not a coder? There's no company behind OpenStream and no marketing budget. If it's useful to you, [a star and a word to one other person](docs/marketing/spread-the-word.md) is the biggest help there is.
+
 ## Licence
 
 [MIT](LICENSE)

--- a/docs/marketing/spread-the-word.md
+++ b/docs/marketing/spread-the-word.md
@@ -1,0 +1,81 @@
+# Help OpenStream reach more people
+
+OpenStream is free, MIT, and built by two of us in our spare time. There is no
+company behind it, no funding, and no marketing budget. If the app is useful to
+you, the single most valuable thing you can do is help other people find it.
+
+Here is how, smallest effort first.
+
+## Two minutes
+
+- **Star the repo.** Click the ☆ at the top of [the GitHub page](https://github.com/Nabzx/openstream).
+  It is the clearest signal that people actually want this, and it is how most
+  developers decide whether a new project is worth their time. It costs you
+  nothing and it genuinely moves the needle.
+- **Tell one person.** A colleague who dictates a lot, someone who is tired of
+  paying for Wispr Flow, anyone who has ever fired off a half-typed command by
+  accident. One good word-of-mouth recommendation is worth more than a hundred
+  impressions.
+- **Watch the repo** (Watch → Releases only) so you hear about new versions and
+  can mention them when they land.
+
+## If you want words
+
+The one-line pitch:
+
+> Local Mac voice dictation that checks which app you are in before it types a
+> line break, so a spoken "new paragraph" cannot fire off a half-typed command or
+> send an unfinished message. Free, open source, runs entirely on your Mac.
+
+Or just link the demo at the top of [the README](https://github.com/Nabzx/openstream#readme)
+and let it speak for itself.
+
+## If you are active in a community
+
+You know your community better than we do. If any of these are yours, a genuine
+"I have been using this" post or comment helps far more than we could from the
+outside. Lead with the angle that fits:
+
+| Where | The angle that lands |
+|---|---|
+| **Hacker News** | A Show HN, or even a comment linking it on a relevant thread. The break-safety idea (a spoken newline never submits your command) is the hook. |
+| **Lobsters** | Same, tagged `show`. |
+| **r/LocalLLaMA** | On-device, nothing leaves the machine. Parakeet on the Apple Neural Engine. |
+| **r/macapps**, **r/MacOSApps** | Free, private, no account. A real alternative to the paid dictation apps. |
+| **r/opensource** | MIT, auditable, contributions welcome. |
+| **r/commandline**, **r/neovim**, **r/vim** | A stray newline submitting a half-typed command is your exact pain. This fixes it. |
+| **r/productivity** | You talk about four times faster than you type. |
+| **r/apple** | Self-promotion is Sundays only there, and developers only. |
+
+Disclose that you use it (or built it, if you are a contributor). Do not spam
+the same link across ten subreddits in a day.
+
+## If you write or make things
+
+- **Run a newsletter?** OpenStream fits [Console.dev](https://console.dev),
+  [TLDR](https://tldr.tech), [The Changelog](https://changelog.com/news), Mac
+  and privacy newsletters, and on-device-AI roundups. We would love a mention.
+- **Make videos?** If you cover Mac apps or developer tools, get in touch through
+  a [GitHub issue](https://github.com/Nabzx/openstream/issues/new) or a
+  Discussion and we will happily walk you through it or answer questions on
+  camera. Channels whose audience fits: Keep Productive, MacMost, Snazzy Labs,
+  Christian Selig, the dev streamers.
+- **Write a blog post?** How the break-safety works, how it compares to what you
+  were using, what a fully local dictation pipeline looks like inside. Link it in
+  a Discussion and we will share it.
+
+Directory listings help too, and they last: add OpenStream on
+[AlternativeTo](https://alternativeto.net) as an alternative to Wispr Flow and
+superwhisper, or open a PR to `awesome-macos`.
+
+## Report bugs, open pull requests
+
+An engaged user who files a clear bug report or sends a small fix is worth more
+to this project than any amount of promotion. See
+[Contributing](https://github.com/Nabzx/openstream#contributing). Every issue and
+PR also makes the repo look alive, which is its own kind of marketing.
+
+## Thank you
+
+Seriously. A project like this lives or dies on whether the people who find it
+useful tell the next person. If you got this far, you are already helping.


### PR DESCRIPTION
You asked for a marketing doc that entices other OpenStream users to help promote it, so this is written for **them**, not us.

`docs/marketing/spread-the-word.md`:
- **Two minutes:** star the repo (with why it matters), tell one person, watch releases
- **If you want words:** the one-line pitch and a pointer to the demo
- **If you are active in a community:** the subreddits + HN, each with the angle that lands, plus disclose-and-do-not-spam
- **If you write or make things:** newsletters, YouTube channels, blog posts, come talk to us
- **Report bugs / open PRs:** engaged users are the best marketing
- A warm thank-you close

Linked from the README Contributing section ("Not a coder? ..."). British spelling, no em/en dashes.

Generated with [Claude Code](https://claude.com/claude-code)