### PR TITLE
Voice command: copy that (#374)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -27,7 +27,7 @@ The finished text from a completed recording that could not be placed at the cur
 _Avoid_: Failed dictation, lost text
 
 **Voice edit**:
-A transform of text the user has already selected, requested by speaking a Voice-edit command such as "snake case" or "bullet list". Distinct from dictation: the user selects text first and asks for the change explicitly. In v0.3 the transforms are deterministic and run with no model - a semantic rewrite ("make this shorter") is out of scope until a capable model fills the rewrite model server role.
+A transform of text the user has already selected, requested by speaking a Voice-edit command such as "snake case" or "bullet list". Distinct from dictation: the user selects text first and asks for the change explicitly. In v0.3 the transforms are deterministic and run with no model - a semantic rewrite ("make this shorter") is out of scope until a capable model fills the rewrite model server role. "Copy that" is the exception that proves the shape: same trigger, but it writes the selection to the clipboard and never touches the document (#374).
 _Avoid_: Cleanup, correction, LLM pass, rewrite
 
 **Voice-edit command**:

--- a/electron/main.js
+++ b/electron/main.js
@@ -190,6 +190,8 @@ const dictationIntake = createDictationIntake({
 const voiceEditIntake = createVoiceEditIntake({
   transcription,
   delivery: accessibilityHelper,
+  // #374: "copy that" writes the selection here instead of injecting.
+  clipboard: { writeText: (text) => clipboard.writeText(text) },
   onDiagnostic: (name, value) => console.log(`[voice-edit] ${name}: ${JSON.stringify(value)}`),
 });
 
@@ -528,6 +530,9 @@ async function applyVoiceEdit(wavBuffer, selection, timing) {
       console.log(`[voice-edit] release-to-insertion: ${(performance.now() - timing.releasedAtMs).toFixed(1)}ms`);
     }
     setUserVisibleState("idle");
+  } else if (result.status === "copied") {
+    console.log(`[voice-edit] copied ${result.text.length} characters to the clipboard`);
+    showVoiceEditMessage("Copied");
   } else if (result.status === "held") {
     console.log(`[voice-edit] held: ${result.reason}`);
     setUserVisibleState("held", { text: result.text, reason: result.reason });

--- a/electron/voiceEditCommands.js
+++ b/electron/voiceEditCommands.js
@@ -25,6 +25,11 @@ const COMMANDS = {
   // structural
   bullets: { kind: "list", marker: "bullet", aliases: ["bullet list", "bulleted list", "bullet points", "bullet point list", "make a bullet list"] },
   numbered: { kind: "list", marker: "number", aliases: ["numbered list", "number list", "ordered list"] },
+  // clipboard (#374) - the one command that never rewrites the selection.
+  // interpretVoiceEditCommand still returns it as an "ok" result with
+  // commandId "copy"; the coordinator reads that id to route to the
+  // clipboard instead of injection, same as it already reads other ids.
+  copy: { kind: "copy", aliases: ["copy that", "copy this", "copy it", "copy"] },
 };
 
 const ALIAS_TO_ID = new Map();
@@ -128,6 +133,7 @@ function applyCommand(command, selection) {
   if (command.kind === "case") return applyCase(command.id, selection);
   if (command.kind === "wrap") return applyWrap(command, selection);
   if (command.kind === "list") return applyList(command, selection);
+  if (command.kind === "copy") return selection;
   return null;
 }
 

--- a/electron/voiceEditCommands.test.js
+++ b/electron/voiceEditCommands.test.js
@@ -79,6 +79,24 @@ test("list: a multi-line selection is declined", () => {
   assert.equal(result("bullet list", "line one\nline two, line three").status, "declined");
 });
 
+test("#374: copy that returns the selection unchanged as the result", () => {
+  assert.deepEqual(result("copy that", "hello world"), {
+    status: "ok",
+    commandId: "copy",
+    result: "hello world",
+  });
+});
+
+test("#374: copy's other aliases and trailing punctuation all match", () => {
+  for (const spoken of ["copy this", "copy it", "copy", "Copy that."]) {
+    assert.equal(result(spoken, "some text").commandId, "copy", spoken);
+  }
+});
+
+test("#374: copy never declines - any selection, however prose-like, can be copied", () => {
+  assert.equal(result("copy that", "a whole sentence, with punctuation!").status, "ok");
+});
+
 test("unrecognised command leaves an explicit status", () => {
   assert.deepEqual(result("make this sing", "whatever"), { status: "unrecognised" });
 });

--- a/electron/voiceEditCoordinator.js
+++ b/electron/voiceEditCoordinator.js
@@ -11,7 +11,10 @@ const { interpretVoiceEditCommand } = require("./voiceEditCommands");
 // and `delivery` are injected and asserted, and completions are queued so
 // two edits process strictly FIFO.
 function createVoiceEditIntake(options) {
-  const { transcription, delivery, onDiagnostic = () => {} } = options;
+  // #374: clipboard is optional so existing callers (and every test that
+  // doesn't care about "copy that") don't need to know it exists. Only
+  // reached if the command actually is copy - see below.
+  const { transcription, delivery, clipboard, onDiagnostic = () => {} } = options;
 
   assertAdapter("transcription", transcription, "transcribe");
   assertAdapter("delivery", delivery, "deliver");
@@ -68,6 +71,19 @@ function createVoiceEditIntake(options) {
     }
 
     const { commandId, result } = interpreted;
+
+    // #374: "copy that" never rewrites the selection or touches the
+    // target app - it reads the selection captured at key-down and writes
+    // it to the clipboard. No injection, so none of the newline / delivery
+    // machinery below applies.
+    if (commandId === "copy") {
+      if (!clipboard || typeof clipboard.writeText !== "function") {
+        return failed("copy", new Error("no clipboard adapter was configured"));
+      }
+      clipboard.writeText(result);
+      emitDiagnostic("voiceEdit.copied", result.length);
+      return { status: "copied", commandId, text: result };
+    }
 
     const needsNewlines = result.includes("\n");
     const targetTakesNewlines =

--- a/electron/voiceEditCoordinator.test.js
+++ b/electron/voiceEditCoordinator.test.js
@@ -22,6 +22,12 @@ function fakeAdapters(overrides = {}) {
         return { kind: "inserted" };
       },
     },
+    // #374: omit entirely to test the "no clipboard adapter configured" path.
+    clipboard: overrides.noClipboard
+      ? undefined
+      : {
+          writeText: (text) => calls.push(["clipboard.writeText", text]),
+        },
     onDiagnostic: (name, value) => calls.push(["diag", name, value]),
   };
 }
@@ -57,6 +63,32 @@ test("a declined command (prose given to an identifier case) never calls deliver
   assert.equal(result.status, "declined");
   assert.equal(result.commandId, "snake");
   assert.ok(!a.calls.some((c) => c[0] === "deliver"));
+});
+
+test("#374: copy that writes the selection to the clipboard and never calls deliver", async () => {
+  const a = fakeAdapters({ transcript: "copy that" });
+  const result = await createVoiceEditIntake(a).complete(WAV, ctx("the quick brown fox"));
+  assert.deepEqual(result, { status: "copied", commandId: "copy", text: "the quick brown fox" });
+  assert.deepEqual(a.calls.find((c) => c[0] === "clipboard.writeText"), ["clipboard.writeText", "the quick brown fox"]);
+  assert.ok(!a.calls.some((c) => c[0] === "deliver"), "copy never injects");
+});
+
+test("#374: copy works in an app that isn't break-safe, since nothing is injected", async () => {
+  // The newline / break-safe gate below is about what can land in the
+  // document - copy never reaches it, because it never writes anything.
+  const a = fakeAdapters({ transcript: "copy this" });
+  const result = await createVoiceEditIntake(a).complete(
+    WAV,
+    ctx("some code\nwith a line break", { bundleId: "com.apple.Terminal" }),
+  );
+  assert.equal(result.status, "copied");
+});
+
+test("#374: copy without a clipboard adapter configured fails cleanly", async () => {
+  const a = fakeAdapters({ transcript: "copy that", noClipboard: true });
+  const result = await createVoiceEditIntake(a).complete(WAV, ctx("hello"));
+  assert.equal(result.status, "failed");
+  assert.equal(result.stage, "copy");
 });
 
 test("a newline result into a non-break-safe app is held, not delivered", async () => {

--- a/src/commandReference.ts
+++ b/src/commandReference.ts
@@ -144,6 +144,12 @@ export const COMMAND_SECTIONS: CommandSection[] = [
           { say: "numbered list  ·  ordered list", becomes: "each item numbered 1., 2., 3." },
         ],
       },
+      {
+        title: "Clipboard",
+        commands: [
+          { say: "copy that  ·  copy this", becomes: "copies the selection — the document is left untouched" },
+        ],
+      },
     ],
   },
 ];


### PR DESCRIPTION
Closes #374.

Select text, hold push-to-talk, say **"copy that"** (also "copy this" / "copy it" / "copy"). The selection goes to the clipboard; the document is left untouched.

## How it fits

A new command kind in the voice-edit grammar (`electron/voiceEditCommands.js`). `interpretVoiceEditCommand` returns it like any other recognised command - `{ status: "ok", commandId: "copy", result: <the selection, unchanged> }` - and `voiceEditCoordinator` reads `commandId === "copy"` to write to the clipboard and return `{ status: "copied" }` **before** the newline / break-safe / delivery logic. Nothing is injected, so none of that applies, and there's no new safety question the way there is for paste (#375).

`clipboard` is an optional injected adapter, same shape as `transcription` and `delivery`. The overlay shows a brief "Copied".

## Also updated

- `src/commandReference.ts` - a "Clipboard" group on the Commands page
- `CONTEXT.md` - the Voice edit glossary entry, since "copy that" stretches "a transform of selected text"

## Checks

`npm test` (116 vitest + 277 node, +6 new), `npm run typecheck`, `npm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
