### PR TITLE
Surface model-server failures to the user (#254)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -51,7 +51,7 @@ The process that rewrites existing text on request. It serves voice edits, and i
 _Avoid_: llama-server, the LLM, cleanup model
 
 **Model supervisor**:
-The single component that owns the lifecycle of every model server: starting it, restarting it after a crash or a settings change, and releasing it.
+The single component that owns the lifecycle of every model server: starting it, restarting it after a crash or a settings change, and releasing it. It keeps retrying a crashed server, but after several fast failures in a row it reports the server as **failed** so the app can say so rather than sit silent (#254).
 _Avoid_: Process manager, runner, daemon
 
 **Resident**:

--- a/electron/main.js
+++ b/electron/main.js
@@ -620,7 +620,11 @@ async function transcribeAndPrint(wavBuffer, timing, recordStartBundleId) {
     setUserVisibleState("held", { text: result.text, reason: result.reason });
   } else if (result.status === "failed") {
     console.error(`[dictation] ${result.stage} failed: ${result.reason}`);
-    setUserVisibleState("idle");
+    // #254: don't drop to idle in silence - a failed transcription looks
+    // exactly like a dead hotkey otherwise. Say which stage broke.
+    showVoiceEditMessage(
+      result.stage === "transcription" ? "Couldn’t transcribe that" : "That didn’t go through",
+    );
   } else if (result.status === "no-speech") {
     console.log("[dictation] (no speech detected)");
     setUserVisibleState("idle");
@@ -679,6 +683,8 @@ function loadTrayIcons() {
 }
 
 let permissionsBlocked = false;
+// #254: the roles (transcription / rewrite) whose server is crash-looping.
+const failedModels = new Set();
 
 function setTrayState(state) {
   if (!trayIcons[state]) {
@@ -687,7 +693,12 @@ function setTrayState(state) {
   trayState = state;
   tray.setImage(trayIcons[state]);
   const base = state === "idle" ? "OpenStream" : `OpenStream — ${state}`;
-  tray.setToolTip(permissionsBlocked ? `${base} (permissions needed)` : base);
+  const note = permissionsBlocked
+    ? " (permissions needed)"
+    : failedModels.size > 0
+      ? " (model not running)"
+      : "";
+  tray.setToolTip(`${base}${note}`);
 }
 
 // #47: reflected in the tray tooltip so a degraded app is visible without
@@ -695,6 +706,18 @@ function setTrayState(state) {
 function updateTrayForPermissions(verdict) {
   permissionsBlocked = !verdict.ok;
   if (tray) setTrayState(trayState);
+}
+
+// #254: a model server entering / leaving its crash-looped state. Update the
+// tray, and push a health refresh to the window so the System panel reacts
+// immediately rather than on its next poll.
+function reflectModelStatus(role, status) {
+  if (status === "failed") failedModels.add(role);
+  else failedModels.delete(role);
+  console.error(`[${role} model] status: ${status}`);
+  if (tray) setTrayState(trayState);
+  if (win && !win.isDestroyed()) win.webContents.send("health-changed");
+  if (status === "failed") openWindowTo("home");
 }
 
 // Positioned fresh on every show, not once at creation, so it follows
@@ -860,6 +883,14 @@ ipcMain.handle("app:open-privacy-settings", (event, key) => {
   if (url) shell.openExternal(url);
 });
 
+// #254: a crash-looping server is "failed", not perpetually "starting" -
+// readiness (is it up?) and supervisor status (is it giving up?) together
+// decide what the user is told.
+function modelHealth(ready, status) {
+  if (ready) return "ready";
+  return status === "failed" ? "failed" : "starting";
+}
+
 ipcMain.handle("app:get-health", async () => {
   const [transcription, rewrite, permissions] = await Promise.all([
     transcriptionHelper.isReady(),
@@ -868,9 +899,18 @@ ipcMain.handle("app:get-health", async () => {
   ]);
   return {
     permissions: permissions.grants,
-    transcriptionModel: transcription ? "ready" : "starting",
-    rewriteModel: rewrite ? "ready" : "starting",
+    transcriptionModel: modelHealth(transcription, transcriptionHelper.status()),
+    rewriteModel: modelHealth(rewrite, rewriteModelServer.status()),
   };
+});
+
+ipcMain.handle("app:restart-model", (event, role) => {
+  // #254: the "Restart" affordance on the Home System panel.
+  if (role === "transcription") transcriptionHelper.restart();
+  else if (role === "rewrite") rewriteModelServer.restart();
+  else return { ok: false };
+  console.log(`[${role} model] restart requested by the user`);
+  return { ok: true };
 });
 
 ipcMain.handle("settings:start-shortcut-capture", (event) => {
@@ -1043,6 +1083,11 @@ app.whenReady().then(() => {
   const startModelServers = () => {
     transcriptionHelper.start();
     rewriteModelServer.start();
+    // #254: a crash-looping server updates the tray tooltip and nudges the
+    // window open, the same way a missing permission does - a dictation tool
+    // that silently does nothing is indistinguishable from a broken hotkey.
+    transcriptionHelper.onStatusChange((status) => reflectModelStatus("transcription", status));
+    rewriteModelServer.onStatusChange((status) => reflectModelStatus("rewrite", status));
   };
 
   // #249: a packaged app ships without the model weights and fetches them

--- a/electron/modelSupervisor.js
+++ b/electron/modelSupervisor.js
@@ -1,6 +1,12 @@
 const { spawn: defaultSpawn } = require("child_process");
 
 const DEFAULT_RESTART_DELAY_MS = 1000;
+// #254: a process that fails this many times in a row, each within
+// FAILURE_WINDOW_MS of the last, is crash-looping rather than hitting a
+// one-off blip. The supervisor keeps retrying (a local binary can recover),
+// but reports "failed" so the app can say so instead of sitting silent.
+const CRASH_LOOP_THRESHOLD = 3;
+const FAILURE_WINDOW_MS = 12000;
 
 function createModelSupervisor(options) {
   const {
@@ -13,6 +19,9 @@ function createModelSupervisor(options) {
     clearRestartTimer = clearTimeout,
     stdout = process.stdout,
     stderr = process.stderr,
+    now = () => Date.now(),
+    crashLoopThreshold = CRASH_LOOP_THRESHOLD,
+    failureWindowMs = FAILURE_WINDOW_MS,
   } = options;
 
   if (!roleName) throw new Error("Model supervisor requires a roleName");
@@ -21,16 +30,54 @@ function createModelSupervisor(options) {
   let child = null;
   let stopping = false;
   let restartTimer = null;
+  let consecutiveFailures = 0;
+  let lastStartAt = 0;
+  const statusListeners = new Set();
 
   function prefixedWrite(stream, data) {
     stream.write(`[${roleName}] ${data}`);
+  }
+
+  function emitStatus(value) {
+    for (const listener of statusListeners) {
+      try {
+        listener(value);
+      } catch {
+        // A listener must never break the supervisor.
+      }
+    }
+  }
+
+  // The current run has stayed up past the failure window, so a past crash
+  // loop counts as recovered. Checked lazily (on status()) rather than on a
+  // timer - a few seconds of stale "failed" after a recovery is harmless.
+  function clearIfRecovered() {
+    if (consecutiveFailures > 0 && child && now() - lastStartAt > failureWindowMs) {
+      consecutiveFailures = 0;
+      emitStatus("running");
+    }
+  }
+
+  function status() {
+    clearIfRecovered();
+    if (consecutiveFailures >= crashLoopThreshold) return "failed";
+    return child ? "running" : "starting";
+  }
+
+  function onStatusChange(listener) {
+    statusListeners.add(listener);
+    return () => statusListeners.delete(listener);
   }
 
   function restartAfterFailure(failedChild, message) {
     if (child !== failedChild) return;
     child = null;
     if (stopping) return;
+    // A run that lasted longer than the window was healthy - this failure
+    // starts a fresh count rather than adding to an old loop.
+    consecutiveFailures = now() - lastStartAt < failureWindowMs ? consecutiveFailures + 1 : 1;
     stderr.write(`[${roleName}] ${message}, restarting in ${restartDelayMs}ms\n`);
+    if (consecutiveFailures === crashLoopThreshold) emitStatus("failed");
     restartTimer = setRestartTimer(() => {
       restartTimer = null;
       start();
@@ -40,6 +87,7 @@ function createModelSupervisor(options) {
   function start() {
     if (child) return;
     stopping = false;
+    lastStartAt = now();
     const spawnedChild = spawn(command, args);
     child = spawnedChild;
 
@@ -68,7 +116,16 @@ function createModelSupervisor(options) {
     }
   }
 
-  return { start, stop, roleName };
+  // #254: a user asking to restart a failed server is saying "try again from
+  // scratch" - clear the crash-loop count so it isn't reported as failed the
+  // instant it comes back up.
+  function restart() {
+    consecutiveFailures = 0;
+    stop();
+    start();
+  }
+
+  return { start, stop, restart, status, onStatusChange, roleName };
 }
 
-module.exports = { createModelSupervisor, DEFAULT_RESTART_DELAY_MS };
+module.exports = { createModelSupervisor, DEFAULT_RESTART_DELAY_MS, CRASH_LOOP_THRESHOLD };

--- a/electron/modelSupervisor.test.js
+++ b/electron/modelSupervisor.test.js
@@ -135,3 +135,67 @@ test("stop cancels a pending restart after an unexpected exit", () => {
 
   assert.equal(timer.cancelled, true);
 });
+
+function crashLoopSupervisor(overrides = {}) {
+  const spawned = [];
+  const statuses = [];
+  const supervisor = createModelSupervisor({
+    roleName: "rewrite model server",
+    command: "/tmp/rewrite-server",
+    spawn: () => {
+      const child = fakeChild();
+      spawned.push(child);
+      return child;
+    },
+    setRestartTimer: (fn) => {
+      fn();
+      return {};
+    },
+    stderr: captureStream([]),
+    now: () => 0,
+    failureWindowMs: 1000,
+    ...overrides,
+  });
+  supervisor.onStatusChange((s) => statuses.push(s));
+  return { supervisor, spawned, statuses, latest: () => spawned[spawned.length - 1] };
+}
+
+test("#254: three fast failures in a row report the server as failed", () => {
+  const { supervisor, latest, statuses } = crashLoopSupervisor();
+  supervisor.start();
+  assert.equal(supervisor.status(), "running");
+
+  latest().emit("exit", 1, null);
+  assert.equal(supervisor.status(), "running");
+  latest().emit("exit", 1, null);
+  assert.equal(supervisor.status(), "running");
+  latest().emit("exit", 1, null);
+
+  assert.equal(supervisor.status(), "failed");
+  assert.deepEqual(statuses, ["failed"]);
+});
+
+test("#254: a run that outlasts the failure window resets the crash count", () => {
+  let clock = 0;
+  const { supervisor, latest } = crashLoopSupervisor({ now: () => clock });
+  supervisor.start();
+  latest().emit("exit", 1, null);
+  latest().emit("exit", 1, null);
+  // The next run stays up well past the window before it dies.
+  clock = 5000;
+  latest().emit("exit", 1, null);
+
+  assert.equal(supervisor.status(), "running");
+});
+
+test("#254: restart() clears a failed server", () => {
+  const { supervisor, latest } = crashLoopSupervisor();
+  supervisor.start();
+  latest().emit("exit", 1, null);
+  latest().emit("exit", 1, null);
+  latest().emit("exit", 1, null);
+  assert.equal(supervisor.status(), "failed");
+
+  supervisor.restart();
+  assert.equal(supervisor.status(), "running");
+});

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -23,6 +23,15 @@ function onSetupProgress(callback) {
   return () => ipcRenderer.removeListener("setup-progress", listener);
 }
 
+// #254: main pushes this when a model server's health changes (a crash
+// loop, or a recovery), so the System panel refreshes without waiting for
+// its poll. Carries no payload - the renderer re-fetches getHealth().
+function onHealthChanged(callback) {
+  const listener = () => callback();
+  ipcRenderer.on("health-changed", listener);
+  return () => ipcRenderer.removeListener("health-changed", listener);
+}
+
 // The renderer's only route to the main process, per contextIsolation - see
 // the settings window's webPreferences in main.js. First surface: settings
 // (#19). This will grow to cover the hotkey helper, the accessibility
@@ -36,6 +45,7 @@ contextBridge.exposeInMainWorld("openstream", {
     openPrivacySettings: (key) => ipcRenderer.invoke("app:open-privacy-settings", key),
     getSetupProgress: () => ipcRenderer.invoke("app:get-setup-progress"),
     retryModelDownload: () => ipcRenderer.invoke("app:retry-model-download"),
+    restartModel: (role) => ipcRenderer.invoke("app:restart-model", role),
   },
   settings: {
     get: () => ipcRenderer.invoke("settings:get"),
@@ -62,4 +72,5 @@ contextBridge.exposeInMainWorld("openstream", {
   onNavigate,
   onDictationState,
   onSetupProgress,
+  onHealthChanged,
 });

--- a/electron/rewriteModelServer.js
+++ b/electron/rewriteModelServer.js
@@ -41,6 +41,12 @@ function createRewriteModelServer(options = {}) {
   return {
     start: () => ensureSupervisor().start(),
     stop: () => supervisor?.stop(),
+    // #254: "failed" once it is crash-looping; "starting" until the first
+    // spawn; "running" while a process is up (readiness is a separate HTTP
+    // probe in main.js).
+    status: () => (supervisor ? supervisor.status() : "starting"),
+    onStatusChange: (listener) => ensureSupervisor().onStatusChange(listener),
+    restart: () => ensureSupervisor().restart(),
     healthUrl: () => `http://${HOST}:${port}/health`,
     chatCompletionsUrl: () => `http://${HOST}:${port}/v1/chat/completions`,
   };

--- a/electron/transcriptionHelper.js
+++ b/electron/transcriptionHelper.js
@@ -13,8 +13,13 @@ const { resourcesRoot } = require("./paths");
 // a {"event":"ready"} line once the model is loaded, then id-tagged
 // request/reply pairs.
 
+const { CRASH_LOOP_THRESHOLD } = require("./modelSupervisor");
+
 const BIN_PATH = path.join(resourcesRoot(), "bin", "transcription-helper");
 const RESTART_DELAY_MS = 1000;
+// #254: matches modelSupervisor - this many fast failures in a row means
+// the helper is crash-looping, not hitting a blip.
+const FAILURE_WINDOW_MS = 12000;
 
 // Parakeet on the ANE is well under a second on a short clip once warm, but
 // the first call after launch pays a Metal/ANE warm-up and a long dictation
@@ -31,12 +36,42 @@ function createTranscriptionHelper({
   setRestartTimer = setTimeout,
   clearRestartTimer = clearTimeout,
   stderr = process.stderr,
+  now = () => Date.now(),
+  crashLoopThreshold = CRASH_LOOP_THRESHOLD,
+  failureWindowMs = FAILURE_WINDOW_MS,
 } = {}) {
   let child = null;
   let stopping = false;
   let restartTimer = null;
   let nextId = 1;
   const pending = new Map();
+
+  // #254: crash-loop tracking, so the app can show the model as failed
+  // rather than silently retrying forever.
+  let consecutiveFailures = 0;
+  let lastStartAt = 0;
+  const statusListeners = new Set();
+
+  function emitStatus(value) {
+    for (const listener of statusListeners) {
+      try {
+        listener(value);
+      } catch {
+        // A listener must never break the helper.
+      }
+    }
+  }
+
+  function onStatusChange(listener) {
+    statusListeners.add(listener);
+    return () => statusListeners.delete(listener);
+  }
+
+  function status() {
+    if (consecutiveFailures >= crashLoopThreshold) return "failed";
+    if (ready) return "running";
+    return "starting";
+  }
 
   let ready = false;
   let readyResolve;
@@ -53,6 +88,11 @@ function createTranscriptionHelper({
 
   function markReady() {
     ready = true;
+    // A clean ready signal ends any crash loop.
+    if (consecutiveFailures > 0) {
+      consecutiveFailures = 0;
+      emitStatus("running");
+    }
     readyResolve();
   }
 
@@ -94,6 +134,7 @@ function createTranscriptionHelper({
   function start() {
     if (child) return;
     stopping = false;
+    lastStartAt = now();
     const spawnedChild = spawnProcess(BIN_PATH);
     child = spawnedChild;
 
@@ -108,9 +149,11 @@ function createTranscriptionHelper({
         settle(id, null, new Error("transcription-helper exited before replying"));
       }
       if (stopping) return;
+      consecutiveFailures = now() - lastStartAt < failureWindowMs ? consecutiveFailures + 1 : 1;
       stderr.write(
         `[transcription-helper] exited unexpectedly (code ${code}), restarting in ${restartDelayMs}ms\n`,
       );
+      if (consecutiveFailures === crashLoopThreshold) emitStatus("failed");
       restartTimer = setRestartTimer(() => {
         restartTimer = null;
         start();
@@ -174,7 +217,15 @@ function createTranscriptionHelper({
     return reply.text.trim();
   }
 
-  return { start, stop, isReady, whenReady, transcribe };
+  // #254: a user-driven restart of a failed helper - clear the crash-loop
+  // count so it isn't still "failed" the moment it comes back.
+  function restart() {
+    consecutiveFailures = 0;
+    stop();
+    start();
+  }
+
+  return { start, stop, restart, isReady, whenReady, status, onStatusChange, transcribe };
 }
 
 module.exports = {

--- a/electron/transcriptionHelper.test.js
+++ b/electron/transcriptionHelper.test.js
@@ -130,3 +130,71 @@ test("an {event:error} line is logged but does not reject the ready gate outrigh
   assert.ok(chunks.join("").includes("download failed"));
   helper.stop();
 });
+
+function crashLoopHelper() {
+  const children = [];
+  const statuses = [];
+  const helper = createTranscriptionHelper({
+    spawnProcess: () => {
+      const c = fakeProcess();
+      children.push(c);
+      return c;
+    },
+    stderr: captureStream([]),
+    setRestartTimer: (fn) => {
+      fn();
+      return 0;
+    },
+    now: () => 0,
+    failureWindowMs: 1000,
+  });
+  helper.onStatusChange((s) => statuses.push(s));
+  return { helper, children, statuses, latest: () => children[children.length - 1] };
+}
+
+test("#254: three fast exits in a row report the helper as failed", async () => {
+  const { helper, latest, statuses } = crashLoopHelper();
+  helper.start();
+  assert.equal(helper.status(), "starting");
+
+  for (let i = 0; i < 2; i += 1) {
+    latest().emit("exit", 1);
+    await nextTurn();
+    assert.equal(helper.status(), "starting");
+  }
+  latest().emit("exit", 1);
+  await nextTurn();
+
+  assert.equal(helper.status(), "failed");
+  assert.deepEqual(statuses, ["failed"]);
+  helper.stop();
+});
+
+test("#254: a ready event ends the crash loop", async () => {
+  const { helper, latest } = crashLoopHelper();
+  helper.start();
+  for (let i = 0; i < 3; i += 1) {
+    latest().emit("exit", 1);
+    await nextTurn();
+  }
+  assert.equal(helper.status(), "failed");
+
+  latest().stdout.write('{"event":"ready"}\n');
+  await nextTurn();
+  assert.equal(helper.status(), "running");
+  helper.stop();
+});
+
+test("#254: restart() clears a failed state", async () => {
+  const { helper, latest } = crashLoopHelper();
+  helper.start();
+  for (let i = 0; i < 3; i += 1) {
+    latest().emit("exit", 1);
+    await nextTurn();
+  }
+  assert.equal(helper.status(), "failed");
+
+  helper.restart();
+  assert.equal(helper.status(), "starting");
+  helper.stop();
+});

--- a/src/openstreamBridge.d.ts
+++ b/src/openstreamBridge.d.ts
@@ -14,7 +14,9 @@ export type SetShortcutResult =
   | { ok: true; settings: StoredSettings }
   | { ok: false; kind: "unsupported" | "unavailable" | "internal-failure"; message: string };
 
-export type ModelHealth = "ready" | "starting";
+export type ModelHealth = "ready" | "starting" | "failed";
+
+export type ModelRole = "transcription" | "rewrite";
 
 // #47. accessibility: granted | missing. inputMonitoring: granted | missing
 // | unknown (IOHIDCheckAccess couldn't tell). microphone: granted | missing
@@ -65,6 +67,7 @@ declare global {
         openPrivacySettings(key: PermissionKey): Promise<void>;
         getSetupProgress(): Promise<SetupProgress | null>;
         retryModelDownload(): Promise<void>;
+        restartModel(role: ModelRole): Promise<{ ok: boolean }>;
       };
       settings: {
         get(): Promise<StoredSettings>;
@@ -89,6 +92,7 @@ declare global {
       onNavigate(callback: (page: string) => void): () => void;
       onDictationState(callback: (state: "idle" | "recording" | "transcribing") => void): () => void;
       onSetupProgress(callback: (progress: SetupProgress) => void): () => void;
+      onHealthChanged(callback: () => void): () => void;
     };
   }
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -47,9 +47,14 @@ function grantPill(state: GrantState): { tone: PillTone; label: string } {
 }
 
 function modelPill(state: ModelHealth): { tone: PillTone; label: string } {
-  return state === "ready"
-    ? { tone: "ok", label: "Ready" }
-    : { tone: "wait", label: "Starting…" };
+  switch (state) {
+    case "ready":
+      return { tone: "ok", label: "Ready" };
+    case "failed":
+      return { tone: "err", label: "Not running" };
+    default:
+      return { tone: "wait", label: "Starting…" };
+  }
 }
 
 type Activity = "idle" | "recording" | "transcribing";
@@ -75,45 +80,63 @@ export default function Home({ navigate }: { navigate: (page: Page) => void }) {
     };
     poll();
     const timer = setInterval(poll, HEALTH_POLL_MS);
+    // #254: main pushes this on a crash loop / recovery so the panel doesn't
+    // wait out the poll interval to show it.
+    const unsubscribe = window.openstream.onHealthChanged(poll);
     return () => {
       active = false;
       clearInterval(timer);
+      unsubscribe();
     };
   }, []);
 
-  const rows: { icon: JSX.Element; label: string; sub?: string; pill: { tone: PillTone; label: string } }[] =
-    health
-      ? [
-          {
-            icon: <ShieldIcon className="row-icon" />,
-            label: "Accessibility",
-            pill: grantPill(health.permissions.accessibility),
-          },
-          {
-            icon: <InputMonitorIcon className="row-icon" />,
-            label: "Input Monitoring",
-            pill: grantPill(health.permissions.inputMonitoring),
-          },
-          {
-            icon: <MicIcon className="row-icon" />,
-            label: "Microphone",
-            pill: grantPill(health.permissions.microphone),
-          },
-          {
-            icon: <WaveformIcon className="row-icon" />,
-            label: "Transcription model",
-            sub: "Local · whisper.cpp",
-            pill: modelPill(health.transcriptionModel),
-          },
-          {
-            icon: <WaveformIcon className="row-icon" />,
-            label: "Rewrite model",
-            sub: "Local · paragraph breaks",
-            pill: modelPill(health.rewriteModel),
-          },
-        ]
-      : [];
+  const restartModel = (role: "transcription" | "rewrite") => {
+    window.openstream.app.restartModel(role).then(() => window.openstream.app.getHealth().then(setHealth));
+  };
 
+  type Row = {
+    icon: JSX.Element;
+    label: string;
+    sub?: string;
+    pill: { tone: PillTone; label: string };
+    restart?: "transcription" | "rewrite";
+  };
+  const rows: Row[] = health
+    ? [
+        {
+          icon: <ShieldIcon className="row-icon" />,
+          label: "Accessibility",
+          pill: grantPill(health.permissions.accessibility),
+        },
+        {
+          icon: <InputMonitorIcon className="row-icon" />,
+          label: "Input Monitoring",
+          pill: grantPill(health.permissions.inputMonitoring),
+        },
+        {
+          icon: <MicIcon className="row-icon" />,
+          label: "Microphone",
+          pill: grantPill(health.permissions.microphone),
+        },
+        {
+          icon: <WaveformIcon className="row-icon" />,
+          label: "Transcription model",
+          sub: "Local · Parakeet on the Neural Engine",
+          pill: modelPill(health.transcriptionModel),
+          restart: health.transcriptionModel === "failed" ? "transcription" : undefined,
+        },
+        {
+          icon: <WaveformIcon className="row-icon" />,
+          label: "Rewrite model",
+          sub: "Local · paragraph breaks",
+          pill: modelPill(health.rewriteModel),
+          restart: health.rewriteModel === "failed" ? "rewrite" : undefined,
+        },
+      ]
+    : [];
+
+  const modelFailed =
+    health && (health.transcriptionModel === "failed" || health.rewriteModel === "failed");
   const permissionsNeedAttention =
     health && (health.permissions.accessibility !== "granted" || health.permissions.inputMonitoring === "missing");
   const ready =
@@ -185,6 +208,13 @@ export default function Home({ navigate }: { navigate: (page: Page) => void }) {
               Fix
             </button>
           </div>
+        ) : modelFailed ? (
+          <div className="row">
+            <span className="row-label" style={{ color: "var(--err)" }}>
+              A model server keeps stopping — dictation won{"’"}t work until it{"’"}s back.
+            </span>
+            <StatusPill tone="err" label="Not running" />
+          </div>
         ) : ready ? (
           <button
             type="button"
@@ -215,6 +245,16 @@ export default function Home({ navigate }: { navigate: (page: Page) => void }) {
                 {row.sub && <small>{row.sub}</small>}
               </span>
               <StatusPill tone={row.pill.tone} label={row.pill.label} />
+              {row.restart && (
+                <button
+                  type="button"
+                  className="btn"
+                  style={{ marginLeft: 10 }}
+                  onClick={() => restartModel(row.restart!)}
+                >
+                  Restart
+                </button>
+              )}
             </div>
           ))}
       </div>


### PR DESCRIPTION
Closes #254. A dictation tool that silently does nothing is indistinguishable from a broken hotkey — this makes a dead or crash-looping model server visible and recoverable.

## Crash-loop detection

Both supervisors — the generic `modelSupervisor` (rewrite server) and the bespoke loop in `transcriptionHelper` — now track consecutive fast failures. Three in a row, each within 12s of the last, means the server is crash-looping rather than hitting a blip:

- it **keeps retrying** (a local binary can recover from a transient cause)
- but `status()` reports `"failed"`, and an `onStatusChange` listener fires once on the transition
- a sustained healthy run (outlasting the window) or, for the transcription helper, a clean `{"event":"ready"}` clears it
- `restart()` clears the count and re-spawns immediately

## What the user sees

- **Home "System" panel**: a failed server shows red ("Not running") with a **Restart** button. `app:restart-model` wires it through. The panel also gets a top-line error when any model is down, matching the missing-permission treatment.
- **Tray tooltip**: gains " (model not running)" so it's visible with the window closed. The window opens itself to Home on the failure, same as a missing permission.
- **`health-changed`** push from main so the panel reacts immediately instead of waiting out its 4s poll.
- **`app:get-health`**: `transcriptionModel` / `rewriteModel` can now be `"failed"`, not just `"ready"` / `"starting"`.
- **A failed transcription** shows a brief overlay message ("Couldn't transcribe that") instead of dropping to idle in silence.
- Fixed the stale **"Local · whisper.cpp"** line on the panel → "Local · Parakeet on the Neural Engine".

## Tests

`modelSupervisor.test.js` + `transcriptionHelper.test.js`: 3-fast-failures → failed, healthy run / ready resets, `restart()` clears. Injected clock, no real timers. Full suite (310) + typecheck + renderer build green.

## Not in this PR

Exponential backoff on the retry loop (it still retries at the constant 1s), and idle model unload (#257). The retry stays cheap for a local process and the visible "failed" state plus a manual restart covers the actual complaint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
