### PR TITLE
Voice command: paste (#375)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -73,7 +73,7 @@ Resolving the frontmost application and the focused field via the macOS Accessib
 _Avoid_: App detection, focus detection, context
 
 **Break-safe application**:
-An application where inserting a line break does not submit or send. The app inserts a paragraph break only in these. Every application is treated as unsafe until it is listed.
+An application where inserting a line break does not submit or send. Anything that would put a newline at the cursor - a spoken paragraph break, a multi-line paste (#375) - happens only in these. Every application is treated as unsafe until it is listed.
 _Avoid_: Allow-listed app, multi-line app, safe app
 
 **Break placement**:

--- a/electron/dictationCoordinator.js
+++ b/electron/dictationCoordinator.js
@@ -1,5 +1,30 @@
 const { cleanup } = require("./cleanup/rules");
 const { isBreakSafeApplication } = require("./breakSafety");
+
+// #375: a bare spoken "paste" is a command, not dictation. Strict
+// whole-utterance match - "paste the report" types literally, like any
+// other sentence with the word in it.
+const PASTE_PHRASES = new Set([
+  "paste",
+  "paste that",
+  "paste it",
+  "paste clipboard",
+  "paste the clipboard",
+  "paste from clipboard",
+  "paste from the clipboard",
+]);
+
+// A clipboard bigger than this is not what a spoken "paste" is for.
+const PASTE_MAX_CHARS = 10000;
+
+function isPasteCommand(rawText) {
+  return PASTE_PHRASES.has(
+    rawText
+      .toLowerCase()
+      .trim()
+      .replace(/[.,!?;:]+$/, ""),
+  );
+}
 const {
   splitSentences,
   repairBreakIndices,
@@ -26,6 +51,10 @@ function createDictationIntake(options) {
     // prompt needs - but the range is only rendered when this is switched on.
     // See spike/list-boundaries-125/FINDINGS.md.
     listDetection = false,
+    // #375: optional - only reached when the whole utterance is a bare
+    // "paste" command. Callers/tests that don't wire it get no paste
+    // command, everything else unchanged.
+    clipboard = null,
   } = options;
 
   assertAdapter("transcription", transcription, "transcribe");
@@ -129,6 +158,51 @@ function createDictationIntake(options) {
     const breakSafe = isBreakSafeApplication(focusContext.bundleId);
     emitDiagnostic("context.breakSafe", breakSafe);
     emitDiagnostic("context.oneLineField", focusContext.isOneLineField);
+
+    // #375: a bare "paste" puts the clipboard at the cursor. Gated the
+    // same way spoken line breaks are - a clipboard with newlines can run
+    // a command in a terminal, so multi-line paste only goes through in a
+    // break-safe app; a single-line clipboard is just text and is allowed
+    // anywhere. #355's app-switch guard already ran above, so the target
+    // is still the app dictation started in.
+    if (clipboard && typeof clipboard.readText === "function" && isPasteCommand(rawText)) {
+      emitDiagnostic("paste.command", true);
+      const clipboardText = clipboard.readText();
+      if (!clipboardText) {
+        return { status: "info", message: "Nothing on the clipboard to paste" };
+      }
+      if (clipboardText.length > PASTE_MAX_CHARS) {
+        emitDiagnostic("paste.tooLarge", clipboardText.length);
+        return { status: "info", message: `The clipboard is too big to paste (${clipboardText.length} characters)` };
+      }
+      if (/[\r\n]/.test(clipboardText) && !breakSafe) {
+        emitDiagnostic("paste.blockedInUnsafeApp", focusContext.bundleId);
+        return {
+          status: "held",
+          text: clipboardText,
+          reason: `won't paste multi-line text into ${focusContext.bundleId} — a line break there could run a command`,
+        };
+      }
+      try {
+        const deliveryResult = await delivery.deliver(clipboardText, focusContext.bundleId);
+        if (deliveryResult?.kind === "inserted") {
+          return { status: "pasted", text: clipboardText };
+        }
+        if (deliveryResult?.kind === "held") {
+          return {
+            status: "held",
+            text: clipboardText,
+            reason:
+              typeof deliveryResult.reason === "string" ? deliveryResult.reason : "the paste could not be placed",
+          };
+        }
+        throw new Error("delivery adapter returned an invalid result");
+      } catch (error) {
+        const reason = errorMessage(error);
+        emitDiagnostic("paste.deliveryFailure", reason);
+        return { status: "held", text: clipboardText, reason };
+      }
+    }
 
     // #307: when the focused element wasn't AX-ready, isOneLineField is a
     // guess, not a real role read - and the guess is "one-line" (#181). In a

--- a/electron/dictationCoordinator.test.js
+++ b/electron/dictationCoordinator.test.js
@@ -20,6 +20,8 @@ function createIntake({
   vocabulary,
   onDiagnostic,
   listDetection,
+  // #375: undefined = no clipboard adapter wired at all.
+  clipboardText,
 } = {}) {
   const diagnostics = [];
   const delivered = [];
@@ -47,6 +49,7 @@ function createIntake({
     vocabulary,
     onDiagnostic: onDiagnostic || ((name, value) => diagnostics.push([name, value])),
     listDetection,
+    clipboard: clipboardText !== undefined ? { readText: () => clipboardText } : null,
   });
 
   return { intake, diagnostics, delivered, breakCalls };
@@ -567,6 +570,83 @@ test("#355: delivery gets the bundle id just confirmed as frontmost", async () =
   await harness.intake.complete(completedWav, "com.apple.Notes");
 
   assert.deepEqual(receivedArgs, [["Hello world.", "com.apple.Notes"]]);
+});
+
+test("#375: a bare \"paste\" puts the clipboard at the cursor, not the word", async () => {
+  const args = [];
+  const harness = createIntake({
+    transcript: "paste",
+    clipboardText: "text from the clipboard",
+    deliver: async (...a) => {
+      args.push(a);
+      return { kind: "inserted" };
+    },
+  });
+
+  const result = await harness.intake.complete(completedWav);
+
+  assert.deepEqual(result, { status: "pasted", text: "text from the clipboard" });
+  assert.deepEqual(args, [["text from the clipboard", "com.apple.TextEdit"]]);
+});
+
+test("#375: the aliases match; extra words do not", async () => {
+  for (const spoken of ["paste", "Paste.", "paste that", "paste the clipboard"]) {
+    const harness = createIntake({ transcript: spoken, clipboardText: "x" });
+    assert.equal((await harness.intake.complete(completedWav)).status, "pasted", spoken);
+  }
+  const dictated = createIntake({ transcript: "paste the report into the doc", clipboardText: "x" });
+  const result = await dictated.intake.complete(completedWav);
+  assert.equal(result.status, "delivered", "a sentence with 'paste' in it is ordinary dictation");
+  assert.deepEqual(dictated.delivered, ["Paste the report into the doc."]);
+});
+
+test("#375: multi-line clipboard is held in a non-break-safe app, delivered in a break-safe one", async () => {
+  let deliveries = 0;
+  const held = createIntake({
+    transcript: "paste",
+    bundleId: "com.apple.Terminal",
+    clipboardText: "line one\nline two",
+    deliver: async () => {
+      deliveries++;
+      return { kind: "inserted" };
+    },
+  });
+  const heldResult = await held.intake.complete(completedWav);
+  assert.equal(heldResult.status, "held");
+  assert.equal(heldResult.text, "line one\nline two");
+  assert.match(heldResult.reason, /line break there could run a command/);
+  assert.equal(deliveries, 0);
+
+  const ok = createIntake({ transcript: "paste", bundleId: "com.apple.TextEdit", clipboardText: "line one\nline two" });
+  assert.equal((await ok.intake.complete(completedWav)).status, "pasted");
+});
+
+test("#375: a single-line clipboard pastes even in a terminal", async () => {
+  const harness = createIntake({
+    transcript: "paste",
+    bundleId: "com.apple.Terminal",
+    clipboardText: "npm run build",
+  });
+  assert.equal((await harness.intake.complete(completedWav)).status, "pasted");
+});
+
+test("#375: nothing or too much on the clipboard is a message, not a paste", async () => {
+  const empty = createIntake({ transcript: "paste", clipboardText: "" });
+  const emptyResult = await empty.intake.complete(completedWav);
+  assert.equal(emptyResult.status, "info");
+  assert.match(emptyResult.message, /Nothing on the clipboard/);
+
+  const huge = createIntake({ transcript: "paste", clipboardText: "x".repeat(10001) });
+  const hugeResult = await huge.intake.complete(completedWav);
+  assert.equal(hugeResult.status, "info");
+  assert.match(hugeResult.message, /too big/);
+});
+
+test("#375: with no clipboard adapter, \"paste\" is just dictation", async () => {
+  const harness = createIntake({ transcript: "paste" });
+  const result = await harness.intake.complete(completedWav);
+  assert.equal(result.status, "delivered");
+  assert.deepEqual(harness.delivered, ["Paste."]);
 });
 
 test("delivery failure holds the complete finished text without retrying delivery", async () => {

--- a/electron/main.js
+++ b/electron/main.js
@@ -177,6 +177,8 @@ function recordDictationDiagnostic(name, value) {
 
 const dictationIntake = createDictationIntake({
   transcription,
+  // #375: a spoken "paste" reads from here.
+  clipboard: { readText: () => clipboard.readText() },
   contextDetection: accessibilityHelper,
   breakPlacement,
   delivery: accessibilityHelper,
@@ -573,6 +575,14 @@ async function transcribeAndPrint(wavBuffer, timing, recordStartBundleId) {
       console.log(`[dictation] release-to-insertion: ${latencyMs.toFixed(1)}ms (${budgetResult} 1000ms budget)`);
     }
     setUserVisibleState("idle");
+  } else if (result.status === "pasted") {
+    // #375: a spoken "paste" - the clipboard is now at the cursor.
+    console.log(`[dictation] pasted ${result.text.length} characters from the clipboard`);
+    showVoiceEditMessage("Pasted");
+  } else if (result.status === "info") {
+    // #375: nothing to paste, or the clipboard was too large.
+    console.log(`[dictation] ${result.message}`);
+    showVoiceEditMessage(result.message);
   } else if (result.status === "held") {
     console.log(`[dictation] injection held: ${result.reason}`);
     setUserVisibleState("held", { text: result.text, reason: result.reason });

--- a/src/commandReference.ts
+++ b/src/commandReference.ts
@@ -89,6 +89,13 @@ export const COMMAND_SECTIONS: CommandSection[] = [
         ],
       },
       {
+        title: "Clipboard",
+        note: "Say it on its own — the whole utterance, nothing else, or it types literally.",
+        commands: [
+          { say: "paste  ·  paste that", becomes: "the clipboard, at the cursor. Multi-line only in break-safe apps." },
+        ],
+      },
+      {
         title: "Quoting, spelling & numbers",
         commands: [
           { say: "quote … end quote", becomes: "wraps what's between them in “…”", mono: false },


### PR DESCRIPTION
Closes #375 (option B — paste at the cursor).

Hold push-to-talk, say just **"paste"** (also "paste that" / "paste it" / "paste the clipboard"), and the clipboard lands at the cursor.

## How it fits

Caught in the dictation flow (`dictationCoordinator`), not voice-edit, because there's no selection. A strict whole-utterance match after normalising - "paste the report into the doc" is ordinary dictation and types literally.

## The safety questions, answered

- **Terminals / dangerous apps.** A clipboard with newlines pasted into a terminal runs a command (each `\n` is an Enter). So multi-line paste only goes through in a **break-safe app** - the same gate spoken line breaks already use. A single-line clipboard is just text and pastes anywhere.
- **App switched mid-flight.** Already covered - #355's guard runs before this code and `delivery.deliver()` gets the confirmed bundle id.
- **Empty / huge / binary clipboard.** Empty or non-text (`readText()` returns `""`) shows "Nothing on the clipboard to paste". Over 10k characters shows a "too big" message. Neither pastes.
- **Confirmation.** None, for v1 - it's an explicit spoken command on the user's own clipboard, gated on break-safety, and the overlay shows "Pasted". On a blocked or failed paste the clipboard text is held in the overlay for manual paste.

`clipboard` is an optional injected adapter on the dictation intake, same shape as `transcription` / `delivery` / `contextDetection`.

## Also updated

`src/commandReference.ts` (a "Clipboard" group under "While dictating"), `CONTEXT.md` (the Break-safe application entry - it now gates paste too).

## Checks

`npm test` (116 vitest + 277 node, +6 new), `npm run typecheck`, `npm run build` green.

## Follow-up

"Paste over this" (selection-replace) is the separate #375-follow-up option A, deliberately not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
