### PR TITLE
Turn spoken compound tens into digits (#332)

### DIFF
--- a/electron/cleanup/rules.js
+++ b/electron/cleanup/rules.js
@@ -326,6 +326,42 @@ const NUMBER_WORD_PATTERN =
   "thousand|and)";
 const NUMBER_PHRASE_PATTERN = `${NUMBER_WORD_PATTERN}(?:[\\s-]+${NUMBER_WORD_PATTERN})*`;
 
+// #332: a spoken compound number in the tens ("twenty three", "forty
+// seven") is a quantity and reads better as digits. Deliberately narrow -
+// bare "twenty", hundred-scale numbers, years ("nineteen eighty four")
+// and "X and Y" enumerations ("chapters one and two") are all left as
+// words until the eval corpus (#171) can prove a wider pass doesn't
+// mangle ordinary writing. This form has no such ambiguity: nobody says
+// "twenty three" in prose meaning anything but 23.
+const SPOKEN_TENS = {
+  twenty: 20, thirty: 30, forty: 40, fifty: 50, sixty: 60, seventy: 70, eighty: 80, ninety: 90,
+};
+const SPOKEN_ONES = {
+  one: 1, two: 2, three: 3, four: 4, five: 5, six: 6, seven: 7, eight: 8, nine: 9,
+};
+
+// Any number word that, sitting either side of a "twenty three", means we
+// are looking at something bigger or stranger than a plain two-digit count
+// - a year ("nineteen eighty four"), a larger figure ("twenty three
+// hundred"). Leave those alone.
+const SPOKEN_NUMBER_CONTEXT =
+  "one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|thirteen|" +
+  "fourteen|fifteen|sixteen|seventeen|eighteen|nineteen|twenty|thirty|forty|" +
+  "fifty|sixty|seventy|eighty|ninety|hundred|thousand|million|billion";
+const SPOKEN_NUMBER_PATTERN = new RegExp(
+  `(?<!\\b(?:${SPOKEN_NUMBER_CONTEXT})[\\s-])` +
+    "\\b(twenty|thirty|forty|fifty|sixty|seventy|eighty|ninety)[\\s-]" +
+    "(one|two|three|four|five|six|seven|eight|nine)\\b" +
+    `(?![\\s-](?:${SPOKEN_NUMBER_CONTEXT})\\b)`,
+  "gi",
+);
+
+function applySpokenNumbers(text) {
+  return text.replace(SPOKEN_NUMBER_PATTERN, (_match, tens, ones) =>
+    String(SPOKEN_TENS[tens.toLowerCase()] + SPOKEN_ONES[ones.toLowerCase()]),
+  );
+}
+
 function applyCurrency(text) {
   // Combined form first, so a standalone "cents" pass below can't run on a
   // span this pass already consumed.
@@ -507,6 +543,7 @@ function cleanup(text, options = {}) {
   text = applySpokenEmoji(text);
   text = applyQuoteMarkers(text);
   text = applyCurrency(text);
+  text = applySpokenNumbers(text);
   text = stripLeadingFillers(text);
   if (!oneLineBox) {
     text = segmentSentences(text);
@@ -542,6 +579,7 @@ module.exports = {
   applyQuoteMarkers,
   parseNumberWords,
   applyCurrency,
+  applySpokenNumbers,
   applySpellOut,
   stripLeadingFillers,
   segmentSentences,

--- a/electron/cleanup/rules.test.js
+++ b/electron/cleanup/rules.test.js
@@ -341,6 +341,29 @@ test("\"a\"/\"an\" as a number word means one, the same idiom as ordinary Englis
   assert.equal(cleanup("that will cost a dollar and fifty cents"), "That will cost $1.50.");
 });
 
+test("compound spoken numbers in the tens become digits (#332)", () => {
+  const cases = [
+    ["i counted twenty three of them", "I counted 23 of them."],
+    ["she is forty seven", "She is 47."],
+    ["press the button ninety nine times", "Press the button 99 times."],
+    ["chapter twenty-one", "Chapter 21."],
+  ];
+  for (const [raw, expected] of cases) {
+    assert.equal(cleanup(raw), expected, raw);
+  }
+});
+
+test("spoken-number conversion stays clear of anything ambiguous (#332)", () => {
+  // A bare number word can still be prose ("twenty of them").
+  assert.equal(cleanup("i have twenty of them"), "I have twenty of them.");
+  // "X and Y" is an enumeration, not a sum.
+  assert.equal(cleanup("read chapters one and two"), "Read chapters one and two.");
+  // Hundred-scale numbers are left alone for now (often hyperbole).
+  assert.equal(cleanup("i told you a hundred times"), "I told you a hundred times.");
+  // Years read wrong if summed, so the teens form is untouched.
+  assert.equal(cleanup("it was nineteen eighty four"), "It was nineteen eighty four.");
+});
+
 test("spell:/spell that: assembles single-letter tokens into one capitalised word (#132)", () => {
   assert.equal(cleanup("my name is spell that j o h n"), "My name is John.");
   assert.equal(cleanup("spell: b o o k"), "Book.");

--- a/src/commandReference.ts
+++ b/src/commandReference.ts
@@ -102,6 +102,7 @@ export const COMMAND_SECTIONS: CommandSection[] = [
           { say: "spell, then the letters", becomes: "“spell J O H N” → John", mono: false },
           { say: "fifty dollars", becomes: "$50", mono: true },
           { say: "three dollars and twenty cents", becomes: "$3.20", mono: true },
+          { say: "twenty three", becomes: "23 — compound tens only; “twenty” on its own stays a word", mono: false },
         ],
       },
       {


### PR DESCRIPTION
Closes #332.

Parakeet spells small numbers out, so saying "twenty three" produced the words "twenty three" rather than "23". #130 kept number conversion strictly to a currency context because bare conversion is ambiguous ("I have two cats" must stay "two"). This adds one narrow slice that is not ambiguous.

## What converts

A spoken compound number in the tens, after the currency pass:

- "I counted twenty three of them" -> "I counted 23 of them."
- "she is forty seven" -> "She is 47."
- "chapter twenty-one" -> "Chapter 21." (hyphen or space)

## What is deliberately left alone

This is the design call for you to veto. Everything below stays as words until the eval corpus (#171) exists to prove a wider pass does not mangle ordinary writing:

- a bare "twenty" on its own ("I have twenty of them")
- "X and Y" enumerations ("read chapters one and two" is not "read chapters 3")
- hundred-scale numbers ("I told you a hundred times" - usually hyperbole)
- year forms ("it was nineteen eighty four" - reads wrong if summed)

The regex guards against a number word on either side of the match, so "nineteen eighty four" does not partially convert to "nineteen 84".

## Tests

Added two cases to `rules.test.js` (the conversions, and the four things that must not convert). Full suite + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
