### PR TITLE
Injection: synthesise keystrokes from a private event source (#368)

### DIFF
--- a/native/accessibility-helper/Sources/AccessibilityInjection/Config.swift
+++ b/native/accessibility-helper/Sources/AccessibilityInjection/Config.swift
@@ -32,6 +32,12 @@ public struct Config {
     // we skip rung 1 entirely and paste, and we trust an unverifiable
     // paste rather than falling to blind char-by-char typing.
     public var pasteFirstBundleIds: Set<String>
+    // #368: Google Docs re-focuses its hidden editing iframe a beat after
+    // key focus returns to the browser. A paste fired inside that beat -
+    // which a warm dictation does, ~150ms after the hotkey release - lands
+    // nowhere. Wait this long before pasting into a pasteFirst app. The
+    // first, cold dictation already clears it via the AX warm-up.
+    public var browserPasteSettleMs: Double
 
     public init(
         settleMs: Double = 400,
@@ -56,7 +62,8 @@ public struct Config {
             "org.mozilla.firefox",
             "com.vivaldi.Vivaldi",
             "com.operasoftware.Opera",
-        ]
+        ],
+        browserPasteSettleMs: Double = 400
     ) {
         self.settleMs = settleMs
         self.settleBudgetMs = settleBudgetMs
@@ -68,5 +75,6 @@ public struct Config {
         self.longTextChars = longTextChars
         self.stableForBlindPasteMs = stableForBlindPasteMs
         self.pasteFirstBundleIds = pasteFirstBundleIds
+        self.browserPasteSettleMs = browserPasteSettleMs
     }
 }

--- a/native/accessibility-helper/Sources/AccessibilityInjection/FieldInfo.swift
+++ b/native/accessibility-helper/Sources/AccessibilityInjection/FieldInfo.swift
@@ -2,10 +2,15 @@ public struct FieldInfo {
     public var role: String
     public var valueChars: Int?      // nil when the value attribute isn't readable
     public var selectedTextSettable: Bool
+    // #368: bundle id of the app that owns the focused element, resolved
+    // from its pid - more reliable than the frontmost-app tracker, which
+    // lags when the helper is launched from a terminal.
+    public var bundleId: String?
 
-    public init(role: String, valueChars: Int?, selectedTextSettable: Bool) {
+    public init(role: String, valueChars: Int?, selectedTextSettable: Bool, bundleId: String? = nil) {
         self.role = role
         self.valueChars = valueChars
         self.selectedTextSettable = selectedTextSettable
+        self.bundleId = bundleId
     }
 }

--- a/native/accessibility-helper/Sources/AccessibilityInjection/InjectionEngine.swift
+++ b/native/accessibility-helper/Sources/AccessibilityInjection/InjectionEngine.swift
@@ -83,9 +83,13 @@ public final class InjectionEngine {
         let info = focused.fieldInfo
         let readableAndFieldSized = info.valueChars.map { $0 <= config.axValueMaxChars } ?? false
         // #368: Google Docs and other browser editors render to a canvas and
-        // manage input themselves - an AX write returns .success and does
-        // nothing. Skip rung 1 there and paste.
-        let pasteFirst = (tracker.currentFrontmostBundleId()).map(config.pasteFirstBundleIds.contains) ?? false
+        // manage input themselves. An AX write there sometimes no-ops and
+        // sometimes lands but isn't reflected in the AX value, so a
+        // fall-through paste doubles the text. Skip rung 1 in a browser and
+        // paste once. Prefer the focused element's own owner over the
+        // frontmost tracker, which lags from a terminal launch.
+        let ownerBundleId = info.bundleId ?? tracker.currentFrontmostBundleId()
+        let pasteFirst = ownerBundleId.map(config.pasteFirstBundleIds.contains) ?? false
 
         // Rung 1: write straight into the field. An AX write that returns
         // .success is not proof the text arrived (#368), so read the field

--- a/native/accessibility-helper/Sources/AccessibilityInjection/InjectionEngine.swift
+++ b/native/accessibility-helper/Sources/AccessibilityInjection/InjectionEngine.swift
@@ -100,6 +100,13 @@ public final class InjectionEngine {
         }
 
         // Rung 2: clipboard + paste.
+        // #368: give a browser editor a beat to re-focus its input surface
+        // before the paste. A warm dictation otherwise pastes ~150ms after
+        // the hotkey release, before Docs' hidden iframe is focused, and
+        // the Cmd+V lands nowhere.
+        if pasteFirst {
+            sleep(config.browserPasteSettleMs / 1000.0)
+        }
         let pasteResult = paster.paste(text: text, verifyAgainst: readableAndFieldSized ? focused : nil)
         if pasteResult.delivered {
             return .delivered(method: "pasted", verified: pasteResult.verified, note: pasteResult.note)

--- a/native/accessibility-helper/Sources/AccessibilityInjection/RealAdapters.swift
+++ b/native/accessibility-helper/Sources/AccessibilityInjection/RealAdapters.swift
@@ -384,7 +384,14 @@ public final class RealClipboardPaster: ClipboardPasting {
     }
 
     private func synthesizeCmdV() {
-        let source = CGEventSource(stateID: .hidSystemState)
+        // #368: a `.hidSystemState` source ORs the live hardware modifier
+        // flags into the event at post time. When the paste fires within a
+        // few hundred ms of the push-to-talk key release - which it does on
+        // every dictation after the first, once the AX channel is warm -
+        // that key's modifier is still settling, so the paste goes out as
+        // Cmd+<that modifier>+V and the app ignores it. A `.privateState`
+        // source carries exactly the flags we set, nothing else.
+        let source = CGEventSource(stateID: .privateState)
         let vKeyCode: CGKeyCode = 9 // 'V' on the ANSI layout
         let keyDown = CGEvent(keyboardEventSource: source, virtualKey: vKeyCode, keyDown: true)
         let keyUp = CGEvent(keyboardEventSource: source, virtualKey: vKeyCode, keyDown: false)
@@ -402,11 +409,15 @@ public final class RealKeyTyper: KeyTyping {
     public init() {}
 
     public func type(_ text: String) {
-        let source = CGEventSource(stateID: .hidSystemState)
+        // #368: private source + explicitly cleared flags, so a lingering
+        // hotkey modifier can't turn a typed 'c' into Cmd+C mid-transcript.
+        let source = CGEventSource(stateID: .privateState)
         for scalar in text.unicodeScalars {
             var chars = [UniChar(scalar.value)]
             let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: true)
             let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: false)
+            keyDown?.flags = []
+            keyUp?.flags = []
             keyDown?.keyboardSetUnicodeString(stringLength: 1, unicodeString: &chars)
             keyUp?.keyboardSetUnicodeString(stringLength: 1, unicodeString: &chars)
             keyDown?.post(tap: .cghidEventTap)

--- a/native/accessibility-helper/Sources/AccessibilityInjection/RealAdapters.swift
+++ b/native/accessibility-helper/Sources/AccessibilityInjection/RealAdapters.swift
@@ -24,7 +24,12 @@ public final class RealAXTarget: AccessibilityTarget {
         var settable: DarwinBoolean = false
         AXUIElementIsAttributeSettable(element, kAXSelectedTextAttribute as CFString, &settable)
 
-        return FieldInfo(role: role, valueChars: valueChars, selectedTextSettable: settable.boolValue)
+        var pid: pid_t = 0
+        let bundleId = AXUIElementGetPid(element, &pid) == .success && pid > 0
+            ? NSRunningApplication(processIdentifier: pid)?.bundleIdentifier
+            : nil
+
+        return FieldInfo(role: role, valueChars: valueChars, selectedTextSettable: settable.boolValue, bundleId: bundleId)
     }
 
     // Rung 1: replace the current selection (a caret is a zero-length

--- a/native/accessibility-helper/Tests/AccessibilityInjectionTests/InjectionEngineTests.swift
+++ b/native/accessibility-helper/Tests/AccessibilityInjectionTests/InjectionEngineTests.swift
@@ -78,13 +78,12 @@ struct InjectionEngineTests {
     // input surface has re-focused.
     @Test func browserSkipsRung1AndPastesAfterASettle() {
         let target = FakeAccessibilityTarget(
-            fieldInfo: FieldInfo(role: "AXTextArea", valueChars: 5, selectedTextSettable: true),
+            fieldInfo: FieldInfo(role: "AXTextArea", valueChars: 5, selectedTextSettable: true, bundleId: "com.google.Chrome"),
             valueToReadBack: "hello"
         )
         let (engine, time, paster, _) = makeEngine(
             focusTarget: target,
-            pasteResult: PasteResult(delivered: true, verified: false, note: "sent, but nothing confirmed it landed"),
-            bundleId: "com.google.Chrome"
+            pasteResult: PasteResult(delivered: true, verified: false, note: "sent, but nothing confirmed it landed")
         )
 
         let outcome = engine.decide(text: "hello")
@@ -113,13 +112,12 @@ struct InjectionEngineTests {
     // type char by char (which mangles the text in Docs).
     @Test func browserTrustsAnUnverifiablePasteInsteadOfTypingBlind() {
         let target = FakeAccessibilityTarget(
-            fieldInfo: FieldInfo(role: "AXTextArea", valueChars: 5, selectedTextSettable: true),
+            fieldInfo: FieldInfo(role: "AXTextArea", valueChars: 5, selectedTextSettable: true, bundleId: "com.apple.Safari"),
             valueToReadBack: "stale"
         )
         let (engine, _, _, typer) = makeEngine(
             focusTarget: target,
-            pasteResult: PasteResult(delivered: false, verified: false, note: "the app did not accept the paste"),
-            bundleId: "com.apple.Safari"
+            pasteResult: PasteResult(delivered: false, verified: false, note: "the app did not accept the paste")
         )
 
         let outcome = engine.decide(text: "hello")

--- a/native/accessibility-helper/Tests/AccessibilityInjectionTests/InjectionEngineTests.swift
+++ b/native/accessibility-helper/Tests/AccessibilityInjectionTests/InjectionEngineTests.swift
@@ -74,13 +74,14 @@ struct InjectionEngineTests {
     }
 
     // #368: in a browser, skip rung 1 entirely - the AX write is known to
-    // no-op there - and go straight to paste.
-    @Test func browserSkipsRung1AndPastes() {
+    // no-op there - and go straight to paste, after a settle so the doc's
+    // input surface has re-focused.
+    @Test func browserSkipsRung1AndPastesAfterASettle() {
         let target = FakeAccessibilityTarget(
             fieldInfo: FieldInfo(role: "AXTextArea", valueChars: 5, selectedTextSettable: true),
             valueToReadBack: "hello"
         )
-        let (engine, _, paster, _) = makeEngine(
+        let (engine, time, paster, _) = makeEngine(
             focusTarget: target,
             pasteResult: PasteResult(delivered: true, verified: false, note: "sent, but nothing confirmed it landed"),
             bundleId: "com.google.Chrome"
@@ -91,6 +92,21 @@ struct InjectionEngineTests {
         #expect(outcome == .delivered(method: "pasted", verified: false, note: "sent, but nothing confirmed it landed"))
         #expect(target.writtenText == nil, "rung 1 must not fire in a browser")
         #expect(paster.callCount == 1)
+        #expect(time.elapsedMs >= config.browserPasteSettleMs, "the browser settle must run before the paste")
+    }
+
+    @Test func nonBrowserPasteHasNoSettle() {
+        let target = FakeAccessibilityTarget(
+            fieldInfo: FieldInfo(role: "AXWebArea", valueChars: nil, selectedTextSettable: false)
+        )
+        let (engine, time, _, _) = makeEngine(
+            focusTarget: target,
+            pasteResult: PasteResult(delivered: true, verified: false, note: "sent, but nothing confirmed it landed")
+        )
+
+        _ = engine.decide(text: "hello")
+
+        #expect(time.elapsedMs == 0, "no settle outside a pasteFirst app")
     }
 
     // #368: a browser paste we can't verify is delivered, not a reason to


### PR DESCRIPTION
Follow-up to #369. Dictation into Google Docs worked once then stopped.

The log told the story: first insertion at 1074ms (worked), every one after at ~150ms (nothing appears), engine reports `delivered` each time.

The paste and the fallback typer built their `CGEvent`s from a `.hidSystemState` source, which ORs the live hardware modifier flags into the event at post time. Once the AX channel is warm, every dictation after the first fires ~150ms after the push-to-talk key release, while that key's modifier is still settling in HID state, so the synthetic Cmd+V went out as Cmd+<modifier>+V and Docs dropped it. The first dictation only landed because the cold AX warm-up delayed it a full second, past the settle.

Both paths now use `.privateState`, and the typer clears flags explicitly, so events carry exactly the modifiers set.

## Verification

Swift Sources build clean. `npm test` green. Needs a manual check: 3+ dictations in a row into a Google Doc, and a normal web field, all landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)