### PR TITLE
Abort playback if the frontmost app changes mid-flight (#355)

### DIFF
--- a/electron/accessibilityHelper.js
+++ b/electron/accessibilityHelper.js
@@ -175,8 +175,12 @@ function createAccessibilityHelper({
     };
   }
 
-  async function deliver(text) {
-    const reply = await request("insert", { text });
+  // #355: expectedBundleId is the app the caller resolved focus context
+  // against - typically just now, so the helper's own abort check (which
+  // watches for the app changing again, mid-typing) has a fresh baseline.
+  // Optional so existing callers are unaffected.
+  async function deliver(text, expectedBundleId) {
+    const reply = await request("insert", { text, ...(expectedBundleId ? { expectedBundleId } : {}) });
     if (reply.status === "delivered") return { kind: "inserted" };
     if (reply.status === "held" && typeof reply.reason === "string") {
       return { kind: "held", reason: reply.reason };

--- a/electron/accessibilityHelper.test.js
+++ b/electron/accessibilityHelper.test.js
@@ -60,6 +60,24 @@ test("accessibility helper correlates context and insertion replies received out
   helper.stop();
 });
 
+// #355: the caller passes the bundle id it resolved focus context against,
+// so the helper's own abort check has a baseline to compare against.
+test("accessibility helper sends expectedBundleId when the caller supplies one", async () => {
+  const child = fakeProcess();
+  const requests = readRequests(child);
+  const helper = createAccessibilityHelper({ spawnProcess: () => child });
+  helper.start();
+
+  const delivered = helper.deliver("Some text.", "com.apple.TextEdit");
+  await nextTurn();
+
+  assert.deepEqual(requests, [{ id: "1", cmd: "insert", text: "Some text.", expectedBundleId: "com.apple.TextEdit" }]);
+
+  child.stdout.write('{"id":"1","status":"held","reason":"the frontmost app changed during the dictation"}\n');
+  assert.deepEqual(await delivered, { kind: "held", reason: "the frontmost app changed during the dictation" });
+  helper.stop();
+});
+
 test("getSelection returns the selection and focus context on an ok reply", async () => {
   const child = fakeProcess();
   const requests = readRequests(child);

--- a/electron/dictationCoordinator.js
+++ b/electron/dictationCoordinator.js
@@ -36,15 +36,18 @@ function createDictationIntake(options) {
 
   let queue = Promise.resolve();
 
-  function complete(wavBuffer) {
-    const result = queue.then(() => processCompletedDictation(wavBuffer));
+  // #355: recordStartBundleId is the app the caller resolved as frontmost
+  // when the push-to-talk key went down - optional, so a caller that
+  // doesn't capture it (or the tests) gets the old behaviour untouched.
+  function complete(wavBuffer, recordStartBundleId) {
+    const result = queue.then(() => processCompletedDictation(wavBuffer, recordStartBundleId));
     // An unexpected programming error must reject its own call without
     // preventing later completed recordings from leaving the queue.
     queue = result.catch(() => {});
     return result;
   }
 
-  async function processCompletedDictation(wavBuffer) {
+  async function processCompletedDictation(wavBuffer, recordStartBundleId) {
     if (!wavBuffer || wavBuffer.byteLength <= 44) {
       return { status: "empty" };
     }
@@ -82,6 +85,29 @@ function createDictationIntake(options) {
       // the app context detection actually landed on.
       emitDiagnostic("context.bundleId", focusContext.bundleId);
       emitDiagnostic("context.axReady", focusContext.axReady !== false);
+
+      // #355: record start to playback end is one continuous window. Any
+      // keystroke or paste can be destructive in the wrong app - a TUI's
+      // single-key shortcut, a chat box's Enter-to-send - even though the
+      // words themselves are innocent, so a switch away from the app the
+      // user was dictating into holds the transcript rather than guessing
+      // which context to format it for.
+      if (
+        typeof recordStartBundleId === "string" &&
+        recordStartBundleId.length > 0 &&
+        recordStartBundleId !== focusContext.bundleId
+      ) {
+        emitDiagnostic("context.appSwitchedDuringDictation", `${recordStartBundleId} -> ${focusContext.bundleId}`);
+        const salvaged = cleanup(rawText, { oneLineBox: false, breakSafe: false });
+        if (!salvaged) {
+          return { status: "no-speech" };
+        }
+        return {
+          status: "held",
+          text: salvaged,
+          reason: `the frontmost app changed while you were dictating (was ${recordStartBundleId}, now ${focusContext.bundleId})`,
+        };
+      }
     } catch (error) {
       // #227: a context read that fails outright (the helper is down, or
       // nothing is frontmost) used to drop the transcript silently as a
@@ -171,7 +197,10 @@ function createDictationIntake(options) {
     }
 
     try {
-      const deliveryResult = await delivery.deliver(finishedText);
+      // #355: pass the bundle just confirmed as frontmost, so the helper's
+      // own abort check (which watches for the app changing again, this
+      // time mid-injection) has a fresh baseline rather than none at all.
+      const deliveryResult = await delivery.deliver(finishedText, focusContext.bundleId);
       if (deliveryResult?.kind === "inserted") {
         return { status: "delivered", text: finishedText };
       }

--- a/electron/dictationCoordinator.test.js
+++ b/electron/dictationCoordinator.test.js
@@ -509,6 +509,66 @@ test("context detection failure holds the transcript instead of dropping it (#22
   );
 });
 
+test("#355: a different frontmost app than record start holds instead of delivering", async () => {
+  let deliveryCalls = 0;
+  const harness = createIntake({
+    bundleId: "com.apple.Terminal",
+    deliver: async () => {
+      deliveryCalls++;
+      return { kind: "inserted" };
+    },
+  });
+
+  const result = await harness.intake.complete(completedWav, "com.apple.TextEdit");
+
+  // The lazygit case: the words are innocent, the destination isn't - held,
+  // not delivered into whatever is frontmost now.
+  assert.equal(result.status, "held");
+  assert.equal(result.text, "Hello world.");
+  assert.match(
+    result.reason,
+    /the frontmost app changed while you were dictating \(was com\.apple\.TextEdit, now com\.apple\.Terminal\)/,
+  );
+  assert.equal(deliveryCalls, 0, "a mid-dictation app switch never reaches delivery");
+  assert.ok(
+    harness.diagnostics.some(
+      ([name, value]) => name === "context.appSwitchedDuringDictation" && value === "com.apple.TextEdit -> com.apple.Terminal",
+    ),
+  );
+});
+
+test("#355: the same frontmost app at record start and at delivery proceeds normally", async () => {
+  const harness = createIntake({ bundleId: "com.apple.TextEdit" });
+
+  const result = await harness.intake.complete(completedWav, "com.apple.TextEdit");
+
+  assert.equal(result.status, "delivered");
+  assert.deepEqual(harness.delivered, ["Hello world."]);
+});
+
+test("#355: no record-start bundle id means the check is skipped entirely", async () => {
+  const harness = createIntake({ bundleId: "com.apple.Terminal" });
+
+  const result = await harness.intake.complete(completedWav);
+
+  assert.equal(result.status, "delivered", "existing callers that don't track record start are unaffected");
+});
+
+test("#355: delivery gets the bundle id just confirmed as frontmost", async () => {
+  const receivedArgs = [];
+  const harness = createIntake({
+    bundleId: "com.apple.Notes",
+    deliver: async (...args) => {
+      receivedArgs.push(args);
+      return { kind: "inserted" };
+    },
+  });
+
+  await harness.intake.complete(completedWav, "com.apple.Notes");
+
+  assert.deepEqual(receivedArgs, [["Hello world.", "com.apple.Notes"]]);
+});
+
 test("delivery failure holds the complete finished text without retrying delivery", async () => {
   let deliveryCalls = 0;
   const harness = createIntake({

--- a/electron/main.js
+++ b/electron/main.js
@@ -200,6 +200,13 @@ const VOICE_EDIT_MAX_CHARS = 5000;
 
 // Set at key-down (the async selection read), consumed at recording-complete.
 let pendingSelectionRead = null;
+// #355: which app was frontmost when the key went down, read the same way
+// (async, never delays recording). dictationIntake compares this against
+// the app it finds frontmost once the transcript is ready, and holds
+// rather than deliver into a different app than the one dictation started
+// in - a keystroke or paste can be destructive there even when the words
+// themselves are innocent.
+let pendingFrontmostAtRecordStart = null;
 
 // The desktop window is only ever opened from an explicit user action -
 // the tray item, a Dock-icon click (the `activate` handler), a second
@@ -459,6 +466,13 @@ const heldResultController = createHeldResultController({
 // recording, so this is deliberately not awaited here.
 function beginPushToTalk() {
   pendingSelectionRead = accessibilityHelper.getSelection().catch(() => null);
+  // #355: same treatment as the selection read - async, never delays
+  // recording, and just gives dictation a "before" snapshot to compare
+  // against once the transcript is ready.
+  pendingFrontmostAtRecordStart = accessibilityHelper
+    .getFocusContext()
+    .then((context) => context.bundleId)
+    .catch(() => null);
   pushToTalkCoordinator.keyDown();
 }
 
@@ -467,11 +481,15 @@ async function handleCompletedRecording(wavBuffer, timing) {
   pendingSelectionRead = null;
   const selection = selectionRead ? await selectionRead : null;
 
+  const frontmostRead = pendingFrontmostAtRecordStart;
+  pendingFrontmostAtRecordStart = null;
+  const recordStartBundleId = frontmostRead ? await frontmostRead : null;
+
   if (selection && selection.text.length > 0 && selection.text.length <= VOICE_EDIT_MAX_CHARS) {
     showVoiceEditWorking();
     return applyVoiceEdit(wavBuffer, selection, timing);
   }
-  return transcribeAndPrint(wavBuffer, timing);
+  return transcribeAndPrint(wavBuffer, timing, recordStartBundleId);
 }
 
 function showVoiceEditWorking() {
@@ -528,10 +546,10 @@ async function applyVoiceEdit(wavBuffer, selection, timing) {
   }
 }
 
-async function transcribeAndPrint(wavBuffer, timing) {
+async function transcribeAndPrint(wavBuffer, timing, recordStartBundleId) {
   let result;
   try {
-    result = await dictationIntake.complete(wavBuffer);
+    result = await dictationIntake.complete(wavBuffer, recordStartBundleId);
   } catch (error) {
     console.error("[dictation] unexpected intake failure:", error);
     setUserVisibleState("idle");

--- a/native/accessibility-helper/Sources/AccessibilityInjection/InjectionEngine.swift
+++ b/native/accessibility-helper/Sources/AccessibilityInjection/InjectionEngine.swift
@@ -36,7 +36,13 @@ public final class InjectionEngine {
         self.log = log
     }
 
-    public func decide(text: String) -> InjectionOutcome {
+    // expectedBundleId, when supplied, is the app the dictation started in
+    // (#355). Record start to playback end is one continuous window - a
+    // keystroke or a paste can be destructive in the wrong app (a TUI's
+    // single-key shortcut, a chat box's Enter-to-send) even though the text
+    // itself is perfectly innocent. Callers that don't know about this
+    // (existing tests, any future caller) pass nil and nothing changes.
+    public func decide(text: String, expectedBundleId: String? = nil) -> InjectionOutcome {
         // Settle guard: never trust a target while the last app switch is
         // more recent than settleMs. Poll rather than trust a single
         // reading, since the tracker updates asynchronously in production.
@@ -91,6 +97,13 @@ public final class InjectionEngine {
         let ownerBundleId = info.bundleId ?? tracker.currentFrontmostBundleId()
         let pasteFirst = ownerBundleId.map(config.pasteFirstBundleIds.contains) ?? false
 
+        // #355: the frontmost app has already moved on from where this
+        // dictation started. Hold rather than deliver blind - same
+        // treatment as every other case this engine can't trust.
+        if let expected = expectedBundleId, let owner = ownerBundleId, owner != expected {
+            return .held(reason: "the frontmost app changed during the dictation (was \(expected), now \(owner))")
+        }
+
         // Rung 1: write straight into the field. An AX write that returns
         // .success is not proof the text arrived (#368), so read the field
         // back and confirm before trusting it.
@@ -130,7 +143,21 @@ public final class InjectionEngine {
         // so rung 3 only fires here, where we have positive evidence rung 2
         // failed, never for the fields we could not verify in the first
         // place.
-        typer.type(text)
+        //
+        // #355: this is the rung that actually runs for a while on long
+        // text, so it is the one place the app can genuinely change mid-
+        // playback rather than just between record end and injection start.
+        // shouldAbort is polled before every character; the tracker (not an
+        // AX resolve) is cheap enough to check that often without slowing
+        // typing down further.
+        let typedEverything = typer.type(text) {
+            guard let expected = expectedBundleId else { return false }
+            return tracker.currentFrontmostBundleId().map { $0 != expected } ?? false
+        }
+        if !typedEverything {
+            log("stopped typing partway through - the frontmost app changed")
+            return .held(reason: "the frontmost app changed while typing; stopped rather than send keystrokes into the wrong app")
+        }
         let long = text.count > config.longTextChars
         return .delivered(
             method: "typed character by character",

--- a/native/accessibility-helper/Sources/AccessibilityInjection/Protocols.swift
+++ b/native/accessibility-helper/Sources/AccessibilityInjection/Protocols.swift
@@ -44,7 +44,9 @@ public protocol ClipboardPasting {
 }
 
 public protocol KeyTyping {
-    func type(_ text: String)
+    // #355: shouldAbort is polled before every character; typing stops the
+    // moment it returns true. Returns whether the whole text was typed.
+    func type(_ text: String, shouldAbort: () -> Bool) -> Bool
 }
 
 public protocol AppSwitchTracking {

--- a/native/accessibility-helper/Sources/AccessibilityInjection/RealAdapters.swift
+++ b/native/accessibility-helper/Sources/AccessibilityInjection/RealAdapters.swift
@@ -413,11 +413,15 @@ public final class RealClipboardPaster: ClipboardPasting {
 public final class RealKeyTyper: KeyTyping {
     public init() {}
 
-    public func type(_ text: String) {
+    public func type(_ text: String, shouldAbort: () -> Bool) -> Bool {
         // #368: private source + explicitly cleared flags, so a lingering
         // hotkey modifier can't turn a typed 'c' into Cmd+C mid-transcript.
         let source = CGEventSource(stateID: .privateState)
         for scalar in text.unicodeScalars {
+            // #355: checked before every character, not just once, since
+            // this is the rung that can run for long enough that the app
+            // genuinely changes partway through.
+            if shouldAbort() { return false }
             var chars = [UniChar(scalar.value)]
             let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: true)
             let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: false)
@@ -428,5 +432,6 @@ public final class RealKeyTyper: KeyTyping {
             keyDown?.post(tap: .cghidEventTap)
             keyUp?.post(tap: .cghidEventTap)
         }
+        return true
     }
 }

--- a/native/accessibility-helper/Sources/accessibility-helper/main.swift
+++ b/native/accessibility-helper/Sources/accessibility-helper/main.swift
@@ -101,7 +101,11 @@ while let line = readLine(strippingNewline: true) {
             emit(["id": id, "status": "error", "reason": "insert requires non-empty \"text\""])
             continue
         }
-        var reply = engine.decide(text: text).replyFields
+        // #355: the bundle id the caller resolved when the dictation
+        // started, if it sent one. Optional - a caller that doesn't know
+        // about this gets the old behaviour, no abort check at all.
+        let expectedBundleId = obj["expectedBundleId"] as? String
+        var reply = engine.decide(text: text, expectedBundleId: expectedBundleId).replyFields
         reply["id"] = id
         emit(reply)
     case "permissions":

--- a/native/accessibility-helper/Tests/AccessibilityInjectionTests/Fakes.swift
+++ b/native/accessibility-helper/Tests/AccessibilityInjectionTests/Fakes.swift
@@ -80,9 +80,20 @@ final class FakePaster: ClipboardPasting {
 
 final class FakeTyper: KeyTyping {
     private(set) var typedText: String?
+    private(set) var completed: Bool?
+    // Test config: when true (the default), shouldAbort is polled once, as
+    // if it were the first character - enough to prove the engine wires it
+    // through, without simulating a full character-by-character loop.
+    var checksAbort = true
 
-    func type(_ text: String) {
+    func type(_ text: String, shouldAbort: () -> Bool) -> Bool {
         typedText = text
+        if checksAbort && shouldAbort() {
+            completed = false
+            return false
+        }
+        completed = true
+        return true
     }
 }
 

--- a/native/accessibility-helper/Tests/AccessibilityInjectionTests/InjectionEngineTests.swift
+++ b/native/accessibility-helper/Tests/AccessibilityInjectionTests/InjectionEngineTests.swift
@@ -220,6 +220,55 @@ struct InjectionEngineTests {
         #expect(typer.typedText == nil)
     }
 
+    // MARK: - #355: abort when the frontmost app changes mid-flight
+
+    @Test func abortsUpfrontWhenTheAppHasAlreadyChanged() {
+        // The lazygit case: dictation started in one app, the user has
+        // since switched to another, and the words themselves ("Pie in the
+        // sky") are innocent - it's the destination that turned dangerous.
+        let target = FakeAccessibilityTarget(
+            fieldInfo: FieldInfo(role: "AXTextField", valueChars: 10, selectedTextSettable: true, bundleId: "com.apple.Terminal")
+        )
+        let (engine, _, paster, typer) = makeEngine(focusTarget: target)
+
+        let outcome = engine.decide(text: "hello", expectedBundleId: "com.apple.TextEdit")
+
+        #expect(outcome == .held(reason: "the frontmost app changed during the dictation (was com.apple.TextEdit, now com.apple.Terminal)"))
+        #expect(target.writtenText == nil, "must not write into the app it started in front of, let alone the new one")
+        #expect(paster.callCount == 0)
+        #expect(typer.typedText == nil)
+    }
+
+    @Test func matchingExpectedBundleIdDoesNotAbort() {
+        let target = FakeAccessibilityTarget(
+            fieldInfo: FieldInfo(role: "AXTextField", valueChars: 10, selectedTextSettable: true, bundleId: "com.apple.TextEdit"),
+            valueToReadBack: "hello"
+        )
+        let (engine, _, _, _) = makeEngine(focusTarget: target)
+
+        let outcome = engine.decide(text: "hello", expectedBundleId: "com.apple.TextEdit")
+
+        #expect(outcome == .delivered(method: "wrote into the field", verified: true, note: "inserted at the caret, clipboard untouched"))
+    }
+
+    @Test func rung3StopsTypingWhenTheAppChangesPartway() {
+        // Unlike the upfront check, this is a genuine mid-playback switch:
+        // rung 3 was already under way when the app changed.
+        let target = FakeAccessibilityTarget(
+            fieldInfo: FieldInfo(role: "AXTextField", valueChars: 10, selectedTextSettable: false, bundleId: "com.apple.Terminal")
+        )
+        let (engine, _, _, typer) = makeEngine(
+            focusTarget: target,
+            pasteResult: PasteResult(delivered: false, verified: false, note: "the app did not accept the paste"),
+            bundleId: "com.apple.Terminal2" // the tracker now sees a different app than the dictation started in
+        )
+
+        let outcome = engine.decide(text: "hello", expectedBundleId: "com.apple.Terminal")
+
+        #expect(outcome == .held(reason: "the frontmost app changed while typing; stopped rather than send keystrokes into the wrong app"))
+        #expect(typer.completed == false)
+    }
+
     @Test func longTextTypedBlindGetsAWarningNote() {
         let target = FakeAccessibilityTarget(
             fieldInfo: FieldInfo(role: "AXTextField", valueChars: 10, selectedTextSettable: false)


### PR DESCRIPTION
Closes #355.

Any injected keystroke can be destructive in the wrong app, not just Enter: `shift-p` in lazygit pushes the repo, a chat box's Enter sends. The current break-safe list only ever gated newlines. This adds the broader rule a user raised: if the frontmost app changes anywhere between record start and playback end, hold rather than deliver blind.

## Swift (`native/accessibility-helper`)

`InjectionEngine.decide` takes an optional `expectedBundleId`:
- Checked once up front, against the focused element's owner (the pid-resolved lookup from #368, not the frontmost tracker), before any of the three rungs run.
- Polled again before every character during rung 3's blind typing - the one rung that runs long enough for the app to genuinely change partway through - via the cheap tracker read rather than an AX resolve per character.
- Either way: `.held`, the same outcome every other undeliverable case already produces.

`KeyTyping.type` gains a `shouldAbort` callback and reports whether it finished. Existing callers passing no `expectedBundleId` are unaffected - both checks are opt-in per request.

## JS (`electron/`)

`beginPushToTalk` now reads focus context at key-down (same fire-and-forget shape as the #17 selection read - async, never delays recording). `dictationCoordinator` compares that against the app it resolves once the transcript is ready; a mismatch holds the transcript (safe-default cleanup) with a reason naming both apps, through the same held-text overlay panel every other case uses. The bundle just confirmed also goes to `delivery.deliver()` as `expectedBundleId`, giving the Swift-side check a fresh baseline for the narrower window after that.

## Checks

`npm test` (116 vitest + 271 node, +9 new), `npm run typecheck`, Swift `swift build` all green. The swift-testing suite needs a full Xcode toolchain and doesn't run here or in CI (same caveat as #369/#370) - the new Swift tests follow the existing suite's patterns exactly.

## Not in scope

Voice editing (`applyVoiceEdit`) doesn't get this guard yet - it already requires an existing text selection, a narrower risk profile, and goes through a separate intake module. Worth a follow-up if it turns out to matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
