### PR TITLE
Injection: verify rung 1, paste-first in browsers (#368)

### DIFF
--- a/native/accessibility-helper/Sources/AccessibilityInjection/Config.swift
+++ b/native/accessibility-helper/Sources/AccessibilityInjection/Config.swift
@@ -26,6 +26,12 @@ public struct Config {
     public var axValueMaxChars: Int
     public var longTextChars: Int
     public var stableForBlindPasteMs: Double?
+    // #368: apps whose focused element accepts a kAXSelectedTextAttribute
+    // write and silently drops it (Google Docs renders to a canvas and
+    // manages input itself; other browser editors do the same). In these
+    // we skip rung 1 entirely and paste, and we trust an unverifiable
+    // paste rather than falling to blind char-by-char typing.
+    public var pasteFirstBundleIds: Set<String>
 
     public init(
         settleMs: Double = 400,
@@ -36,7 +42,21 @@ public struct Config {
         restoreMs: Double = 300,
         axValueMaxChars: Int = 2000,
         longTextChars: Int = 120,
-        stableForBlindPasteMs: Double? = 800
+        stableForBlindPasteMs: Double? = 800,
+        pasteFirstBundleIds: Set<String> = [
+            "com.google.Chrome",
+            "com.google.Chrome.canary",
+            "com.google.Chrome.beta",
+            "com.google.Chrome.dev",
+            "com.apple.Safari",
+            "com.apple.SafariTechnologyPreview",
+            "company.thebrowser.Browser",
+            "com.microsoft.edgemac",
+            "com.brave.Browser",
+            "org.mozilla.firefox",
+            "com.vivaldi.Vivaldi",
+            "com.operasoftware.Opera",
+        ]
     ) {
         self.settleMs = settleMs
         self.settleBudgetMs = settleBudgetMs
@@ -47,5 +67,6 @@ public struct Config {
         self.axValueMaxChars = axValueMaxChars
         self.longTextChars = longTextChars
         self.stableForBlindPasteMs = stableForBlindPasteMs
+        self.pasteFirstBundleIds = pasteFirstBundleIds
     }
 }

--- a/native/accessibility-helper/Sources/AccessibilityInjection/InjectionEngine.swift
+++ b/native/accessibility-helper/Sources/AccessibilityInjection/InjectionEngine.swift
@@ -82,14 +82,20 @@ public final class InjectionEngine {
 
         let info = focused.fieldInfo
         let readableAndFieldSized = info.valueChars.map { $0 <= config.axValueMaxChars } ?? false
+        // #368: Google Docs and other browser editors render to a canvas and
+        // manage input themselves - an AX write returns .success and does
+        // nothing. Skip rung 1 there and paste.
+        let pasteFirst = (tracker.currentFrontmostBundleId()).map(config.pasteFirstBundleIds.contains) ?? false
 
-        // Rung 1: write straight into the field.
-        if info.selectedTextSettable && readableAndFieldSized {
-            if focused.writeAtCaret(text) {
+        // Rung 1: write straight into the field. An AX write that returns
+        // .success is not proof the text arrived (#368), so read the field
+        // back and confirm before trusting it.
+        if !pasteFirst && info.selectedTextSettable && readableAndFieldSized {
+            if focused.writeAtCaret(text), let after = focused.readValue(), after.contains(text) {
                 return .delivered(method: "wrote into the field", verified: true, note: "inserted at the caret, clipboard untouched")
             }
-            log("kAXSelectedTextAttribute reported settable but the write failed, falling back to paste")
-        } else if info.selectedTextSettable, let chars = info.valueChars, chars > config.axValueMaxChars {
+            log("rung 1 write did not confirm (settable role \(info.role)); falling back to paste")
+        } else if !pasteFirst && info.selectedTextSettable, let chars = info.valueChars, chars > config.axValueMaxChars {
             log("refusing to write into \(info.role) - \(chars) characters of existing content looks like scrollback, not a field")
         }
 
@@ -97,6 +103,14 @@ public final class InjectionEngine {
         let pasteResult = paster.paste(text: text, verifyAgainst: readableAndFieldSized ? focused : nil)
         if pasteResult.delivered {
             return .delivered(method: "pasted", verified: pasteResult.verified, note: pasteResult.note)
+        }
+
+        // #368: in a browser we usually can't read the field back, so a
+        // paste we couldn't verify is the norm, not a failure. A single
+        // Cmd+V into Docs works; typing it char by char mangles it. Trust
+        // the paste rather than dropping to rung 3.
+        if pasteFirst {
+            return .delivered(method: "pasted", verified: false, note: "sent to the browser; can't read it back to confirm")
         }
 
         // The app rejected a paste we could actually verify. One atomic

--- a/native/accessibility-helper/Sources/AccessibilityInjection/Protocols.swift
+++ b/native/accessibility-helper/Sources/AccessibilityInjection/Protocols.swift
@@ -50,4 +50,11 @@ public protocol KeyTyping {
 public protocol AppSwitchTracking {
     func ageMs() -> Double
     func currentFrontmostName() -> String?
+    // #368: bundle id of the frontmost app, for the paste-first list.
+    // Defaulted so fakes that predate it keep compiling.
+    func currentFrontmostBundleId() -> String?
+}
+
+public extension AppSwitchTracking {
+    func currentFrontmostBundleId() -> String? { nil }
 }

--- a/native/accessibility-helper/Sources/AccessibilityInjection/RealAdapters.swift
+++ b/native/accessibility-helper/Sources/AccessibilityInjection/RealAdapters.swift
@@ -110,6 +110,10 @@ public final class RealAppSwitchTracker: AppSwitchTracking {
         currentFrontmostApp()?.localizedName
     }
 
+    public func currentFrontmostBundleId() -> String? {
+        currentFrontmostApp()?.bundleIdentifier
+    }
+
     // Not part of AppSwitchTracking - RealFocusResolver needs the actual
     // NSRunningApplication (for its pid), not just its name.
     public func currentFrontmostApp() -> NSRunningApplication? {

--- a/native/accessibility-helper/Tests/AccessibilityInjectionTests/Fakes.swift
+++ b/native/accessibility-helper/Tests/AccessibilityInjectionTests/Fakes.swift
@@ -89,10 +89,12 @@ final class FakeTyper: KeyTyping {
 final class FakeTracker: AppSwitchTracking {
     var ageProvider: () -> Double
     var appName: String?
+    var bundleId: String?
 
-    init(age: @escaping () -> Double, appName: String?) {
+    init(age: @escaping () -> Double, appName: String?, bundleId: String? = nil) {
         self.ageProvider = age
         self.appName = appName
+        self.bundleId = bundleId
     }
 
     func ageMs() -> Double {
@@ -101,5 +103,9 @@ final class FakeTracker: AppSwitchTracking {
 
     func currentFrontmostName() -> String? {
         appName
+    }
+
+    func currentFrontmostBundleId() -> String? {
+        bundleId
     }
 }

--- a/native/accessibility-helper/Tests/AccessibilityInjectionTests/InjectionEngineTests.swift
+++ b/native/accessibility-helper/Tests/AccessibilityInjectionTests/InjectionEngineTests.swift
@@ -15,12 +15,13 @@ struct InjectionEngineTests {
         missesBeforeSuccess: Int = 0,
         pasteResult: PasteResult = PasteResult(delivered: true, verified: false, note: ""),
         trackerAge: @escaping () -> Double = { 10_000 },
-        appName: String? = "TestApp"
+        appName: String? = "TestApp",
+        bundleId: String? = nil
     ) -> (engine: InjectionEngine, time: SimulatedTime, paster: FakePaster, typer: FakeTyper) {
         let time = SimulatedTime()
         let paster = FakePaster(result: pasteResult)
         let typer = FakeTyper()
-        let tracker = FakeTracker(age: trackerAge, appName: appName)
+        let tracker = FakeTracker(age: trackerAge, appName: appName, bundleId: bundleId)
         let engine = InjectionEngine(
             config: config,
             focusResolver: FakeFocusResolver(target: focusTarget, missesBeforeSuccess: missesBeforeSuccess),
@@ -38,7 +39,8 @@ struct InjectionEngineTests {
 
     @Test func rung1WritesAtCaretWhenFieldIsSettableAndSmall() {
         let target = FakeAccessibilityTarget(
-            fieldInfo: FieldInfo(role: "AXTextField", valueChars: 10, selectedTextSettable: true)
+            fieldInfo: FieldInfo(role: "AXTextField", valueChars: 10, selectedTextSettable: true),
+            valueToReadBack: "say hello there"
         )
         let (engine, _, paster, _) = makeEngine(focusTarget: target)
 
@@ -47,6 +49,67 @@ struct InjectionEngineTests {
         #expect(outcome == .delivered(method: "wrote into the field", verified: true, note: "inserted at the caret, clipboard untouched"))
         #expect(target.writtenText == "hello")
         #expect(paster.callCount == 0, "rung 1 succeeded, rung 2 should never fire")
+    }
+
+    // #368: an AX write that returns .success but doesn't actually land the
+    // text - Google Docs and other canvas editors - must fall through to
+    // paste, not be reported as a verified success.
+    @Test func rung1FallsThroughWhenTheWriteReturnsSuccessButTheTextIsntThere() {
+        let target = FakeAccessibilityTarget(
+            fieldInfo: FieldInfo(role: "AXTextArea", valueChars: 0, selectedTextSettable: true),
+            writeSucceeds: true,
+            valueToReadBack: ""
+        )
+        let (engine, _, paster, typer) = makeEngine(
+            focusTarget: target,
+            pasteResult: PasteResult(delivered: true, verified: true, note: "read back and confirmed")
+        )
+
+        let outcome = engine.decide(text: "hello")
+
+        #expect(outcome == .delivered(method: "pasted", verified: true, note: "read back and confirmed"))
+        #expect(target.writtenText == "hello", "rung 1 was still attempted")
+        #expect(paster.callCount == 1, "rung 1 didn't confirm, so rung 2 ran")
+        #expect(typer.typedText == nil)
+    }
+
+    // #368: in a browser, skip rung 1 entirely - the AX write is known to
+    // no-op there - and go straight to paste.
+    @Test func browserSkipsRung1AndPastes() {
+        let target = FakeAccessibilityTarget(
+            fieldInfo: FieldInfo(role: "AXTextArea", valueChars: 5, selectedTextSettable: true),
+            valueToReadBack: "hello"
+        )
+        let (engine, _, paster, _) = makeEngine(
+            focusTarget: target,
+            pasteResult: PasteResult(delivered: true, verified: false, note: "sent, but nothing confirmed it landed"),
+            bundleId: "com.google.Chrome"
+        )
+
+        let outcome = engine.decide(text: "hello")
+
+        #expect(outcome == .delivered(method: "pasted", verified: false, note: "sent, but nothing confirmed it landed"))
+        #expect(target.writtenText == nil, "rung 1 must not fire in a browser")
+        #expect(paster.callCount == 1)
+    }
+
+    // #368: a browser paste we can't verify is delivered, not a reason to
+    // type char by char (which mangles the text in Docs).
+    @Test func browserTrustsAnUnverifiablePasteInsteadOfTypingBlind() {
+        let target = FakeAccessibilityTarget(
+            fieldInfo: FieldInfo(role: "AXTextArea", valueChars: 5, selectedTextSettable: true),
+            valueToReadBack: "stale"
+        )
+        let (engine, _, _, typer) = makeEngine(
+            focusTarget: target,
+            pasteResult: PasteResult(delivered: false, verified: false, note: "the app did not accept the paste"),
+            bundleId: "com.apple.Safari"
+        )
+
+        let outcome = engine.decide(text: "hello")
+
+        #expect(outcome == .delivered(method: "pasted", verified: false, note: "sent to the browser; can't read it back to confirm"))
+        #expect(typer.typedText == nil, "rung 3 must not fire in a browser")
     }
 
     @Test func rung1RefusesAScrollbackSizedField() {


### PR DESCRIPTION
Closes #368.

Dictation silently failed in Google Docs: it renders to a canvas and manages input itself, so a `kAXSelectedTextAttribute` write returns `.success` and does nothing. The engine trusted that as a verified delivery.

**Fix 1** rung 1 now reads the field back and only claims success if the text actually landed; otherwise it falls through to paste (the discipline rung 2 already had).

**Fix 2** a paste-first bundle-id list (Chrome, Safari, Arc, Edge, Brave, Firefox, Vivaldi, Opera). In those: skip rung 1, and trust an unverifiable paste rather than dropping to rung 3 blind char-by-char typing, which mangles text in Docs.

`Config` gains `pasteFirstBundleIds`; `AppSwitchTracking` gains `currentFrontmostBundleId()` (defaulted so existing fakes still compile). New tests added in `InjectionEngineTests.swift`.

## Verification

Swift Sources build clean (`swift build`, debug + release). `npm test` green (116 vitest + 266 node). The swift-testing suite needs a full Xcode toolchain and runs in neither this environment nor CI, so the Docs path needs a manual check: dictate into a Google Doc in Chrome and Safari, and into a normal web `<textarea>`, and confirm text lands in all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)