### PR TITLE
Idle model unload to cut resident RAM (#257)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -59,7 +59,7 @@ A model server that is already loaded and waiting, so a request pays inference c
 _Avoid_: Warm, preloaded, cached
 
 **Idle release**:
-Shutting a model server down after a period without requests, so it holds no memory between bursts of use.
+Shutting a model server down after a configurable period without a dictation, so it holds no memory between bursts of use (#257). The next dictation reloads it and pays the one-time warm-up. Off by default - the resident design (ADR-0002) is the norm; this is opt-in for machines that mind the ~1 GB.
 _Avoid_: Eviction, unloading, timeout kill
 
 ### Cleanup

--- a/electron/idleUnloader.js
+++ b/electron/idleUnloader.js
@@ -1,0 +1,67 @@
+// #257: the model servers sit resident for the app's life - ~1 GB of RAM
+// even when nobody has dictated for hours. This is the deliberate trade for
+// zero per-dictation load cost (ADR-0002), but a long idle period doesn't
+// need it. After `idleMs` without a dictation, `onUnload` is called; the
+// next dictation calls `onReload` and pays the one-time warm-up.
+//
+// Pure and timer-injectable so it can be tested without real time. main.js
+// owns the wiring: noteActivity() on key-down and on a finished dictation,
+// setIdleMs() when the setting changes, stop() at quit.
+function createIdleUnloader({
+  idleMs = 0,
+  onUnload,
+  onReload,
+  setTimer = setTimeout,
+  clearTimer = clearTimeout,
+}) {
+  if (typeof onUnload !== "function" || typeof onReload !== "function") {
+    throw new Error("createIdleUnloader needs onUnload and onReload callbacks");
+  }
+
+  let currentIdleMs = idleMs;
+  let timer = null;
+  let unloaded = false;
+
+  function disarm() {
+    if (timer !== null) {
+      clearTimer(timer);
+      timer = null;
+    }
+  }
+
+  function arm() {
+    disarm();
+    // 0 (or anything not positive) means the feature is off - stay resident.
+    if (!(currentIdleMs > 0) || unloaded) return;
+    timer = setTimer(() => {
+      timer = null;
+      unloaded = true;
+      onUnload();
+    }, currentIdleMs);
+  }
+
+  return {
+    // A dictation is starting or has just finished. Reload first if we had
+    // parked the servers, then restart the idle countdown.
+    noteActivity() {
+      if (unloaded) {
+        unloaded = false;
+        onReload();
+      }
+      arm();
+    },
+    // The idle-timeout setting changed (minutes, or 0 for off).
+    setIdleMs(ms) {
+      currentIdleMs = ms;
+      arm();
+    },
+    isUnloaded() {
+      return unloaded;
+    },
+    stop() {
+      disarm();
+    },
+  };
+}
+
+module.exports = { createIdleUnloader };

--- a/electron/idleUnloader.test.js
+++ b/electron/idleUnloader.test.js
@@ -1,0 +1,115 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { createIdleUnloader } = require("./idleUnloader");
+
+// A fake timer: one pending callback, fired by hand.
+function fakeTimers() {
+  let pending = null;
+  let nextHandle = 1;
+  return {
+    set: (fn) => {
+      pending = fn;
+      return nextHandle++;
+    },
+    clear: () => {
+      pending = null;
+    },
+    fire: () => {
+      const fn = pending;
+      pending = null;
+      if (fn) fn();
+    },
+    get armed() {
+      return pending !== null;
+    },
+  };
+}
+
+function make(overrides = {}) {
+  const events = [];
+  const timers = fakeTimers();
+  const unloader = createIdleUnloader({
+    idleMs: overrides.idleMs ?? 1000,
+    onUnload: () => events.push("unload"),
+    onReload: () => events.push("reload"),
+    setTimer: timers.set,
+    clearTimer: timers.clear,
+  });
+  return { unloader, timers, events };
+}
+
+test("does not arm until the first activity", () => {
+  const { timers } = make();
+  assert.equal(timers.armed, false);
+});
+
+test("arms on activity and unloads when the timer fires", () => {
+  const { unloader, timers, events } = make();
+  unloader.noteActivity();
+  assert.equal(timers.armed, true);
+  timers.fire();
+  assert.deepEqual(events, ["unload"]);
+  assert.equal(unloader.isUnloaded(), true);
+});
+
+test("the next activity reloads and re-arms", () => {
+  const { unloader, timers, events } = make();
+  unloader.noteActivity();
+  timers.fire(); // unload
+  unloader.noteActivity();
+  assert.deepEqual(events, ["unload", "reload"]);
+  assert.equal(unloader.isUnloaded(), false);
+  assert.equal(timers.armed, true);
+});
+
+test("activity while still loaded just restarts the countdown, no reload", () => {
+  const { unloader, events } = make();
+  unloader.noteActivity();
+  unloader.noteActivity();
+  unloader.noteActivity();
+  assert.deepEqual(events, []);
+});
+
+test("zero minutes means never unload", () => {
+  const { unloader, timers, events } = make({ idleMs: 0 });
+  unloader.noteActivity();
+  assert.equal(timers.armed, false);
+  assert.deepEqual(events, []);
+});
+
+test("setIdleMs(0) disarms a pending countdown", () => {
+  const { unloader, timers } = make();
+  unloader.noteActivity();
+  assert.equal(timers.armed, true);
+  unloader.setIdleMs(0);
+  assert.equal(timers.armed, false);
+});
+
+test("setIdleMs to a positive value arms straight away when loaded", () => {
+  const { unloader, timers } = make({ idleMs: 0 });
+  unloader.noteActivity();
+  assert.equal(timers.armed, false);
+  unloader.setIdleMs(500);
+  assert.equal(timers.armed, true);
+});
+
+test("setIdleMs does not resurrect the countdown while unloaded - the next activity does", () => {
+  const { unloader, timers } = make();
+  unloader.noteActivity();
+  timers.fire(); // unloaded
+  unloader.setIdleMs(2000);
+  assert.equal(timers.armed, false);
+  unloader.noteActivity();
+  assert.equal(timers.armed, true);
+});
+
+test("stop() clears any pending countdown", () => {
+  const { unloader, timers } = make();
+  unloader.noteActivity();
+  unloader.stop();
+  assert.equal(timers.armed, false);
+});
+
+test("needs both callbacks", () => {
+  assert.throws(() => createIdleUnloader({ onUnload: () => {} }), /onUnload and onReload/);
+});

--- a/electron/main.js
+++ b/electron/main.js
@@ -24,6 +24,7 @@ const { ensureModels, modelsMissing } = require("./modelStore");
 const hotkeyHelper = require("./hotkeyHelper");
 const accessibilityHelper = require("./accessibilityHelper");
 const { createSettingsStore } = require("./settingsStore");
+const { createIdleUnloader } = require("./idleUnloader");
 const { setBreakSafeApplications, DEFAULT_BREAK_SAFE_BUNDLE_IDS } = require("./breakSafety");
 const { createBundleIdReader } = require("./appBundleId");
 const { createBreakPlacementHttpAdapter } = require("./breakPlacementHttpAdapter");
@@ -145,6 +146,8 @@ let captureReady = false;
 let modelsReady = false;
 let retryModelDownload = () => {};
 let settingsStore = null;
+// #257: set up once the settings store exists (in the startup block).
+let idleUnloader = null;
 let pushToTalkShortcut = null;
 let shortcutCaptureSender = null;
 // Chromium does not reliably deliver a standalone Fn keydown. A one-shot
@@ -476,6 +479,9 @@ const heldResultController = createHeldResultController({
 // failed read just means "ordinary dictation" and must never delay
 // recording, so this is deliberately not awaited here.
 function beginPushToTalk() {
+  // #257: a key-down means the user is back. Reload the servers first if
+  // they were parked, then restart the idle countdown.
+  if (idleUnloader) idleUnloader.noteActivity();
   pendingSelectionRead = accessibilityHelper.getSelection().catch(() => null);
   // #355: same treatment as the selection read - async, never delays
   // recording, and just gives dictation a "before" snapshot to compare
@@ -496,11 +502,17 @@ async function handleCompletedRecording(wavBuffer, timing) {
   pendingFrontmostAtRecordStart = null;
   const recordStartBundleId = frontmostRead ? await frontmostRead : null;
 
-  if (selection && selection.text.length > 0 && selection.text.length <= VOICE_EDIT_MAX_CHARS) {
-    showVoiceEditWorking();
-    return applyVoiceEdit(wavBuffer, selection, timing);
+  try {
+    if (selection && selection.text.length > 0 && selection.text.length <= VOICE_EDIT_MAX_CHARS) {
+      showVoiceEditWorking();
+      return await applyVoiceEdit(wavBuffer, selection, timing);
+    }
+    return await transcribeAndPrint(wavBuffer, timing, recordStartBundleId);
+  } finally {
+    // #257: dictation is done - restart the idle countdown from now, not
+    // from when the key went down.
+    if (idleUnloader) idleUnloader.noteActivity();
   }
-  return transcribeAndPrint(wavBuffer, timing, recordStartBundleId);
 }
 
 function showVoiceEditWorking() {
@@ -897,10 +909,13 @@ ipcMain.handle("app:get-health", async () => {
     probeHttp(rewriteModelServer.healthUrl()),
     checkPermissions(),
   ]);
+  // #257: parked servers aren't "starting" - they won't start until the
+  // next dictation, and saying so avoids a panel stuck on "Starting…".
+  const asleep = Boolean(idleUnloader && idleUnloader.isUnloaded());
   return {
     permissions: permissions.grants,
-    transcriptionModel: modelHealth(transcription, transcriptionHelper.status()),
-    rewriteModel: modelHealth(rewrite, rewriteModelServer.status()),
+    transcriptionModel: asleep ? "asleep" : modelHealth(transcription, transcriptionHelper.status()),
+    rewriteModel: asleep ? "asleep" : modelHealth(rewrite, rewriteModelServer.status()),
   };
 });
 
@@ -968,6 +983,13 @@ ipcMain.handle("settings:reset-break-safe-apps", () => {
 ipcMain.handle("settings:set-copy-transcript", (event, enabled) => {
   // #255: validated in the store, same as the other setters.
   return settingsStore.setCopyTranscriptToClipboard(enabled);
+});
+
+ipcMain.handle("settings:set-idle-unload-minutes", (event, minutes) => {
+  // #257: the store validates; the unloader re-arms with the new timeout.
+  const settings = settingsStore.setIdleUnloadMinutes(minutes);
+  if (idleUnloader) idleUnloader.setIdleMs(settings.idleUnloadMinutes * 60_000);
+  return settings;
 });
 
 // #19: pick an app from disk instead of hunting down its bundle id by
@@ -1090,6 +1112,22 @@ app.whenReady().then(() => {
     rewriteModelServer.onStatusChange((status) => reflectModelStatus("rewrite", status));
   };
 
+  // #257: park the model servers after a long idle, reload on the next
+  // dictation. Off unless the user sets a timeout in Settings.
+  idleUnloader = createIdleUnloader({
+    idleMs: settingsStore.get().idleUnloadMinutes * 60_000,
+    onUnload: () => {
+      console.log("[models] idle - unloading the model servers to free memory");
+      transcriptionHelper.stop();
+      rewriteModelServer.stop();
+    },
+    onReload: () => {
+      console.log("[models] reloading the model servers after idle");
+      transcriptionHelper.start();
+      rewriteModelServer.start();
+    },
+  });
+
   // #249: a packaged app ships without the model weights and fetches them
   // on first run. Gate the servers - and the hotkey - on the weights being
   // in place, and show the download on a Setup screen.
@@ -1123,6 +1161,7 @@ app.on("will-quit", () => {
   fnShortcutCapture.stop();
   shortcutCaptureSender = null;
   pushToTalkShortcut?.stop();
+  idleUnloader?.stop();
   accessibilityHelper.stop();
   transcriptionHelper.stop();
   rewriteModelServer.stop();

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -63,6 +63,7 @@ contextBridge.exposeInMainWorld("openstream", {
     setVocabularyProjectPath: (projectPath) => ipcRenderer.invoke("settings:set-vocabulary-path", projectPath),
     setTermCorrections: (entries) => ipcRenderer.invoke("settings:set-term-corrections", entries),
     setCopyTranscript: (enabled) => ipcRenderer.invoke("settings:set-copy-transcript", enabled),
+    setIdleUnloadMinutes: (minutes) => ipcRenderer.invoke("settings:set-idle-unload-minutes", minutes),
   },
   vocabulary: {
     rescan: () => ipcRenderer.invoke("vocabulary:rescan"),

--- a/electron/settingsStore.js
+++ b/electron/settingsStore.js
@@ -23,7 +23,21 @@ const DEFAULT_SETTINGS = {
   // that doesn't land is never a lost dictation. Off by default - it
   // clobbers whatever the user had copied.
   copyTranscriptToClipboard: false,
+  // #257: unload the model servers after this many minutes idle, reloading
+  // (with a one-time warm-up) on the next dictation. 0 = off, stay resident.
+  idleUnloadMinutes: 0,
 };
+
+// #257: a whole number of minutes, 0 (off) to a day. A day is already well
+// past "why is my first dictation slow" territory - the cap is just a guard
+// against a nonsense value from a hand-edited file.
+const MAX_IDLE_UNLOAD_MINUTES = 1440;
+
+function validateIdleUnloadMinutes(minutes) {
+  if (typeof minutes !== "number" || !Number.isInteger(minutes) || minutes < 0 || minutes > MAX_IDLE_UNLOAD_MINUTES) {
+    throw new Error(`idleUnloadMinutes must be a whole number of minutes between 0 and ${MAX_IDLE_UNLOAD_MINUTES}`);
+  }
+}
 
 const VALID_MODIFIERS = new Set(["cmd", "shift", "alt", "ctrl"]);
 
@@ -220,6 +234,11 @@ function createSettingsStore({ filePath }) {
     return commit({ ...load(), copyTranscriptToClipboard: enabled });
   }
 
+  function setIdleUnloadMinutes(minutes) {
+    validateIdleUnloadMinutes(minutes);
+    return commit({ ...load(), idleUnloadMinutes: minutes });
+  }
+
   function setWindowBounds(bounds) {
     validateWindowBounds(bounds);
     // Only the four geometry keys are kept - a caller passing a whole
@@ -249,6 +268,7 @@ function createSettingsStore({ filePath }) {
     setVocabularyProjectPath,
     setTermCorrections,
     setCopyTranscriptToClipboard,
+    setIdleUnloadMinutes,
     setWindowBounds,
     onChange,
   };
@@ -263,4 +283,6 @@ module.exports = {
   validateTermCorrections,
   MAX_TERM_CORRECTIONS,
   MAX_TERM_CORRECTION_LENGTH,
+  validateIdleUnloadMinutes,
+  MAX_IDLE_UNLOAD_MINUTES,
 };

--- a/electron/settingsStore.test.js
+++ b/electron/settingsStore.test.js
@@ -219,6 +219,26 @@ test("#255: setCopyTranscriptToClipboard rejects a non-boolean", () => {
   assert.throws(() => store.setCopyTranscriptToClipboard("yes"), /must be a boolean/);
 });
 
+test("#257: idleUnloadMinutes defaults to 0 (off)", () => {
+  const store = createSettingsStore({ filePath: tempFilePath() });
+  assert.equal(store.get().idleUnloadMinutes, 0);
+});
+
+test("#257: setIdleUnloadMinutes persists and reflects afterwards", () => {
+  const filePath = tempFilePath();
+  const store = createSettingsStore({ filePath });
+  store.setIdleUnloadMinutes(10);
+  assert.equal(store.get().idleUnloadMinutes, 10);
+  assert.equal(JSON.parse(fs.readFileSync(filePath, "utf8")).idleUnloadMinutes, 10);
+});
+
+test("#257: setIdleUnloadMinutes rejects non-integers, negatives, and absurd values", () => {
+  const store = createSettingsStore({ filePath: tempFilePath() });
+  for (const bad of [5.5, -1, "10", 10000, NaN]) {
+    assert.throws(() => store.setIdleUnloadMinutes(bad), /idleUnloadMinutes/);
+  }
+});
+
 test("setVocabularyProjectPath persists a trimmed path and get() reflects it afterwards", () => {
   const filePath = tempFilePath();
   const store = createSettingsStore({ filePath });

--- a/src/index.css
+++ b/src/index.css
@@ -340,6 +340,21 @@ button { font: inherit; }
   box-shadow: 0 0 0 1px var(--acc);
 }
 
+/* A native <select> given .field: drop the platform chrome and draw our own
+   chevron so it reads on the dark panel like the other controls. */
+select.field {
+  flex: 0 1 auto;
+  -webkit-appearance: none;
+  appearance: none;
+  padding-right: 30px;
+  background-image: linear-gradient(45deg, transparent 50%, var(--muted) 50%),
+    linear-gradient(135deg, var(--muted) 50%, transparent 50%);
+  background-position: calc(100% - 15px) center, calc(100% - 11px) center;
+  background-size: 4px 4px, 4px 4px;
+  background-repeat: no-repeat;
+}
+select.field option { color: initial; }
+
 .select {
   display: inline-flex;
   align-items: center;

--- a/src/openstreamBridge.d.ts
+++ b/src/openstreamBridge.d.ts
@@ -8,13 +8,14 @@ export type StoredSettings = {
   vocabularyProjectPath: string | null;
   termCorrections: TermCorrection[];
   copyTranscriptToClipboard: boolean;
+  idleUnloadMinutes: number;
 };
 
 export type SetShortcutResult =
   | { ok: true; settings: StoredSettings }
   | { ok: false; kind: "unsupported" | "unavailable" | "internal-failure"; message: string };
 
-export type ModelHealth = "ready" | "starting" | "failed";
+export type ModelHealth = "ready" | "starting" | "failed" | "asleep";
 
 export type ModelRole = "transcription" | "rewrite";
 
@@ -83,6 +84,7 @@ declare global {
         ): Promise<{ settings: StoredSettings; status: VocabularyStatus }>;
         setTermCorrections(entries: TermCorrection[]): Promise<StoredSettings>;
         setCopyTranscript(enabled: boolean): Promise<StoredSettings>;
+        setIdleUnloadMinutes(minutes: number): Promise<StoredSettings>;
       };
       vocabulary: {
         rescan(): Promise<VocabularyStatus>;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -52,6 +52,8 @@ function modelPill(state: ModelHealth): { tone: PillTone; label: string } {
       return { tone: "ok", label: "Ready" };
     case "failed":
       return { tone: "err", label: "Not running" };
+    case "asleep":
+      return { tone: "muted", label: "Asleep" };
     default:
       return { tone: "wait", label: "Starting…" };
   }
@@ -137,6 +139,8 @@ export default function Home({ navigate }: { navigate: (page: Page) => void }) {
 
   const modelFailed =
     health && (health.transcriptionModel === "failed" || health.rewriteModel === "failed");
+  const modelsAsleep =
+    health && health.transcriptionModel === "asleep" && health.rewriteModel === "asleep";
   const permissionsNeedAttention =
     health && (health.permissions.accessibility !== "granted" || health.permissions.inputMonitoring === "missing");
   const ready =
@@ -214,6 +218,13 @@ export default function Home({ navigate }: { navigate: (page: Page) => void }) {
               A model server keeps stopping — dictation won{"’"}t work until it{"’"}s back.
             </span>
             <StatusPill tone="err" label="Not running" />
+          </div>
+        ) : modelsAsleep ? (
+          <div className="row">
+            <span className="row-label">
+              Models asleep to save memory<small>The next dictation wakes them, after a short pause.</small>
+            </span>
+            <StatusPill tone="muted" label="Asleep" />
           </div>
         ) : ready ? (
           <button

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -35,6 +35,59 @@ function CopyTranscriptSection() {
   );
 }
 
+const IDLE_UNLOAD_OPTIONS = [
+  { value: 0, label: "Never (stay loaded)" },
+  { value: 5, label: "After 5 minutes idle" },
+  { value: 10, label: "After 10 minutes idle" },
+  { value: 20, label: "After 20 minutes idle" },
+  { value: 30, label: "After 30 minutes idle" },
+  { value: 60, label: "After 1 hour idle" },
+];
+
+function IdleUnloadSection() {
+  const [minutes, setMinutes] = useState<number | null>(null);
+
+  useEffect(() => {
+    window.openstream.settings.get().then((settings) => setMinutes(settings.idleUnloadMinutes));
+  }, []);
+
+  // A saved custom value that isn't one of the presets still needs a row.
+  const options =
+    minutes !== null && !IDLE_UNLOAD_OPTIONS.some((o) => o.value === minutes)
+      ? [...IDLE_UNLOAD_OPTIONS, { value: minutes, label: `After ${minutes} minutes idle` }]
+      : IDLE_UNLOAD_OPTIONS;
+
+  return (
+    <div className="setting-item">
+      <h3 className="setting-item__name">Free memory when idle</h3>
+      <p className="setting-item__desc">
+        The speech models hold about a gigabyte of memory while they’re loaded. Unload them after a spell of not
+        dictating; the next dictation waits a few seconds for them to come back.
+      </p>
+      <div className="setting-item__control">
+        <select
+          className="field"
+          value={minutes ?? 0}
+          disabled={minutes === null}
+          onChange={(event) => {
+            const next = Number(event.target.value);
+            setMinutes(next);
+            window.openstream.settings
+              .setIdleUnloadMinutes(next)
+              .then((settings) => setMinutes(settings.idleUnloadMinutes));
+          }}
+        >
+          {options.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
+  );
+}
+
 function StartupSection() {
   const [openAtLogin, setOpenAtLogin] = useState<boolean | null>(null);
 
@@ -89,6 +142,8 @@ export default function Settings() {
         </div>
 
         <CopyTranscriptSection />
+
+        <IdleUnloadSection />
 
         <StartupSection />
       </div>


### PR DESCRIPTION
Closes #257. The transcription helper and the rewrite server together hold ~1 GB resident for the app's life. Resident-by-default is the deliberate trade for zero per-dictation load cost (ADR-0002); this makes it opt-out for a long idle.

## How it works

- **`electron/idleUnloader.js`** — a small, timer-injectable helper. `noteActivity()` (called on key-down and again when a dictation finishes) restarts the countdown. When the timer fires, `onUnload` stops both servers. The next `noteActivity()` calls `onReload` to start them again, then re-arms.
- **`settingsStore`** — `idleUnloadMinutes`, validated (whole minutes, 0–1440). `0` = off, the default.
- **`main.js`** — wires `onUnload` → `transcriptionHelper.stop()` + `rewriteModelServer.stop()`, `onReload` → `.start()` on both. `beginPushToTalk` notes activity first, so a key-down reloads a parked server before the recording even starts; the first transcription then waits out the ~15–20s Parakeet warm-up, comfortably inside the existing 30s request ceiling.
- **Settings** — a "Free memory when idle" dropdown: Never / 5 / 10 / 20 / 30 min / 1 hour.
- **Home System panel** — a parked server shows as **"Asleep"** (muted), not a misleading permanent "Starting…". `app:get-health` gains the `"asleep"` state; the panel summary explains the next dictation wakes them.

`stop()` is the clean path (`stopping = true`), so #254's crash-loop detection doesn't count an idle unload as a failure.

## Design calls

1. **One timeout for both servers.** The issue notes the rewrite model is a stronger candidate to unload aggressively — but two timers/settings is more surface than it's worth. One control, both servers.
2. **Off by default.** A surprise 20s first-dictation-after-lunch should be something you opt into.
3. **No exponential retry / backoff changes** — out of scope, that's the supervisor's own concern.

## Tests

`idleUnloader.test.js` (10: arm/fire/reload/re-arm, off at 0, `setIdleMs` re-arm and disarm, no resurrection while unloaded, `stop()`), `settingsStore.test.js` (3: default, persist, validation). Full suite (323) + typecheck + build green. The `main.js` wiring itself has no unit test, consistent with the rest of that file — covered by the manual dictation pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
