### PR TITLE
Names & terms: a user correction table for transcription (#321)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -68,6 +68,10 @@ _Avoid_: Eviction, unloading, timeout kill
 Deterministic, non-model text tidying applied to every dictation. Costs under a millisecond. It does all cleanup except break placement, which it asks the rewrite model server to decide.
 _Avoid_: Post-processing, formatting pass
 
+**Term correction**:
+A user-supplied "heard this, write that" pair (#321), applied during rules cleanup after the built-in vocabulary. It rewrites one exact word or phrase the transcription reliably gets wrong, most often a name. Deterministic and literal - it never guesses at a near-miss it was not told about.
+_Avoid_: vocabulary biasing (that acts during transcription, not after), autocorrect, dictionary
+
 **Context detection**:
 Resolving the frontmost application and the focused field via the macOS Accessibility API. It is the input to break-safe determination, not the decision itself: it reports the bundle id and the AX role, and what is done with them is defined separately.
 _Avoid_: App detection, focus detection, context

--- a/electron/cleanup/rules.js
+++ b/electron/cleanup/rules.js
@@ -446,6 +446,35 @@ function applyVocab(text) {
   return text;
 }
 
+// #321: user-maintained proper-noun / project-term corrections. Same idea as
+// VOCAB above - a fixed "heard this, write that" table - but supplied at call
+// time from Settings rather than hardcoded, because the terms are personal
+// (someone's name, their project's vocabulary). Each entry is
+// { heard, write }: a case-insensitive whole-word / whole-phrase match on
+// `heard`, replaced with `write` exactly as typed. Deterministic like VOCAB;
+// it only ever rewrites a phrase the user listed verbatim, it never guesses
+// at near-misses (that needs the eval corpus, #171, and a different design).
+const CORRECTION_WORD_CHAR = "[\\p{L}\\p{N}_]";
+
+function applyCorrections(text, corrections) {
+  if (!Array.isArray(corrections)) return text;
+  for (const entry of corrections) {
+    const heard = typeof entry?.heard === "string" ? entry.heard.trim() : "";
+    const write = typeof entry?.write === "string" ? entry.write : "";
+    if (!heard) continue;
+    const escaped = heard.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    // Word-boundary guard, but only on a side where `heard` actually ends in
+    // a word character: "Nabil" won't match inside "Nabila", yet a term like
+    // "C#" still matches with a space right after it.
+    const lead = new RegExp(`^${CORRECTION_WORD_CHAR}`, "u").test(heard) ? `(?<!${CORRECTION_WORD_CHAR})` : "";
+    const trail = new RegExp(`${CORRECTION_WORD_CHAR}$`, "u").test(heard) ? `(?!${CORRECTION_WORD_CHAR})` : "";
+    const pattern = new RegExp(`${lead}${escaped}${trail}`, "giu");
+    // A function replacement so a `$` in the user's text stays literal.
+    text = text.replace(pattern, () => write);
+  }
+  return text;
+}
+
 function capitalise(text) {
   text = text.replace(/\bi\b/g, "I");
   text = text.replace(/\bi'(m|ve|ll|d)\b/g, (_match, suffix) => "I'" + suffix);
@@ -481,6 +510,9 @@ function terminalPunct(text) {
  * @param {boolean} [options.breakSafe] - frontmost app is on the break-safe
  *   allow-list (#45 §3). Deny-by-default: unknown/unlisted apps get no
  *   literal newlines even when the user says "new line"/"new paragraph".
+ * @param {{heard: string, write: string}[]} [options.corrections] - #321
+ *   user-maintained term corrections from Settings, applied after the
+ *   built-in vocabulary.
  */
 function cleanup(text, options = {}) {
   const oneLineBox = Boolean(options.oneLineBox);
@@ -515,6 +547,9 @@ function cleanup(text, options = {}) {
   // Apply fixed casing after sentence capitalisation so names such as macOS
   // keep their settled spelling even at the start of a dictation.
   text = applyVocab(text);
+  // #321: user corrections run last of the vocab passes, so they can also
+  // override a built-in VOCAB rule the user disagrees with.
+  text = applyCorrections(text, options.corrections);
   text = oneLineBox ? text.replace(/\.\s*$/, "").replace(/\s+$/, "") : terminalPunct(text);
   // Spaces only, not [ \t]: a doubled "tab tab" (#129) is a deliberate
   // double indent, not doubled whitespace to squeeze down to one.
@@ -546,6 +581,7 @@ module.exports = {
   stripLeadingFillers,
   segmentSentences,
   applyVocab,
+  applyCorrections,
   capitalise,
   terminalPunct,
 };

--- a/electron/cleanup/rules.test.js
+++ b/electron/cleanup/rules.test.js
@@ -1,6 +1,6 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
-const { cleanup, parseNumberWords } = require("./rules");
+const { cleanup, parseNumberWords, applyCorrections } = require("./rules");
 const samples = require("../../spike/llm-cleanup-latency/samples.json");
 
 test("removes standalone and phrase fillers", () => {
@@ -101,6 +101,42 @@ test("applies technical vocabulary fixups", () => {
   for (const [raw, expected] of cases) {
     assert.equal(cleanup(raw), expected, raw);
   }
+});
+
+test("#321: user term corrections rewrite a whole word or phrase, any casing", () => {
+  const corrections = [
+    { heard: "Nabeel", write: "Nabil" },
+    { heard: "open stream", write: "OpenStream" },
+  ];
+  assert.equal(
+    cleanup("i told nabeel about open stream", { corrections }),
+    "I told Nabil about OpenStream.",
+  );
+  assert.equal(cleanup("NABEEL says hi", { corrections }), "Nabil says hi.");
+});
+
+test("#321: a correction never fires inside a longer word", () => {
+  assert.equal(
+    applyCorrections("Nabila met Nabeel", [{ heard: "Nabeel", write: "Nabil" }]),
+    "Nabila met Nabil",
+  );
+});
+
+test("#321: no corrections option leaves cleanup exactly as before", () => {
+  assert.equal(cleanup("hello nabeel"), "Hello nabeel.");
+  assert.equal(cleanup("hello nabeel", { corrections: [] }), "Hello nabeel.");
+  assert.equal(cleanup("hello nabeel", { corrections: null }), "Hello nabeel.");
+});
+
+test("#321: a $ in the replacement stays literal", () => {
+  assert.equal(
+    applyCorrections("that costs five bucks", [{ heard: "five bucks", write: "$5" }]),
+    "that costs $5",
+  );
+});
+
+test("#321: corrections can override a built-in vocabulary rule", () => {
+  assert.equal(cleanup("i run macos", { corrections: [{ heard: "macOS", write: "Mac OS" }] }), "I run Mac OS.");
 });
 
 test("handles spoken self-correction by discarding the preceding clause", () => {

--- a/electron/dictationCoordinator.js
+++ b/electron/dictationCoordinator.js
@@ -43,6 +43,10 @@ function createDictationIntake(options) {
     // no-op that biases nothing, rather than forcing every caller/test to
     // know about vocabulary scanning.
     vocabulary = { getPrompt: () => "" },
+    // #321: user-maintained term corrections from Settings. Optional and
+    // defaulting to none, same as vocabulary - callers/tests that don't wire
+    // it get ordinary cleanup with only the built-in vocabulary.
+    corrections = { getEntries: () => [] },
     onDiagnostic = () => {},
     // #125: the spike found SmolLM2-1.7B over-triggers list detection (a list
     // flagged on 5 of 6 non-lists) and the live prompt is break-only for now,
@@ -62,6 +66,7 @@ function createDictationIntake(options) {
   assertAdapter("breakPlacement", breakPlacement, "placeParagraphBreaks");
   assertAdapter("delivery", delivery, "deliver");
   assertAdapter("vocabulary", vocabulary, "getPrompt");
+  assertAdapter("corrections", corrections, "getEntries");
 
   let queue = Promise.resolve();
 
@@ -98,6 +103,13 @@ function createDictationIntake(options) {
       return { status: "no-speech" };
     }
 
+    // #321: read the user's correction table once for this dictation and fold
+    // it into every cleanup() call below (the main path and both salvage
+    // paths), so a held transcript still gets the name spelled right.
+    const correctionEntries = corrections.getEntries();
+    emitDiagnostic("corrections.count", Array.isArray(correctionEntries) ? correctionEntries.length : 0);
+    const clean = (text, opts) => cleanup(text, { ...opts, corrections: correctionEntries });
+
     let focusContext;
     try {
       focusContext = await contextDetection.getFocusContext();
@@ -127,7 +139,7 @@ function createDictationIntake(options) {
         recordStartBundleId !== focusContext.bundleId
       ) {
         emitDiagnostic("context.appSwitchedDuringDictation", `${recordStartBundleId} -> ${focusContext.bundleId}`);
-        const salvaged = cleanup(rawText, { oneLineBox: false, breakSafe: false });
+        const salvaged = clean(rawText, { oneLineBox: false, breakSafe: false });
         if (!salvaged) {
           return { status: "no-speech" };
         }
@@ -144,7 +156,7 @@ function createDictationIntake(options) {
       // cleaned with the safe defaults (deny line breaks), exactly as a
       // failed delivery does.
       emitDiagnostic("context.failure", errorMessage(error));
-      const salvaged = cleanup(rawText, { oneLineBox: false, breakSafe: false });
+      const salvaged = clean(rawText, { oneLineBox: false, breakSafe: false });
       if (!salvaged) {
         return { status: "no-speech" };
       }
@@ -229,7 +241,7 @@ function createDictationIntake(options) {
       emitDiagnostic("context.breakCommandDropped", focusContext.bundleId);
     }
 
-    let finishedText = cleanup(rawText, {
+    let finishedText = clean(rawText, {
       oneLineBox: treatAsOneLine,
       breakSafe,
     });

--- a/electron/dictationCoordinator.test.js
+++ b/electron/dictationCoordinator.test.js
@@ -18,6 +18,8 @@ function createIntake({
   placeParagraphBreaks,
   deliver,
   vocabulary,
+  // #321: undefined = no corrections adapter wired (the default no-op).
+  corrections,
   onDiagnostic,
   listDetection,
   // #375: undefined = no clipboard adapter wired at all.
@@ -47,6 +49,7 @@ function createIntake({
       }),
     },
     vocabulary,
+    ...(corrections !== undefined ? { corrections } : {}),
     onDiagnostic: onDiagnostic || ((name, value) => diagnostics.push([name, value])),
     listDetection,
     clipboard: clipboardText !== undefined ? { readText: () => clipboardText } : null,
@@ -111,6 +114,39 @@ test("#16: with no vocabulary adapter configured, transcribe gets an empty promp
   await harness.intake.complete(completedWav);
 
   assert.deepEqual(transcriptionCalls, [""]);
+});
+
+test("#321: the corrections adapter's table is applied to the finished text", async () => {
+  const { result, delivered } = await deliveredText({
+    transcript: "i spoke to nabeel about open stream",
+    corrections: {
+      getEntries: () => [
+        { heard: "Nabeel", write: "Nabil" },
+        { heard: "open stream", write: "OpenStream" },
+      ],
+    },
+  });
+  assert.equal(result.status, "delivered");
+  assert.deepEqual(delivered, ["I spoke to Nabil about OpenStream."]);
+});
+
+test("#321: corrections also reach a held (salvaged) transcript", async () => {
+  const harness = createIntake({
+    transcript: "tell nabeel it works",
+    corrections: { getEntries: () => [{ heard: "Nabeel", write: "Nabil" }] },
+    getFocusContext: async () => {
+      throw new Error("helper is down");
+    },
+  });
+  const result = await harness.intake.complete(completedWav);
+  assert.equal(result.status, "held");
+  assert.equal(result.text, "Tell Nabil it works.");
+});
+
+test("#321: with no corrections adapter, cleanup runs unchanged", async () => {
+  const { result, delivered } = await deliveredText({ transcript: "hello nabeel" });
+  assert.equal(result.status, "delivered");
+  assert.deepEqual(delivered, ["Hello nabeel."]);
 });
 
 test("a known unsafe application never receives spoken line breaks", async () => {
@@ -283,6 +319,7 @@ test("repairs malformed break indices without retrying and records format and re
   });
   assert.deepEqual(harness.diagnostics, [
     ["vocabulary.promptLength", 0],
+    ["corrections.count", 0],
     ["context.bundleId", "com.apple.TextEdit"],
     ["context.axReady", true],
     ["context.breakSafe", true],
@@ -340,6 +377,7 @@ test("a flagged spoken list renders as bullets set off from the surrounding pros
   });
   assert.deepEqual(harness.diagnostics, [
     ["vocabulary.promptLength", 0],
+    ["corrections.count", 0],
     ["context.bundleId", "com.apple.TextEdit"],
     ["context.axReady", true],
     ["context.breakSafe", true],
@@ -366,6 +404,7 @@ test("an out-of-range list range is clamped into the text and recorded as repair
   });
   assert.deepEqual(harness.diagnostics, [
     ["vocabulary.promptLength", 0],
+    ["corrections.count", 0],
     ["context.bundleId", "com.apple.TextEdit"],
     ["context.axReady", true],
     ["context.breakSafe", true],
@@ -392,6 +431,7 @@ test("a malformed LIST line fails closed to prose without dropping paragraph bre
   });
   assert.deepEqual(harness.diagnostics, [
     ["vocabulary.promptLength", 0],
+    ["corrections.count", 0],
     ["context.bundleId", "com.apple.TextEdit"],
     ["context.axReady", true],
     ["context.breakSafe", true],
@@ -417,6 +457,7 @@ test("list detection is off by default: a valid range is parsed and reported but
   });
   assert.deepEqual(harness.diagnostics, [
     ["vocabulary.promptLength", 0],
+    ["corrections.count", 0],
     ["context.bundleId", "com.apple.TextEdit"],
     ["context.axReady", true],
     ["context.breakSafe", true],

--- a/electron/main.js
+++ b/electron/main.js
@@ -183,6 +183,9 @@ const dictationIntake = createDictationIntake({
   breakPlacement,
   delivery: accessibilityHelper,
   vocabulary,
+  // #321: the user's term-correction table, read fresh from settings on every
+  // dictation so an edit takes effect on the next utterance.
+  corrections: { getEntries: () => (settingsStore ? settingsStore.get().termCorrections : []) },
   onDiagnostic: recordDictationDiagnostic,
 });
 
@@ -883,6 +886,13 @@ ipcMain.handle("settings:set-break-safe-apps", (event, apps) => {
 ipcMain.handle("app:get-setup-progress", () => lastSetupProgress);
 ipcMain.handle("app:retry-model-download", () => {
   retryModelDownload();
+});
+
+ipcMain.handle("settings:set-term-corrections", (event, entries) => {
+  // #321: setTermCorrections validates and throws on anything malformed, the
+  // same shape as settings:set-break-safe-apps, so a bad renderer edit can't
+  // write a corrupt table that cleanup() would then choke on.
+  return settingsStore.setTermCorrections(entries);
 });
 
 ipcMain.handle("settings:reset-break-safe-apps", () => {

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -51,6 +51,7 @@ contextBridge.exposeInMainWorld("openstream", {
     resetBreakSafeApps: () => ipcRenderer.invoke("settings:reset-break-safe-apps"),
     pickBreakSafeApp: () => ipcRenderer.invoke("settings:pick-break-safe-app"),
     setVocabularyProjectPath: (projectPath) => ipcRenderer.invoke("settings:set-vocabulary-path", projectPath),
+    setTermCorrections: (entries) => ipcRenderer.invoke("settings:set-term-corrections", entries),
   },
   vocabulary: {
     rescan: () => ipcRenderer.invoke("vocabulary:rescan"),

--- a/electron/settingsStore.js
+++ b/electron/settingsStore.js
@@ -12,6 +12,9 @@ const DEFAULT_SETTINGS = {
   // #16: null means no project configured - vocabulary biasing is opt-in,
   // not a default every fresh install has to notice and turn off.
   vocabularyProjectPath: null,
+  // #321: user-maintained "heard this, write that" corrections for names and
+  // project terms the transcription engine gets wrong. Empty by default.
+  termCorrections: [],
   // #212: the desktop window's last size and position. null until the
   // window has been opened and moved/resized once; windowState.js sanity
   // -checks it against the actual display before it's used.
@@ -69,6 +72,48 @@ function validateWindowBounds(bounds) {
       throw new Error(`windowBounds.${key} must be a number when present`);
     }
   }
+}
+
+// #321: a bound on the list keeps the per-dictation regex work trivial (each
+// entry is one cheap pass in cleanup()) and stops a runaway renderer edit
+// bloating the settings file. 200 names/terms is far more than any real list.
+const MAX_TERM_CORRECTIONS = 200;
+const MAX_TERM_CORRECTION_LENGTH = 80;
+
+function validateTermCorrections(entries) {
+  if (!Array.isArray(entries)) {
+    throw new Error("termCorrections must be an array");
+  }
+  if (entries.length > MAX_TERM_CORRECTIONS) {
+    throw new Error(`termCorrections cannot hold more than ${MAX_TERM_CORRECTIONS} entries`);
+  }
+  for (const entry of entries) {
+    if (!entry || typeof entry !== "object") {
+      throw new Error("each term correction must be an object");
+    }
+    for (const key of ["heard", "write"]) {
+      if (typeof entry[key] !== "string" || entry[key].trim().length === 0) {
+        throw new Error(`each term correction needs a non-empty "${key}" string`);
+      }
+      if (entry[key].length > MAX_TERM_CORRECTION_LENGTH) {
+        throw new Error(`term correction "${key}" cannot exceed ${MAX_TERM_CORRECTION_LENGTH} characters`);
+      }
+    }
+  }
+}
+
+function normaliseTermCorrections(entries) {
+  const seen = new Set();
+  const kept = [];
+  for (const entry of entries) {
+    const heard = entry.heard.trim();
+    const write = entry.write.trim();
+    const key = heard.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    kept.push({ heard, write });
+  }
+  return kept;
 }
 
 function validateBreakSafeApps(apps) {
@@ -159,6 +204,11 @@ function createSettingsStore({ filePath }) {
     return commit({ ...load(), vocabularyProjectPath: projectPath === null ? null : projectPath.trim() });
   }
 
+  function setTermCorrections(entries) {
+    validateTermCorrections(entries);
+    return commit({ ...load(), termCorrections: normaliseTermCorrections(entries) });
+  }
+
   function setWindowBounds(bounds) {
     validateWindowBounds(bounds);
     // Only the four geometry keys are kept - a caller passing a whole
@@ -180,7 +230,16 @@ function createSettingsStore({ filePath }) {
     return () => listeners.delete(listener);
   }
 
-  return { get, setShortcut, setHotkey, setBreakSafeApps, setVocabularyProjectPath, setWindowBounds, onChange };
+  return {
+    get,
+    setShortcut,
+    setHotkey,
+    setBreakSafeApps,
+    setVocabularyProjectPath,
+    setTermCorrections,
+    setWindowBounds,
+    onChange,
+  };
 }
 
 module.exports = {
@@ -189,4 +248,7 @@ module.exports = {
   validateShortcut,
   validateNewShortcut,
   validateHotkey: validateShortcut,
+  validateTermCorrections,
+  MAX_TERM_CORRECTIONS,
+  MAX_TERM_CORRECTION_LENGTH,
 };

--- a/electron/settingsStore.test.js
+++ b/electron/settingsStore.test.js
@@ -265,3 +265,43 @@ test("rejects windowBounds with a non-numeric position", () => {
   const store = createSettingsStore({ filePath: tempFilePath() });
   assert.throws(() => store.setWindowBounds({ width: 800, height: 600, x: "left" }), /must be a number/);
 });
+
+test("#321: termCorrections defaults to an empty list", () => {
+  const store = createSettingsStore({ filePath: tempFilePath() });
+  assert.deepEqual(store.get().termCorrections, []);
+});
+
+test("#321: setTermCorrections persists, trims, and dedupes by heard", () => {
+  const filePath = tempFilePath();
+  const store = createSettingsStore({ filePath });
+  store.setTermCorrections([
+    { heard: "  Nabeel  ", write: "  Nabil  " },
+    { heard: "nabeel", write: "Nabil B" },
+    { heard: "open stream", write: "OpenStream" },
+  ]);
+  assert.deepEqual(store.get().termCorrections, [
+    { heard: "Nabeel", write: "Nabil" },
+    { heard: "open stream", write: "OpenStream" },
+  ]);
+  const onDisk = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  assert.equal(onDisk.termCorrections.length, 2);
+});
+
+test("#321: setTermCorrections rejects malformed entries", () => {
+  const store = createSettingsStore({ filePath: tempFilePath() });
+  assert.throws(() => store.setTermCorrections("nope"), /must be an array/);
+  assert.throws(() => store.setTermCorrections([{ heard: "x" }]), /non-empty "write"/);
+  assert.throws(() => store.setTermCorrections([{ heard: "  ", write: "y" }]), /non-empty "heard"/);
+  assert.throws(() => store.setTermCorrections([{ heard: "a".repeat(81), write: "b" }]), /cannot exceed/);
+  assert.throws(
+    () => store.setTermCorrections(Array.from({ length: 201 }, (_v, i) => ({ heard: `h${i}`, write: "w" }))),
+    /more than 200/,
+  );
+});
+
+test("#321: an invalid setTermCorrections call leaves the previous value untouched", () => {
+  const store = createSettingsStore({ filePath: tempFilePath() });
+  store.setTermCorrections([{ heard: "Nabeel", write: "Nabil" }]);
+  assert.throws(() => store.setTermCorrections([{ heard: "", write: "y" }]));
+  assert.deepEqual(store.get().termCorrections, [{ heard: "Nabeel", write: "Nabil" }]);
+});

--- a/src/TermCorrectionsSettings.tsx
+++ b/src/TermCorrectionsSettings.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useState } from "react";
+import type { TermCorrection } from "./openstreamBridge";
+
+// #321: the user's "heard this, write that" table for names and project
+// terms the transcription engine gets wrong. Saved on every add / remove,
+// same as the break-safe app list.
+export default function TermCorrectionsSettings() {
+  const [entries, setEntries] = useState<TermCorrection[] | null>(null);
+  const [heard, setHeard] = useState("");
+  const [write, setWrite] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    window.openstream.settings.get().then((settings) => setEntries(settings.termCorrections));
+  }, []);
+
+  function save(next: TermCorrection[]) {
+    setSaving(true);
+    setError(null);
+    window.openstream.settings
+      .setTermCorrections(next)
+      .then((settings) => setEntries(settings.termCorrections))
+      .catch((err) => setError(err instanceof Error ? err.message : String(err)))
+      .finally(() => setSaving(false));
+  }
+
+  function addEntry() {
+    const h = heard.trim();
+    const w = write.trim();
+    if (!h || !w || !entries) return;
+    if (entries.some((e) => e.heard.toLowerCase() === h.toLowerCase())) {
+      setError(`"${h}" is already in the list`);
+      return;
+    }
+    save([...entries, { heard: h, write: w }]);
+    setHeard("");
+    setWrite("");
+  }
+
+  function removeEntry(target: string) {
+    if (!entries) return;
+    save(entries.filter((e) => e.heard !== target));
+  }
+
+  return (
+    <>
+      <div className="correction-list">
+        {entries === null ? (
+          <span className="chip chip--empty">Loading…</span>
+        ) : entries.length === 0 ? (
+          <span className="chip chip--empty">No corrections yet</span>
+        ) : (
+          entries.map((entry) => (
+            <div className="correction-row" key={entry.heard}>
+              <span className="correction-row__heard">{entry.heard}</span>
+              <span className="correction-row__arrow" aria-hidden="true">
+                →
+              </span>
+              <span className="correction-row__write">{entry.write}</span>
+              <button
+                type="button"
+                onClick={() => removeEntry(entry.heard)}
+                disabled={saving}
+                aria-label={`Remove correction for ${entry.heard}`}
+              >
+                ×
+              </button>
+            </div>
+          ))
+        )}
+      </div>
+
+      <div className="setting-item__control">
+        <input
+          className="field"
+          type="text"
+          placeholder="heard"
+          value={heard}
+          onChange={(event) => setHeard(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") addEntry();
+          }}
+          disabled={saving || entries === null}
+          aria-label="Word or phrase as transcribed"
+        />
+        <span className="correction-row__arrow" aria-hidden="true">
+          →
+        </span>
+        <input
+          className="field"
+          type="text"
+          placeholder="write instead"
+          value={write}
+          onChange={(event) => setWrite(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") addEntry();
+          }}
+          disabled={saving || entries === null}
+          aria-label="What it should be written as"
+        />
+        <button
+          type="button"
+          className="btn"
+          onClick={addEntry}
+          disabled={saving || entries === null || heard.trim().length === 0 || write.trim().length === 0}
+        >
+          Add
+        </button>
+      </div>
+
+      {error && <p className="error-text">{error}</p>}
+
+      <p className="hint">
+        A whole word or phrase, matched however it is capitalised. Runs after transcription, so it fixes a
+        consistent mishearing but not a one-off.
+      </p>
+    </>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -768,6 +768,41 @@ button { font: inherit; }
   border-style: dashed;
 }
 
+/* #321: the Names & terms table - one row per correction, laid out like a
+   stack of chips rather than a data grid. */
+.correction-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 9px;
+}
+.correction-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 7px 4px 11px;
+  font-size: 12px;
+  border-radius: var(--r-sm);
+  background: var(--screen-2);
+  border: 1px solid var(--line-hi);
+  color: var(--fg-hi);
+  align-self: flex-start;
+}
+.correction-row__arrow { color: var(--faint); }
+.correction-row__write { color: var(--acc); }
+.correction-row button {
+  border: 0;
+  background: transparent;
+  color: var(--faint);
+  cursor: default;
+  padding: 0 2px;
+  margin-left: 2px;
+  font-size: 14px;
+  line-height: 1;
+}
+.correction-row button:hover { color: var(--err); }
+.correction-list .chip--empty { align-self: flex-start; }
+
 .settings-advanced { margin-top: 12px; }
 .settings-advanced > summary {
   font-size: 12px;

--- a/src/openstreamBridge.d.ts
+++ b/src/openstreamBridge.d.ts
@@ -1,9 +1,12 @@
 import type { StoredHotkey } from "./hotkey/captureHotkey";
 
+export type TermCorrection = { heard: string; write: string };
+
 export type StoredSettings = {
   hotkey: StoredHotkey;
   breakSafeApps: string[];
   vocabularyProjectPath: string | null;
+  termCorrections: TermCorrection[];
 };
 
 export type SetShortcutResult =
@@ -74,6 +77,7 @@ declare global {
         setVocabularyProjectPath(
           projectPath: string | null
         ): Promise<{ settings: StoredSettings; status: VocabularyStatus }>;
+        setTermCorrections(entries: TermCorrection[]): Promise<StoredSettings>;
       };
       vocabulary: {
         rescan(): Promise<VocabularyStatus>;

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import HotkeySettings from "../HotkeySettings";
 import BreakSafeAppsSettings from "../BreakSafeAppsSettings";
+import TermCorrectionsSettings from "../TermCorrectionsSettings";
 import Toggle from "../components/Toggle";
 
 function StartupSection() {
@@ -45,6 +46,15 @@ export default function Settings() {
             since a newline can submit a half-typed terminal command or send an unfinished message.
           </p>
           <BreakSafeAppsSettings />
+        </div>
+
+        <div className="setting-item">
+          <h3 className="setting-item__name">Names &amp; terms</h3>
+          <p className="setting-item__desc">
+            Fix a name or a project term the transcription keeps getting wrong. Each entry rewrites a word or
+            phrase wherever it is heard, whatever the capitalisation.
+          </p>
+          <TermCorrectionsSettings />
         </div>
 
         <StartupSection />


### PR DESCRIPTION
Closes the near-term half of #321 (the correction table **and** the Settings field — they only make sense together, since the whole point is a user-maintained list).

Parakeet transcribes proper nouns inconsistently — "Nabil" one dictation, "Nabeel" the next. whisper's `initial_prompt` biasing (#16) doesn't apply to Parakeet (ADR-0003), so this is the post-transcription fix.

## How it works

- **`rules.js`** — `applyCorrections(text, corrections)` runs inside `cleanup()`, right after the built-in `VOCAB` pass (so a user entry can also override a built-in rule). Each entry is a `{ heard, write }` pair:
  - case-insensitive match, replacement written verbatim
  - whole word / phrase only — "Nabil" never fires inside "Nabila"; multi-word ("open stream" → "OpenStream") works; the word-boundary guard drops on a side where `heard` ends in punctuation so "C#" still matches
  - deterministic like `VOCAB` — it only ever rewrites a phrase the user typed, never guesses at a near-miss
- **`settingsStore.js`** — a validated `termCorrections` list: capped at 200 entries, each field 80 chars, deduped by `heard` (case-insensitive), both fields trimmed.
- **`dictationCoordinator.js`** — an optional `corrections` adapter (same shape as `vocabulary`), read once per dictation and applied to every `cleanup()` call, including both salvage paths, so a held transcript still gets the name right. Emits a `corrections.count` diagnostic.
- **Settings** — a "Names & terms" section: add a `heard → write` pair, remove one, saved immediately. Matches the existing settings-list / chip idiom.

## Design calls to veto

1. **Explicit `{ heard, write }` pairs, not a bare term list with fuzzy matching.** Fuzzy/homophone matching ("Nabeel"/"Nabeal"/"Nabil" all → "Nabil" from one entry) is what the issue gestures at, but it's error-prone and there's no way to measure regressions until the eval corpus (#171) exists. This ships the safe, deterministic half now.
2. **Runs after transcription, in cleanup — not during it.** #322 (FluidAudio keyword boosting) is the during-transcription route; this is independent of it and useful on its own.
3. Applied to **dictation only**, not voice edits (that text was already corrected once).

## Tests

`rules.test.js` (6 cases: match/casing, longer-word guard, no-option no-op, `$` literal, VOCAB override), `settingsStore.test.js` (5: default, persist/trim/dedupe, malformed rejection, cap, atomicity), `dictationCoordinator.test.js` (3: applied to finished text, reaches a held transcript, absent adapter unchanged). Full suite (296) + typecheck + renderer build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
