### PR TITLE
Voice command: paste over a selection (#378)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -27,7 +27,7 @@ The finished text from a completed recording that could not be placed at the cur
 _Avoid_: Failed dictation, lost text
 
 **Voice edit**:
-A transform of text the user has already selected, requested by speaking a Voice-edit command such as "snake case" or "bullet list". Distinct from dictation: the user selects text first and asks for the change explicitly. In v0.3 the transforms are deterministic and run with no model - a semantic rewrite ("make this shorter") is out of scope until a capable model fills the rewrite model server role. "Copy that" is the exception that proves the shape: same trigger, but it writes the selection to the clipboard and never touches the document (#374).
+A transform of text the user has already selected, requested by speaking a Voice-edit command such as "snake case" or "bullet list". Distinct from dictation: the user selects text first and asks for the change explicitly. In v0.3 the transforms are deterministic and run with no model - a semantic rewrite ("make this shorter") is out of scope until a capable model fills the rewrite model server role. "Copy that" is the exception that proves the shape: same trigger, but it writes the selection to the clipboard and never touches the document (#374). "Paste over this" is the mirror image: the selection is replaced with the clipboard contents, which then flow through the same break-safe gate as any other edit (#378).
 _Avoid_: Cleanup, correction, LLM pass, rewrite
 
 **Voice-edit command**:

--- a/electron/clipboardPasteLimits.js
+++ b/electron/clipboardPasteLimits.js
@@ -1,0 +1,15 @@
+// Shared limits and messages for the spoken "paste" commands: the paste
+// at the cursor during dictation (#375/#377) and the paste over a
+// selection on the voice-edit path (#378). Kept in one place so the two
+// coordinators can't drift apart on the cap or the wording.
+
+// A clipboard bigger than this is not what a spoken "paste" is for.
+const PASTE_MAX_CHARS = 10000;
+
+const EMPTY_CLIPBOARD_MESSAGE = "Nothing on the clipboard to paste";
+
+function clipboardTooBigMessage(length) {
+  return `The clipboard is too big to paste (${length} characters)`;
+}
+
+module.exports = { PASTE_MAX_CHARS, EMPTY_CLIPBOARD_MESSAGE, clipboardTooBigMessage };

--- a/electron/dictationCoordinator.js
+++ b/electron/dictationCoordinator.js
@@ -14,8 +14,11 @@ const PASTE_PHRASES = new Set([
   "paste from the clipboard",
 ]);
 
-// A clipboard bigger than this is not what a spoken "paste" is for.
-const PASTE_MAX_CHARS = 10000;
+const {
+  PASTE_MAX_CHARS,
+  EMPTY_CLIPBOARD_MESSAGE,
+  clipboardTooBigMessage,
+} = require("./clipboardPasteLimits");
 
 function isPasteCommand(rawText) {
   return PASTE_PHRASES.has(
@@ -169,11 +172,11 @@ function createDictationIntake(options) {
       emitDiagnostic("paste.command", true);
       const clipboardText = clipboard.readText();
       if (!clipboardText) {
-        return { status: "info", message: "Nothing on the clipboard to paste" };
+        return { status: "info", message: EMPTY_CLIPBOARD_MESSAGE };
       }
       if (clipboardText.length > PASTE_MAX_CHARS) {
         emitDiagnostic("paste.tooLarge", clipboardText.length);
-        return { status: "info", message: `The clipboard is too big to paste (${clipboardText.length} characters)` };
+        return { status: "info", message: clipboardTooBigMessage(clipboardText.length) };
       }
       if (/[\r\n]/.test(clipboardText) && !breakSafe) {
         emitDiagnostic("paste.blockedInUnsafeApp", focusContext.bundleId);

--- a/electron/main.js
+++ b/electron/main.js
@@ -193,7 +193,11 @@ const voiceEditIntake = createVoiceEditIntake({
   transcription,
   delivery: accessibilityHelper,
   // #374: "copy that" writes the selection here instead of injecting.
-  clipboard: { writeText: (text) => clipboard.writeText(text) },
+  // #378: "paste over this" reads from here and delivers it over the selection.
+  clipboard: {
+    writeText: (text) => clipboard.writeText(text),
+    readText: () => clipboard.readText(),
+  },
   onDiagnostic: (name, value) => console.log(`[voice-edit] ${name}: ${JSON.stringify(value)}`),
 });
 
@@ -535,6 +539,10 @@ async function applyVoiceEdit(wavBuffer, selection, timing) {
   } else if (result.status === "copied") {
     console.log(`[voice-edit] copied ${result.text.length} characters to the clipboard`);
     showVoiceEditMessage("Copied");
+  } else if (result.status === "info") {
+    // #378: nothing to paste over the selection, or the clipboard was too big.
+    console.log(`[voice-edit] ${result.message}`);
+    showVoiceEditMessage(result.message);
   } else if (result.status === "held") {
     console.log(`[voice-edit] held: ${result.reason}`);
     setUserVisibleState("held", { text: result.text, reason: result.reason });

--- a/electron/voiceEditCommands.js
+++ b/electron/voiceEditCommands.js
@@ -30,6 +30,18 @@ const COMMANDS = {
   // commandId "copy"; the coordinator reads that id to route to the
   // clipboard instead of injection, same as it already reads other ids.
   copy: { kind: "copy", aliases: ["copy that", "copy this", "copy it", "copy"] },
+  // #378: replace the selection with the clipboard. Like copy, the grammar
+  // layer has no clipboard, so applyCommand returns the selection only to
+  // signal "ok"; the coordinator sees commandId "paste-over" and swaps in
+  // the clipboard text before it runs the newline / delivery checks.
+  "paste-over": {
+    kind: "paste-over",
+    aliases: [
+      "paste over this", "paste over that", "paste over the selection", "paste over",
+      "replace with clipboard", "replace with the clipboard",
+      "replace this with the clipboard", "replace that with the clipboard",
+    ],
+  },
 };
 
 const ALIAS_TO_ID = new Map();
@@ -134,6 +146,7 @@ function applyCommand(command, selection) {
   if (command.kind === "wrap") return applyWrap(command, selection);
   if (command.kind === "list") return applyList(command, selection);
   if (command.kind === "copy") return selection;
+  if (command.kind === "paste-over") return selection;
   return null;
 }
 

--- a/electron/voiceEditCommands.test.js
+++ b/electron/voiceEditCommands.test.js
@@ -97,6 +97,16 @@ test("#374: copy never declines - any selection, however prose-like, can be copi
   assert.equal(result("copy that", "a whole sentence, with punctuation!").status, "ok");
 });
 
+test("#378: paste over the selection matches and returns ok, whatever the selection", () => {
+  for (const spoken of [
+    "paste over this", "paste over that", "paste over", "Paste over the selection.",
+    "replace with clipboard", "replace with the clipboard",
+  ]) {
+    assert.equal(result(spoken, "old value, with prose").commandId, "paste-over", spoken);
+    assert.equal(result(spoken, "old value").status, "ok", spoken);
+  }
+});
+
 test("unrecognised command leaves an explicit status", () => {
   assert.deepEqual(result("make this sing", "whatever"), { status: "unrecognised" });
 });

--- a/electron/voiceEditCoordinator.js
+++ b/electron/voiceEditCoordinator.js
@@ -1,5 +1,10 @@
 const { isBreakSafeApplication } = require("./breakSafety");
 const { interpretVoiceEditCommand } = require("./voiceEditCommands");
+const {
+  PASTE_MAX_CHARS,
+  EMPTY_CLIPBOARD_MESSAGE,
+  clipboardTooBigMessage,
+} = require("./clipboardPasteLimits");
 
 // Voice-edit intake (#17). The user selected text, held push-to-talk, and
 // spoke a command. This transcribes the command, matches it against the
@@ -85,28 +90,48 @@ function createVoiceEditIntake(options) {
       return { status: "copied", commandId, text: result };
     }
 
-    const needsNewlines = result.includes("\n");
+    // #378: "paste over this" delivers the clipboard in place of the
+    // selection. From here on it is an ordinary transform - the text just
+    // came from the clipboard rather than a rewrite of the selection - so
+    // it flows through the same newline gate and delivery below.
+    let deliverable = result;
+    if (commandId === "paste-over") {
+      if (!clipboard || typeof clipboard.readText !== "function") {
+        return failed("paste", new Error("no clipboard adapter was configured"));
+      }
+      const clipboardText = clipboard.readText();
+      if (!clipboardText) {
+        return { status: "info", commandId, message: EMPTY_CLIPBOARD_MESSAGE };
+      }
+      if (clipboardText.length > PASTE_MAX_CHARS) {
+        emitDiagnostic("voiceEdit.pasteTooLarge", clipboardText.length);
+        return { status: "info", commandId, message: clipboardTooBigMessage(clipboardText.length) };
+      }
+      deliverable = clipboardText;
+    }
+
+    const needsNewlines = deliverable.includes("\n");
     const targetTakesNewlines =
       isBreakSafeApplication(focusContext.bundleId) && !focusContext.isOneLineField;
     if (needsNewlines && !targetTakesNewlines) {
       return {
         status: "held",
         commandId,
-        text: result,
+        text: deliverable,
         reason: "this app can't take the line breaks this edit needs",
       };
     }
 
     try {
-      const deliveryResult = await delivery.deliver(result);
+      const deliveryResult = await delivery.deliver(deliverable);
       if (deliveryResult?.kind === "inserted") {
-        return { status: "delivered", commandId, text: result };
+        return { status: "delivered", commandId, text: deliverable };
       }
       if (deliveryResult?.kind === "held") {
         return {
           status: "held",
           commandId,
-          text: result,
+          text: deliverable,
           reason:
             typeof deliveryResult.reason === "string" ? deliveryResult.reason : "delivery could not proceed",
         };
@@ -115,7 +140,7 @@ function createVoiceEditIntake(options) {
     } catch (error) {
       const reason = errorMessage(error);
       emitDiagnostic("voiceEdit.deliveryFailure", reason);
-      return { status: "held", commandId, text: result, reason };
+      return { status: "held", commandId, text: deliverable, reason };
     }
   }
 

--- a/electron/voiceEditCoordinator.test.js
+++ b/electron/voiceEditCoordinator.test.js
@@ -22,11 +22,15 @@ function fakeAdapters(overrides = {}) {
         return { kind: "inserted" };
       },
     },
-    // #374: omit entirely to test the "no clipboard adapter configured" path.
+    // #374/#378: omit entirely to test the "no clipboard adapter configured" path.
     clipboard: overrides.noClipboard
       ? undefined
       : {
           writeText: (text) => calls.push(["clipboard.writeText", text]),
+          readText: () => {
+            calls.push(["clipboard.readText"]);
+            return overrides.clipboardText ?? "";
+          },
         },
     onDiagnostic: (name, value) => calls.push(["diag", name, value]),
   };
@@ -89,6 +93,51 @@ test("#374: copy without a clipboard adapter configured fails cleanly", async ()
   const result = await createVoiceEditIntake(a).complete(WAV, ctx("hello"));
   assert.equal(result.status, "failed");
   assert.equal(result.stage, "copy");
+});
+
+test("#378: paste over the selection delivers the clipboard, not the selection", async () => {
+  const a = fakeAdapters({ transcript: "paste over this", clipboardText: "newIdentifier" });
+  const result = await createVoiceEditIntake(a).complete(WAV, ctx("oldIdentifier"));
+  assert.deepEqual(result, { status: "delivered", commandId: "paste-over", text: "newIdentifier" });
+  assert.deepEqual(a.calls.find((c) => c[0] === "deliver"), ["deliver", "newIdentifier"]);
+});
+
+test("#378: paste over the selection with an empty clipboard reports it and never delivers", async () => {
+  const a = fakeAdapters({ transcript: "paste over that", clipboardText: "" });
+  const result = await createVoiceEditIntake(a).complete(WAV, ctx("something"));
+  assert.equal(result.status, "info");
+  assert.equal(result.message, "Nothing on the clipboard to paste");
+  assert.ok(!a.calls.some((c) => c[0] === "deliver"));
+});
+
+test("#378: paste over the selection refuses an oversized clipboard", async () => {
+  const a = fakeAdapters({ transcript: "paste over this", clipboardText: "x".repeat(10001) });
+  const result = await createVoiceEditIntake(a).complete(WAV, ctx("something"));
+  assert.equal(result.status, "info");
+  assert.match(result.message, /too big to paste \(10001 characters\)/);
+  assert.ok(!a.calls.some((c) => c[0] === "deliver"));
+});
+
+test("#378: a multi-line clipboard is held out of a non-break-safe app", async () => {
+  const a = fakeAdapters({ transcript: "paste over this", clipboardText: "line one\nline two" });
+  const result = await createVoiceEditIntake(a).complete(WAV, ctx("target", { bundleId: "com.apple.Terminal" }));
+  assert.equal(result.status, "held");
+  assert.equal(result.commandId, "paste-over");
+  assert.ok(!a.calls.some((c) => c[0] === "deliver"));
+});
+
+test("#378: a multi-line clipboard goes through in a break-safe app", async () => {
+  const a = fakeAdapters({ transcript: "paste over this", clipboardText: "line one\nline two" });
+  const result = await createVoiceEditIntake(a).complete(WAV, ctx("target"));
+  assert.equal(result.status, "delivered");
+  assert.equal(result.text, "line one\nline two");
+});
+
+test("#378: paste over the selection without a clipboard adapter fails cleanly", async () => {
+  const a = fakeAdapters({ transcript: "paste over this", noClipboard: true });
+  const result = await createVoiceEditIntake(a).complete(WAV, ctx("hello"));
+  assert.equal(result.status, "failed");
+  assert.equal(result.stage, "paste");
 });
 
 test("a newline result into a non-break-safe app is held, not delivered", async () => {

--- a/src/commandReference.ts
+++ b/src/commandReference.ts
@@ -155,6 +155,7 @@ export const COMMAND_SECTIONS: CommandSection[] = [
         title: "Clipboard",
         commands: [
           { say: "copy that  ·  copy this", becomes: "copies the selection — the document is left untouched" },
+          { say: "paste over this  ·  replace with clipboard", becomes: "swaps the selection for the clipboard. Multi-line only in break-safe apps." },
         ],
       },
     ],


### PR DESCRIPTION
Closes #378. Follow-up to #375 / #377, which shipped "paste" at the cursor (option B). This is option A: paste that replaces a selection.

## The command

Select text, hold push-to-talk, say one of:

- "paste over this" / "paste over that" / "paste over the selection" / "paste over"
- "replace with clipboard" / "replace with the clipboard" / "replace this with the clipboard"

The selection is replaced with the clipboard contents.

## How it works

It rides the voice-edit path (a selection already exists at key-down), so it inherits the newline / break-safe gate and the injection ladder for free:

- single-line clipboard: delivered anywhere, like any other edit
- multi-line clipboard: only lands in a break-safe app, held everywhere else (a line break in a terminal could run a command)
- empty clipboard, or over the 10k-char cap: a message, no delivery

New `paste-over` command kind in `voiceEditCommands.js` alongside `copy` (#374). Like `copy`, the grammar layer has no clipboard, so `applyCommand` returns the selection only to mean "ok"; `voiceEditCoordinator` sees the command id and swaps in the clipboard text before the newline / delivery checks.

The 10k cap and the "Nothing on the clipboard to paste" / "too big to paste" messages moved out of `dictationCoordinator` into a new `electron/clipboardPasteLimits.js`, shared by both paste paths so they can't drift.

## Tests

- `voiceEditCommands.test.js`: the aliases match, any selection is accepted
- `voiceEditCoordinator.test.js`: delivers the clipboard not the selection, empty clipboard reported, oversized refused, multi-line held out of a terminal but through in a break-safe app, no-adapter fails cleanly

Full suite + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
