### PR TITLE
Pause music while recording (#265)

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -25,6 +25,7 @@ const hotkeyHelper = require("./hotkeyHelper");
 const accessibilityHelper = require("./accessibilityHelper");
 const { createSettingsStore } = require("./settingsStore");
 const { createIdleUnloader } = require("./idleUnloader");
+const { createMediaPause } = require("./mediaPause");
 const { setBreakSafeApplications, DEFAULT_BREAK_SAFE_BUNDLE_IDS } = require("./breakSafety");
 const { createBundleIdReader } = require("./appBundleId");
 const { createBreakPlacementHttpAdapter } = require("./breakPlacementHttpAdapter");
@@ -177,6 +178,10 @@ const vocabulary = createVocabularyCache();
 function recordDictationDiagnostic(name, value) {
   console.log(`[dictation] ${name}: ${JSON.stringify(value)}`);
 }
+
+// #265: pause Music / Spotify for the duration of a recording. Gated on the
+// setting at each call site; a no-op when the setting is off.
+const mediaPause = createMediaPause({ onDiagnostic: recordDictationDiagnostic });
 
 const dictationIntake = createDictationIntake({
   transcription,
@@ -664,15 +669,23 @@ const pushToTalkCoordinator = createPushToTalkCoordinator({
     if (!captureWin) return;
     captureWin.webContents.send("start-recording");
     armCancelShortcut();
+    // #265: fire-and-forget - the osascript round-trip must not delay the
+    // recording, and a slow pause just means the first fraction of a second
+    // still has music in it.
+    if (settingsStore && settingsStore.get().pauseMediaWhileRecording) {
+      void mediaPause.pauseForRecording();
+    }
     console.log("[dictation] recording - release the hotkey to stop, Escape to cancel");
   },
   stopCapture(timing) {
     disarmCancelShortcut();
+    void mediaPause.resumeAfterRecording();
     if (!captureWin) return;
     captureWin.webContents.send("stop-recording", timing);
   },
   cancelCapture() {
     disarmCancelShortcut();
+    void mediaPause.resumeAfterRecording();
     if (captureWin) captureWin.webContents.send("cancel-recording");
     console.log("[dictation] cancelled");
   },

--- a/electron/main.js
+++ b/electron/main.js
@@ -1005,6 +1005,11 @@ ipcMain.handle("settings:set-idle-unload-minutes", (event, minutes) => {
   return settings;
 });
 
+ipcMain.handle("settings:set-pause-media", (event, enabled) => {
+  // #265: validated in the store, same as the other toggles.
+  return settingsStore.setPauseMediaWhileRecording(enabled);
+});
+
 // #19: pick an app from disk instead of hunting down its bundle id by
 // hand. Returns { bundleId, name } for the renderer to add, or null if the
 // dialog was cancelled; a bundle with no readable identifier rejects.

--- a/electron/mediaPause.js
+++ b/electron/mediaPause.js
@@ -1,0 +1,89 @@
+const { execFile } = require("child_process");
+
+// #265: pause music while a recording is running so the mic doesn't pick it
+// up, then resume it afterwards. Covers Music and Spotify via AppleScript -
+// the common case. Browser video and other players are out for now (they'd
+// need per-app tab scripting or the private MediaRemote framework).
+//
+// Best-effort throughout: the first `pause` a target app gets triggers a
+// one-time macOS Automation prompt, and a denial (or no such app) just
+// means nothing happens. Never blocks or fails a recording.
+const CONTROLLABLE_APPS = ["Music", "Spotify"];
+
+// Pause each app only if it is running AND currently playing, and return the
+// names actually paused. `application "X" is running` is a lightweight check
+// that needs no Automation grant; the `tell` block does, once per app.
+const PAUSE_SCRIPT = `
+set pausedApps to {}
+${CONTROLLABLE_APPS.map(
+  (app) => `if application "${app}" is running then
+  tell application "${app}"
+    if player state is playing then
+      pause
+      set end of pausedApps to "${app}"
+    end if
+  end tell
+end if`,
+).join("\n")}
+return pausedApps`;
+
+function resumeScript(apps) {
+  return apps
+    .map((app) => `if application "${app}" is running then tell application "${app}" to play`)
+    .join("\n");
+}
+
+function parseAppList(stdout) {
+  return stdout
+    .split(",")
+    .map((name) => name.trim())
+    .filter((name) => CONTROLLABLE_APPS.includes(name));
+}
+
+function createMediaPause({ runAppleScript = defaultRunAppleScript, onDiagnostic = () => {} } = {}) {
+  // The apps this instance paused and still owes a resume to.
+  let pausedApps = [];
+  let busy = false;
+
+  async function pauseForRecording() {
+    if (busy || pausedApps.length > 0) return;
+    busy = true;
+    try {
+      pausedApps = parseAppList(await runAppleScript(PAUSE_SCRIPT));
+      if (pausedApps.length > 0) onDiagnostic("mediaPause.paused", pausedApps.join(","));
+    } catch (error) {
+      onDiagnostic("mediaPause.error", errorMessage(error));
+    } finally {
+      busy = false;
+    }
+  }
+
+  async function resumeAfterRecording() {
+    if (pausedApps.length === 0) return;
+    const toResume = pausedApps;
+    pausedApps = [];
+    try {
+      await runAppleScript(resumeScript(toResume));
+      onDiagnostic("mediaPause.resumed", toResume.join(","));
+    } catch (error) {
+      onDiagnostic("mediaPause.error", errorMessage(error));
+    }
+  }
+
+  return { pauseForRecording, resumeAfterRecording };
+}
+
+function defaultRunAppleScript(script) {
+  return new Promise((resolve, reject) => {
+    execFile("osascript", ["-e", script], { timeout: 4000 }, (error, stdout) => {
+      if (error) reject(error);
+      else resolve(stdout || "");
+    });
+  });
+}
+
+function errorMessage(error) {
+  return error instanceof Error && error.message ? error.message : String(error);
+}
+
+module.exports = { createMediaPause, CONTROLLABLE_APPS };

--- a/electron/mediaPause.test.js
+++ b/electron/mediaPause.test.js
@@ -1,0 +1,77 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { createMediaPause } = require("./mediaPause");
+
+function fake(overrides = {}) {
+  const calls = [];
+  const diagnostics = [];
+  const mediaPause = createMediaPause({
+    runAppleScript: async (script) => {
+      calls.push(script);
+      if (typeof overrides.reply === "function") return overrides.reply(script, calls.length);
+      return overrides.reply ?? "";
+    },
+    onDiagnostic: (name, value) => diagnostics.push([name, value]),
+  });
+  return { mediaPause, calls, diagnostics };
+}
+
+test("pauses nothing when no controllable app is playing", async () => {
+  const { mediaPause, calls, diagnostics } = fake({ reply: "" });
+  await mediaPause.pauseForRecording();
+  assert.equal(calls.length, 1);
+  await mediaPause.resumeAfterRecording();
+  // No resume script runs when nothing was paused.
+  assert.equal(calls.length, 1);
+  assert.deepEqual(diagnostics, []);
+});
+
+test("pauses the playing apps and resumes exactly those", async () => {
+  const { mediaPause, calls, diagnostics } = fake({ reply: "Music, Spotify" });
+  await mediaPause.pauseForRecording();
+  await mediaPause.resumeAfterRecording();
+
+  assert.equal(calls.length, 2);
+  assert.match(calls[1], /application "Music" to play/);
+  assert.match(calls[1], /application "Spotify" to play/);
+  assert.deepEqual(diagnostics, [
+    ["mediaPause.paused", "Music,Spotify"],
+    ["mediaPause.resumed", "Music,Spotify"],
+  ]);
+});
+
+test("ignores unknown names in the AppleScript output", async () => {
+  const { mediaPause, calls } = fake({ reply: "Music, VLC, " });
+  await mediaPause.pauseForRecording();
+  await mediaPause.resumeAfterRecording();
+  assert.match(calls[1], /application "Music" to play/);
+  assert.doesNotMatch(calls[1], /VLC/);
+});
+
+test("a second pause while one is already held is a no-op", async () => {
+  const { mediaPause, calls } = fake({ reply: "Music" });
+  await mediaPause.pauseForRecording();
+  await mediaPause.pauseForRecording();
+  assert.equal(calls.length, 1);
+});
+
+test("an osascript failure is swallowed, not thrown", async () => {
+  const { mediaPause, diagnostics } = fake({
+    reply: () => {
+      throw new Error("osascript: not authorised");
+    },
+  });
+  await assert.doesNotReject(mediaPause.pauseForRecording());
+  assert.deepEqual(diagnostics, [["mediaPause.error", "osascript: not authorised"]]);
+});
+
+test("resume after a failed pause does nothing", async () => {
+  const { mediaPause, calls } = fake({
+    reply: () => {
+      throw new Error("nope");
+    },
+  });
+  await mediaPause.pauseForRecording();
+  await mediaPause.resumeAfterRecording();
+  assert.equal(calls.length, 1);
+});

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -64,6 +64,7 @@ contextBridge.exposeInMainWorld("openstream", {
     setTermCorrections: (entries) => ipcRenderer.invoke("settings:set-term-corrections", entries),
     setCopyTranscript: (enabled) => ipcRenderer.invoke("settings:set-copy-transcript", enabled),
     setIdleUnloadMinutes: (minutes) => ipcRenderer.invoke("settings:set-idle-unload-minutes", minutes),
+    setPauseMediaWhileRecording: (enabled) => ipcRenderer.invoke("settings:set-pause-media", enabled),
   },
   vocabulary: {
     rescan: () => ipcRenderer.invoke("vocabulary:rescan"),

--- a/electron/settingsStore.js
+++ b/electron/settingsStore.js
@@ -26,6 +26,9 @@ const DEFAULT_SETTINGS = {
   // #257: unload the model servers after this many minutes idle, reloading
   // (with a one-time warm-up) on the next dictation. 0 = off, stay resident.
   idleUnloadMinutes: 0,
+  // #265: pause Music / Spotify while recording so the mic doesn't pick them
+  // up. Off by default - the first use triggers a macOS Automation prompt.
+  pauseMediaWhileRecording: false,
 };
 
 // #257: a whole number of minutes, 0 (off) to a day. A day is already well
@@ -239,6 +242,13 @@ function createSettingsStore({ filePath }) {
     return commit({ ...load(), idleUnloadMinutes: minutes });
   }
 
+  function setPauseMediaWhileRecording(enabled) {
+    if (typeof enabled !== "boolean") {
+      throw new Error("pauseMediaWhileRecording must be a boolean");
+    }
+    return commit({ ...load(), pauseMediaWhileRecording: enabled });
+  }
+
   function setWindowBounds(bounds) {
     validateWindowBounds(bounds);
     // Only the four geometry keys are kept - a caller passing a whole
@@ -269,6 +279,7 @@ function createSettingsStore({ filePath }) {
     setTermCorrections,
     setCopyTranscriptToClipboard,
     setIdleUnloadMinutes,
+    setPauseMediaWhileRecording,
     setWindowBounds,
     onChange,
   };

--- a/electron/settingsStore.test.js
+++ b/electron/settingsStore.test.js
@@ -239,6 +239,16 @@ test("#257: setIdleUnloadMinutes rejects non-integers, negatives, and absurd val
   }
 });
 
+test("#265: pauseMediaWhileRecording defaults to false and round-trips", () => {
+  const filePath = tempFilePath();
+  const store = createSettingsStore({ filePath });
+  assert.equal(store.get().pauseMediaWhileRecording, false);
+  store.setPauseMediaWhileRecording(true);
+  assert.equal(store.get().pauseMediaWhileRecording, true);
+  assert.equal(JSON.parse(fs.readFileSync(filePath, "utf8")).pauseMediaWhileRecording, true);
+  assert.throws(() => store.setPauseMediaWhileRecording("on"), /must be a boolean/);
+});
+
 test("setVocabularyProjectPath persists a trimmed path and get() reflects it afterwards", () => {
   const filePath = tempFilePath();
   const store = createSettingsStore({ filePath });

--- a/src/openstreamBridge.d.ts
+++ b/src/openstreamBridge.d.ts
@@ -9,6 +9,7 @@ export type StoredSettings = {
   termCorrections: TermCorrection[];
   copyTranscriptToClipboard: boolean;
   idleUnloadMinutes: number;
+  pauseMediaWhileRecording: boolean;
 };
 
 export type SetShortcutResult =
@@ -85,6 +86,7 @@ declare global {
         setTermCorrections(entries: TermCorrection[]): Promise<StoredSettings>;
         setCopyTranscript(enabled: boolean): Promise<StoredSettings>;
         setIdleUnloadMinutes(minutes: number): Promise<StoredSettings>;
+        setPauseMediaWhileRecording(enabled: boolean): Promise<StoredSettings>;
       };
       vocabulary: {
         rescan(): Promise<VocabularyStatus>;

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -88,6 +88,37 @@ function IdleUnloadSection() {
   );
 }
 
+function PauseMediaSection() {
+  const [enabled, setEnabled] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    window.openstream.settings.get().then((settings) => setEnabled(settings.pauseMediaWhileRecording));
+  }, []);
+
+  return (
+    <div className="setting-item">
+      <h3 className="setting-item__name">Pause music while recording</h3>
+      <p className="setting-item__desc">
+        Pauses Music and Spotify when a recording starts and resumes them after, so the mic doesn’t pick them up.
+        The first time, macOS asks permission to control each app.
+      </p>
+      <div className="setting-item__control">
+        <Toggle
+          label="Pause Music and Spotify while recording"
+          checked={enabled ?? false}
+          disabled={enabled === null}
+          onChange={(next) => {
+            setEnabled(next);
+            window.openstream.settings
+              .setPauseMediaWhileRecording(next)
+              .then((settings) => setEnabled(settings.pauseMediaWhileRecording));
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
 function StartupSection() {
   const [openAtLogin, setOpenAtLogin] = useState<boolean | null>(null);
 
@@ -142,6 +173,8 @@ export default function Settings() {
         </div>
 
         <CopyTranscriptSection />
+
+        <PauseMediaSection />
 
         <IdleUnloadSection />
 


### PR DESCRIPTION
Closes #265. Pause music while a recording is running so the mic doesn't pick it up.

## What it does

- New **"Pause music while recording"** setting, off by default. When on: on `start-capture`, pause Music and Spotify if they're running and playing; on `stop`/`cancel`, resume exactly the ones we paused.
- `electron/mediaPause.js` runs the AppleScript. It remembers which apps it paused so resume never touches an app the user paused themselves, and it swallows every failure — a denied Automation prompt, a missing app, an osascript timeout — so it can't break a recording.
- Fire-and-forget at both ends: the osascript round-trip never delays the recording start or the transcription.

## Scope

Music and Spotify only. Browser video (YouTube etc.) and other players would need per-tab scripting or the private MediaRemote framework — out for now. Off by default because the first pause of each app triggers a one-time macOS Automation prompt.

## Commits

1. the `mediaPause` helper + tests
2. `pauseMediaWhileRecording` setting
3. wire into the recording lifecycle
4. renderer plumbing (preload + bridge + IPC)
5. Settings toggle

## Tests

`mediaPause.test.js` (6: nothing playing, pause+resume the right apps, ignore unknown names, double-pause no-op, swallow failures, no resume after a failed pause). `settingsStore.test.js` (default/round-trip/validation). Full suite (330) + typecheck + build green. The `main.js` wiring and the real AppleScript are manual-verify, like the rest of that layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
