### PR TITLE
Copy every dictation to the clipboard, optionally (#255)

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -564,6 +564,20 @@ async function applyVoiceEdit(wavBuffer, selection, timing) {
   }
 }
 
+// #255: when the option is on, every finished dictation also goes on the
+// clipboard, so a paste that doesn't land is still recoverable with Cmd+V.
+// Runs after delivery, so it deliberately overwrites the clipboard the
+// injection engine may have borrowed and restored.
+function maybeCopyTranscript(text) {
+  if (!text || !settingsStore || !settingsStore.get().copyTranscriptToClipboard) return;
+  try {
+    clipboard.writeText(text);
+    console.log("[dictation] transcript copied to the clipboard");
+  } catch (error) {
+    console.error("[dictation] could not copy the transcript:", error);
+  }
+}
+
 async function transcribeAndPrint(wavBuffer, timing, recordStartBundleId) {
   let result;
   try {
@@ -585,6 +599,7 @@ async function transcribeAndPrint(wavBuffer, timing, recordStartBundleId) {
   if (result.status === "delivered") {
     console.log(`[dictation] ${result.text}`);
     console.log("[dictation] inserted through accessibility");
+    maybeCopyTranscript(result.text);
     if (Number.isFinite(timing?.releasedAtMs)) {
       const latencyMs = performance.now() - timing.releasedAtMs;
       const budgetResult = latencyMs < 1000 ? "within" : "over";
@@ -601,6 +616,7 @@ async function transcribeAndPrint(wavBuffer, timing, recordStartBundleId) {
     showVoiceEditMessage(result.message);
   } else if (result.status === "held") {
     console.log(`[dictation] injection held: ${result.reason}`);
+    maybeCopyTranscript(result.text);
     setUserVisibleState("held", { text: result.text, reason: result.reason });
   } else if (result.status === "failed") {
     console.error(`[dictation] ${result.stage} failed: ${result.reason}`);
@@ -907,6 +923,11 @@ ipcMain.handle("settings:reset-break-safe-apps", () => {
   const settings = settingsStore.setBreakSafeApps([...DEFAULT_BREAK_SAFE_BUNDLE_IDS]);
   setBreakSafeApplications(settings.breakSafeApps);
   return settings;
+});
+
+ipcMain.handle("settings:set-copy-transcript", (event, enabled) => {
+  // #255: validated in the store, same as the other setters.
+  return settingsStore.setCopyTranscriptToClipboard(enabled);
 });
 
 // #19: pick an app from disk instead of hunting down its bundle id by

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -52,6 +52,7 @@ contextBridge.exposeInMainWorld("openstream", {
     pickBreakSafeApp: () => ipcRenderer.invoke("settings:pick-break-safe-app"),
     setVocabularyProjectPath: (projectPath) => ipcRenderer.invoke("settings:set-vocabulary-path", projectPath),
     setTermCorrections: (entries) => ipcRenderer.invoke("settings:set-term-corrections", entries),
+    setCopyTranscript: (enabled) => ipcRenderer.invoke("settings:set-copy-transcript", enabled),
   },
   vocabulary: {
     rescan: () => ipcRenderer.invoke("vocabulary:rescan"),

--- a/electron/settingsStore.js
+++ b/electron/settingsStore.js
@@ -19,6 +19,10 @@ const DEFAULT_SETTINGS = {
   // window has been opened and moved/resized once; windowState.js sanity
   // -checks it against the actual display before it's used.
   windowBounds: null,
+  // #255: also put every finished dictation on the clipboard, so a paste
+  // that doesn't land is never a lost dictation. Off by default - it
+  // clobbers whatever the user had copied.
+  copyTranscriptToClipboard: false,
 };
 
 const VALID_MODIFIERS = new Set(["cmd", "shift", "alt", "ctrl"]);
@@ -209,6 +213,13 @@ function createSettingsStore({ filePath }) {
     return commit({ ...load(), termCorrections: normaliseTermCorrections(entries) });
   }
 
+  function setCopyTranscriptToClipboard(enabled) {
+    if (typeof enabled !== "boolean") {
+      throw new Error("copyTranscriptToClipboard must be a boolean");
+    }
+    return commit({ ...load(), copyTranscriptToClipboard: enabled });
+  }
+
   function setWindowBounds(bounds) {
     validateWindowBounds(bounds);
     // Only the four geometry keys are kept - a caller passing a whole
@@ -237,6 +248,7 @@ function createSettingsStore({ filePath }) {
     setBreakSafeApps,
     setVocabularyProjectPath,
     setTermCorrections,
+    setCopyTranscriptToClipboard,
     setWindowBounds,
     onChange,
   };

--- a/electron/settingsStore.test.js
+++ b/electron/settingsStore.test.js
@@ -199,6 +199,26 @@ test("vocabularyProjectPath defaults to null", () => {
   assert.equal(store.get().vocabularyProjectPath, null);
 });
 
+test("#255: copyTranscriptToClipboard defaults to false", () => {
+  const store = createSettingsStore({ filePath: tempFilePath() });
+  assert.equal(store.get().copyTranscriptToClipboard, false);
+});
+
+test("#255: setCopyTranscriptToClipboard persists and reflects afterwards", () => {
+  const filePath = tempFilePath();
+  const store = createSettingsStore({ filePath });
+  store.setCopyTranscriptToClipboard(true);
+  assert.equal(store.get().copyTranscriptToClipboard, true);
+  assert.equal(JSON.parse(fs.readFileSync(filePath, "utf8")).copyTranscriptToClipboard, true);
+  store.setCopyTranscriptToClipboard(false);
+  assert.equal(store.get().copyTranscriptToClipboard, false);
+});
+
+test("#255: setCopyTranscriptToClipboard rejects a non-boolean", () => {
+  const store = createSettingsStore({ filePath: tempFilePath() });
+  assert.throws(() => store.setCopyTranscriptToClipboard("yes"), /must be a boolean/);
+});
+
 test("setVocabularyProjectPath persists a trimmed path and get() reflects it afterwards", () => {
   const filePath = tempFilePath();
   const store = createSettingsStore({ filePath });

--- a/src/openstreamBridge.d.ts
+++ b/src/openstreamBridge.d.ts
@@ -7,6 +7,7 @@ export type StoredSettings = {
   breakSafeApps: string[];
   vocabularyProjectPath: string | null;
   termCorrections: TermCorrection[];
+  copyTranscriptToClipboard: boolean;
 };
 
 export type SetShortcutResult =
@@ -78,6 +79,7 @@ declare global {
           projectPath: string | null
         ): Promise<{ settings: StoredSettings; status: VocabularyStatus }>;
         setTermCorrections(entries: TermCorrection[]): Promise<StoredSettings>;
+        setCopyTranscript(enabled: boolean): Promise<StoredSettings>;
       };
       vocabulary: {
         rescan(): Promise<VocabularyStatus>;

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -4,6 +4,37 @@ import BreakSafeAppsSettings from "../BreakSafeAppsSettings";
 import TermCorrectionsSettings from "../TermCorrectionsSettings";
 import Toggle from "../components/Toggle";
 
+function CopyTranscriptSection() {
+  const [enabled, setEnabled] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    window.openstream.settings.get().then((settings) => setEnabled(settings.copyTranscriptToClipboard));
+  }, []);
+
+  return (
+    <div className="setting-item">
+      <h3 className="setting-item__name">Copy every dictation</h3>
+      <p className="setting-item__desc">
+        Also puts the finished text on the clipboard, so a paste that doesn’t land is never lost. Off by default,
+        since it replaces whatever you had copied.
+      </p>
+      <div className="setting-item__control">
+        <Toggle
+          label="Copy each finished dictation to the clipboard"
+          checked={enabled ?? false}
+          disabled={enabled === null}
+          onChange={(next) => {
+            setEnabled(next);
+            window.openstream.settings
+              .setCopyTranscript(next)
+              .then((settings) => setEnabled(settings.copyTranscriptToClipboard));
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
 function StartupSection() {
   const [openAtLogin, setOpenAtLogin] = useState<boolean | null>(null);
 
@@ -56,6 +87,8 @@ export default function Settings() {
           </p>
           <TermCorrectionsSettings />
         </div>
+
+        <CopyTranscriptSection />
 
         <StartupSection />
       </div>


### PR DESCRIPTION
Closes #255.

## Part 1 — always copy the transcript (built)

A new setting, **Copy every dictation**, off by default. When on, every finished dictation is also written to the clipboard, so a paste that silently fails is never a lost dictation — Cmd+V gets it back.

- `settingsStore`: `copyTranscriptToClipboard` boolean, validated like the other setters.
- `main.js`: `maybeCopyTranscript()` runs in the dictation result handler on both the `delivered` and `held` outcomes. It runs *after* `delivery.deliver()` resolves, so it deliberately lands on top of the clipboard the injection engine may have borrowed and restored during a Rung 2 paste.
- Settings: a "Copy every dictation" toggle.

Off by default because it clobbers whatever the user had copied.

## Part 2 — one-click copy on a held result (already shipped)

The held-result overlay already does this: a `Copy` button that flips to `Copied`, with "Still here. Copy it and paste it where you want." No change needed — noting it here for the issue's checklist.

## Tests

`settingsStore.test.js`: default false, persist/reflect, non-boolean rejected. Full suite (287) + typecheck + renderer build green. The `main.js` wiring has no unit test, consistent with the rest of that file (the Electron entrypoint) — it's covered by the manual dictation pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
