### PR TITLE
Completion chime + configurable overlay position (#256)

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -533,7 +533,7 @@ function showVoiceEditWorking() {
   setTrayState("transcribing");
   notifyWindowState("editing");
   if (!overlayWin || overlayWin.isDestroyed()) return;
-  positionOverlayAtBottom();
+  positionOverlay();
   overlayWin.webContents.send("dictation-state", "editing");
   overlayWin.showInactive();
 }
@@ -760,12 +760,14 @@ function reflectModelStatus(role, status) {
 }
 
 // Positioned fresh on every show, not once at creation, so it follows
-// whichever display the user is actually on - #116, same spot macOS's own
-// dictation HUD uses: bottom-center, clear of the Dock.
-function positionOverlayAtBottom() {
+// whichever display the user is actually on - #116. Bottom-centre by
+// default (where macOS's own dictation HUD sits), or the edge / corner the
+// user picked in Settings (#256).
+function positionOverlay() {
   const display = screen.getDisplayNearestPoint(screen.getCursorScreenPoint());
   const [width, height] = overlayWin.getSize();
-  const { x, y } = computeBottomCenteredPosition(display.workArea, width, height);
+  const position = settingsStore ? settingsStore.get().overlayPosition : undefined;
+  const { x, y } = computeOverlayPosition(display.workArea, width, height, position);
   overlayWin.setPosition(x, y);
 }
 
@@ -796,7 +798,7 @@ function setUserVisibleState(state, details) {
 
   if (state === "recording") {
     heldResultController.dismiss();
-    positionOverlayAtBottom();
+    positionOverlay();
   }
   overlayWin.webContents.send("dictation-state", state);
   if (state === "recording") {

--- a/electron/main.js
+++ b/electron/main.js
@@ -17,7 +17,7 @@ const fs = require("fs");
 const http = require("http");
 const path = require("path");
 const { performance } = require("node:perf_hooks");
-const { computeBottomCenteredPosition } = require("./overlayPosition");
+const { computeOverlayPosition } = require("./overlayPosition");
 const transcriptionHelper = require("./transcriptionHelper");
 const rewriteModelServer = require("./rewriteModelServer");
 const { ensureModels, modelsMissing } = require("./modelStore");
@@ -26,6 +26,7 @@ const accessibilityHelper = require("./accessibilityHelper");
 const { createSettingsStore } = require("./settingsStore");
 const { createIdleUnloader } = require("./idleUnloader");
 const { createMediaPause } = require("./mediaPause");
+const { createSoundCues } = require("./soundCues");
 const { setBreakSafeApplications, DEFAULT_BREAK_SAFE_BUNDLE_IDS } = require("./breakSafety");
 const { createBundleIdReader } = require("./appBundleId");
 const { createBreakPlacementHttpAdapter } = require("./breakPlacementHttpAdapter");
@@ -174,6 +175,9 @@ const breakPlacement = createBreakPlacementHttpAdapter({
   chatCompletionsUrl: rewriteModelServer.chatCompletionsUrl,
 });
 const vocabulary = createVocabularyCache();
+// #256: short sounds at the edges of a dictation. Each call is gated on the
+// setting at its call site and is a no-op otherwise.
+const soundCues = createSoundCues();
 
 function recordDictationDiagnostic(name, value) {
   console.log(`[dictation] ${name}: ${JSON.stringify(value)}`);
@@ -182,6 +186,11 @@ function recordDictationDiagnostic(name, value) {
 // #265: pause Music / Spotify for the duration of a recording. Gated on the
 // setting at each call site; a no-op when the setting is off.
 const mediaPause = createMediaPause({ onDiagnostic: recordDictationDiagnostic });
+
+// #256: true when the user has turned sound cues on.
+function soundCuesEnabled() {
+  return Boolean(settingsStore && settingsStore.get().soundCues);
+}
 
 const dictationIntake = createDictationIntake({
   transcription,
@@ -555,6 +564,7 @@ async function applyVoiceEdit(wavBuffer, selection, timing) {
     if (Number.isFinite(timing?.releasedAtMs)) {
       console.log(`[voice-edit] release-to-insertion: ${(performance.now() - timing.releasedAtMs).toFixed(1)}ms`);
     }
+    if (soundCuesEnabled()) soundCues.textDelivered();
     setUserVisibleState("idle");
   } else if (result.status === "copied") {
     console.log(`[voice-edit] copied ${result.text.length} characters to the clipboard`);
@@ -565,6 +575,7 @@ async function applyVoiceEdit(wavBuffer, selection, timing) {
     showVoiceEditMessage(result.message);
   } else if (result.status === "held") {
     console.log(`[voice-edit] held: ${result.reason}`);
+    if (soundCuesEnabled()) soundCues.dictationHeld();
     setUserVisibleState("held", { text: result.text, reason: result.reason });
   } else if (result.status === "unrecognised") {
     console.log(`[voice-edit] command not recognised: ${JSON.stringify(result.command)}`);
@@ -617,6 +628,7 @@ async function transcribeAndPrint(wavBuffer, timing, recordStartBundleId) {
     console.log(`[dictation] ${result.text}`);
     console.log("[dictation] inserted through accessibility");
     maybeCopyTranscript(result.text);
+    if (soundCuesEnabled()) soundCues.textDelivered();
     if (Number.isFinite(timing?.releasedAtMs)) {
       const latencyMs = performance.now() - timing.releasedAtMs;
       const budgetResult = latencyMs < 1000 ? "within" : "over";
@@ -634,6 +646,7 @@ async function transcribeAndPrint(wavBuffer, timing, recordStartBundleId) {
   } else if (result.status === "held") {
     console.log(`[dictation] injection held: ${result.reason}`);
     maybeCopyTranscript(result.text);
+    if (soundCuesEnabled()) soundCues.dictationHeld();
     setUserVisibleState("held", { text: result.text, reason: result.reason });
   } else if (result.status === "failed") {
     console.error(`[dictation] ${result.stage} failed: ${result.reason}`);
@@ -675,6 +688,7 @@ const pushToTalkCoordinator = createPushToTalkCoordinator({
     if (settingsStore && settingsStore.get().pauseMediaWhileRecording) {
       void mediaPause.pauseForRecording();
     }
+    if (soundCuesEnabled()) soundCues.recordingStarted();
     console.log("[dictation] recording - release the hotkey to stop, Escape to cancel");
   },
   stopCapture(timing) {

--- a/electron/main.js
+++ b/electron/main.js
@@ -1026,6 +1026,20 @@ ipcMain.handle("settings:set-pause-media", (event, enabled) => {
   return settingsStore.setPauseMediaWhileRecording(enabled);
 });
 
+ipcMain.handle("settings:set-sound-cues", (event, enabled) => {
+  // #256: validated in the store, same as the other toggles.
+  return settingsStore.setSoundCues(enabled);
+});
+
+ipcMain.handle("settings:set-overlay-position", (event, position) => {
+  // #256: the store validates against OVERLAY_POSITIONS.
+  const settings = settingsStore.setOverlayPosition(position);
+  // Move it now if it happens to be on screen, so the choice is visible
+  // without waiting for the next recording.
+  if (overlayWin && !overlayWin.isDestroyed() && overlayWin.isVisible()) positionOverlay();
+  return settings;
+});
+
 // #19: pick an app from disk instead of hunting down its bundle id by
 // hand. Returns { bundleId, name } for the renderer to add, or null if the
 // dialog was cancelled; a bundle with no readable identifier rejects.

--- a/electron/overlayPosition.js
+++ b/electron/overlayPosition.js
@@ -1,14 +1,53 @@
 // Pure arithmetic, kept separate from main.js so it's testable without a
 // running Electron instance. macOS's own dictation HUD anchors bottom-
-// center, clear of the Dock - this computes the same spot for our overlay,
-// given the target display's work area (which already excludes the Dock
-// and menu bar) and the overlay window's size. See #116.
-const BOTTOM_MARGIN_PX = 32;
+// center, clear of the Dock - that's the default. #256 lets the user pick
+// another edge or corner; the maths is the same, given the target display's
+// work area (which already excludes the Dock and menu bar) and the overlay
+// window's size. See #116 / #256.
+const EDGE_MARGIN_PX = 32;
+// Kept under the old name for callers that predate #256.
+const BOTTOM_MARGIN_PX = EDGE_MARGIN_PX;
 
-function computeBottomCenteredPosition(workArea, windowWidth, windowHeight, marginPx = BOTTOM_MARGIN_PX) {
-  const x = Math.round(workArea.x + (workArea.width - windowWidth) / 2);
-  const y = Math.round(workArea.y + workArea.height - windowHeight - marginPx);
-  return { x, y };
+const OVERLAY_POSITIONS = ["bottom", "bottom-left", "bottom-right", "top", "top-left", "top-right"];
+const DEFAULT_OVERLAY_POSITION = "bottom";
+
+function computeOverlayPosition(
+  workArea,
+  windowWidth,
+  windowHeight,
+  position = DEFAULT_OVERLAY_POSITION,
+  marginPx = EDGE_MARGIN_PX,
+) {
+  const vertical = String(position).startsWith("top") ? "top" : "bottom";
+  const horizontal = String(position).endsWith("-left")
+    ? "left"
+    : String(position).endsWith("-right")
+      ? "right"
+      : "center";
+
+  let x;
+  if (horizontal === "left") x = workArea.x + marginPx;
+  else if (horizontal === "right") x = workArea.x + workArea.width - windowWidth - marginPx;
+  else x = workArea.x + (workArea.width - windowWidth) / 2;
+
+  const y =
+    vertical === "top"
+      ? workArea.y + marginPx
+      : workArea.y + workArea.height - windowHeight - marginPx;
+
+  return { x: Math.round(x), y: Math.round(y) };
 }
 
-module.exports = { computeBottomCenteredPosition, BOTTOM_MARGIN_PX };
+// The pre-#256 name - bottom-center, the default.
+function computeBottomCenteredPosition(workArea, windowWidth, windowHeight, marginPx = EDGE_MARGIN_PX) {
+  return computeOverlayPosition(workArea, windowWidth, windowHeight, DEFAULT_OVERLAY_POSITION, marginPx);
+}
+
+module.exports = {
+  computeOverlayPosition,
+  computeBottomCenteredPosition,
+  OVERLAY_POSITIONS,
+  DEFAULT_OVERLAY_POSITION,
+  EDGE_MARGIN_PX,
+  BOTTOM_MARGIN_PX,
+};

--- a/electron/overlayPosition.test.js
+++ b/electron/overlayPosition.test.js
@@ -1,6 +1,12 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
-const { computeBottomCenteredPosition, BOTTOM_MARGIN_PX } = require("./overlayPosition");
+const {
+  computeBottomCenteredPosition,
+  computeOverlayPosition,
+  OVERLAY_POSITIONS,
+  BOTTOM_MARGIN_PX,
+  EDGE_MARGIN_PX,
+} = require("./overlayPosition");
 
 test("centers horizontally within the work area", () => {
   const workArea = { x: 0, y: 0, width: 1440, height: 900 };
@@ -27,4 +33,38 @@ test("a custom margin overrides the default", () => {
   const workArea = { x: 0, y: 0, width: 1440, height: 900 };
   const { y } = computeBottomCenteredPosition(workArea, 180, 52, 0);
   assert.equal(y, 900 - 52);
+});
+
+test("#256: each anchor lands against the right edges of the work area", () => {
+  const workArea = { x: 100, y: 50, width: 1440, height: 900 };
+  const w = 180;
+  const h = 52;
+  const m = EDGE_MARGIN_PX;
+  const left = 100 + m;
+  const right = 100 + 1440 - w - m;
+  const centreX = 100 + (1440 - w) / 2;
+  const top = 50 + m;
+  const bottom = 50 + 900 - h - m;
+
+  assert.deepEqual(computeOverlayPosition(workArea, w, h, "bottom"), { x: Math.round(centreX), y: bottom });
+  assert.deepEqual(computeOverlayPosition(workArea, w, h, "bottom-left"), { x: left, y: bottom });
+  assert.deepEqual(computeOverlayPosition(workArea, w, h, "bottom-right"), { x: right, y: bottom });
+  assert.deepEqual(computeOverlayPosition(workArea, w, h, "top"), { x: Math.round(centreX), y: top });
+  assert.deepEqual(computeOverlayPosition(workArea, w, h, "top-left"), { x: left, y: top });
+  assert.deepEqual(computeOverlayPosition(workArea, w, h, "top-right"), { x: right, y: top });
+});
+
+test("#256: an unknown position falls back to bottom-centre", () => {
+  const workArea = { x: 0, y: 0, width: 1440, height: 900 };
+  assert.deepEqual(
+    computeOverlayPosition(workArea, 180, 52, "sideways"),
+    computeOverlayPosition(workArea, 180, 52, "bottom"),
+  );
+});
+
+test("#256: OVERLAY_POSITIONS lists every anchor the picker offers", () => {
+  assert.deepEqual(
+    [...OVERLAY_POSITIONS].sort(),
+    ["bottom", "bottom-left", "bottom-right", "top", "top-left", "top-right"],
+  );
 });

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -65,6 +65,8 @@ contextBridge.exposeInMainWorld("openstream", {
     setCopyTranscript: (enabled) => ipcRenderer.invoke("settings:set-copy-transcript", enabled),
     setIdleUnloadMinutes: (minutes) => ipcRenderer.invoke("settings:set-idle-unload-minutes", minutes),
     setPauseMediaWhileRecording: (enabled) => ipcRenderer.invoke("settings:set-pause-media", enabled),
+    setSoundCues: (enabled) => ipcRenderer.invoke("settings:set-sound-cues", enabled),
+    setOverlayPosition: (position) => ipcRenderer.invoke("settings:set-overlay-position", position),
   },
   vocabulary: {
     rescan: () => ipcRenderer.invoke("vocabulary:rescan"),

--- a/electron/settingsStore.js
+++ b/electron/settingsStore.js
@@ -2,6 +2,7 @@ const fs = require("fs");
 const path = require("path");
 const { DEFAULT_BREAK_SAFE_BUNDLE_IDS } = require("./breakSafety");
 const { STANDALONE_OPTION_KEY_CODE, isSupportedSingleKeyShortcut } = require("./hotkeyDefinitions");
+const { OVERLAY_POSITIONS, DEFAULT_OVERLAY_POSITION } = require("./overlayPosition");
 
 // Matches hotkeyHelper.js's standalone Option default and breakSafety.js's
 // own default allow-list. Existing settings are read as-is below so this
@@ -29,6 +30,11 @@ const DEFAULT_SETTINGS = {
   // #265: pause Music / Spotify while recording so the mic doesn't pick them
   // up. Off by default - the first use triggers a macOS Automation prompt.
   pauseMediaWhileRecording: false,
+  // #256: short sounds at the start of a recording and when text lands.
+  // Off by default.
+  soundCues: false,
+  // #256: which edge / corner the push-to-talk overlay sits at.
+  overlayPosition: DEFAULT_OVERLAY_POSITION,
 };
 
 // #257: a whole number of minutes, 0 (off) to a day. A day is already well
@@ -39,6 +45,12 @@ const MAX_IDLE_UNLOAD_MINUTES = 1440;
 function validateIdleUnloadMinutes(minutes) {
   if (typeof minutes !== "number" || !Number.isInteger(minutes) || minutes < 0 || minutes > MAX_IDLE_UNLOAD_MINUTES) {
     throw new Error(`idleUnloadMinutes must be a whole number of minutes between 0 and ${MAX_IDLE_UNLOAD_MINUTES}`);
+  }
+}
+
+function validateOverlayPosition(position) {
+  if (!OVERLAY_POSITIONS.includes(position)) {
+    throw new Error(`overlayPosition must be one of: ${OVERLAY_POSITIONS.join(", ")}`);
   }
 }
 
@@ -249,6 +261,18 @@ function createSettingsStore({ filePath }) {
     return commit({ ...load(), pauseMediaWhileRecording: enabled });
   }
 
+  function setSoundCues(enabled) {
+    if (typeof enabled !== "boolean") {
+      throw new Error("soundCues must be a boolean");
+    }
+    return commit({ ...load(), soundCues: enabled });
+  }
+
+  function setOverlayPosition(position) {
+    validateOverlayPosition(position);
+    return commit({ ...load(), overlayPosition: position });
+  }
+
   function setWindowBounds(bounds) {
     validateWindowBounds(bounds);
     // Only the four geometry keys are kept - a caller passing a whole
@@ -280,6 +304,8 @@ function createSettingsStore({ filePath }) {
     setCopyTranscriptToClipboard,
     setIdleUnloadMinutes,
     setPauseMediaWhileRecording,
+    setSoundCues,
+    setOverlayPosition,
     setWindowBounds,
     onChange,
   };

--- a/electron/settingsStore.test.js
+++ b/electron/settingsStore.test.js
@@ -249,6 +249,22 @@ test("#265: pauseMediaWhileRecording defaults to false and round-trips", () => {
   assert.throws(() => store.setPauseMediaWhileRecording("on"), /must be a boolean/);
 });
 
+test("#256: soundCues defaults to false and round-trips", () => {
+  const store = createSettingsStore({ filePath: tempFilePath() });
+  assert.equal(store.get().soundCues, false);
+  store.setSoundCues(true);
+  assert.equal(store.get().soundCues, true);
+  assert.throws(() => store.setSoundCues("on"), /must be a boolean/);
+});
+
+test("#256: overlayPosition defaults to bottom and rejects an unknown anchor", () => {
+  const store = createSettingsStore({ filePath: tempFilePath() });
+  assert.equal(store.get().overlayPosition, "bottom");
+  store.setOverlayPosition("top-right");
+  assert.equal(store.get().overlayPosition, "top-right");
+  assert.throws(() => store.setOverlayPosition("middle"), /overlayPosition must be one of/);
+});
+
 test("setVocabularyProjectPath persists a trimmed path and get() reflects it afterwards", () => {
   const filePath = tempFilePath();
   const store = createSettingsStore({ filePath });

--- a/electron/soundCues.js
+++ b/electron/soundCues.js
@@ -1,0 +1,43 @@
+const { execFile } = require("child_process");
+
+// #256: short sounds at the edges of a dictation so you don't have to watch
+// the overlay. Off by default. macOS ships these under /System/Library/
+// Sounds, so there is nothing to bundle and afplay is always present.
+const CUE_SOUNDS = {
+  // Recording has started - a light tap.
+  start: "Pop",
+  // Text landed at the cursor - a soft confirmation.
+  delivered: "Tink",
+  // Couldn't place the text (held for manual paste) - a flatter note.
+  held: "Basso",
+};
+
+function createSoundCues({ play = defaultPlay } = {}) {
+  function cue(name) {
+    const sound = CUE_SOUNDS[name];
+    if (!sound) return;
+    // Fire-and-forget: a cue must never hold up a recording or a delivery.
+    Promise.resolve()
+      .then(() => play(sound))
+      .catch(() => {
+        // A missing sound file or a broken afplay is not worth surfacing.
+      });
+  }
+
+  return {
+    recordingStarted: () => cue("start"),
+    textDelivered: () => cue("delivered"),
+    dictationHeld: () => cue("held"),
+  };
+}
+
+function defaultPlay(sound) {
+  return new Promise((resolve, reject) => {
+    execFile("afplay", [`/System/Library/Sounds/${sound}.aiff`], { timeout: 4000 }, (error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+module.exports = { createSoundCues, CUE_SOUNDS };

--- a/electron/soundCues.test.js
+++ b/electron/soundCues.test.js
@@ -1,0 +1,38 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { createSoundCues, CUE_SOUNDS } = require("./soundCues");
+
+function nextTick() {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+test("each cue plays its mapped system sound", async () => {
+  const played = [];
+  const cues = createSoundCues({ play: async (sound) => played.push(sound) });
+
+  cues.recordingStarted();
+  cues.textDelivered();
+  cues.dictationHeld();
+  await nextTick();
+
+  assert.deepEqual(played, [CUE_SOUNDS.start, CUE_SOUNDS.delivered, CUE_SOUNDS.held]);
+});
+
+test("a play failure is swallowed, never thrown", async () => {
+  const cues = createSoundCues({
+    play: async () => {
+      throw new Error("afplay: no such file");
+    },
+  });
+  assert.doesNotThrow(() => cues.recordingStarted());
+  await nextTick();
+});
+
+test("the cue call returns immediately, before play resolves", async () => {
+  let resolved = false;
+  const cues = createSoundCues({
+    play: () => new Promise((resolve) => setTimeout(() => ((resolved = true), resolve()), 50)),
+  });
+  cues.textDelivered();
+  assert.equal(resolved, false);
+});

--- a/src/openstreamBridge.d.ts
+++ b/src/openstreamBridge.d.ts
@@ -2,6 +2,14 @@ import type { StoredHotkey } from "./hotkey/captureHotkey";
 
 export type TermCorrection = { heard: string; write: string };
 
+export type OverlayPosition =
+  | "bottom"
+  | "bottom-left"
+  | "bottom-right"
+  | "top"
+  | "top-left"
+  | "top-right";
+
 export type StoredSettings = {
   hotkey: StoredHotkey;
   breakSafeApps: string[];
@@ -10,6 +18,8 @@ export type StoredSettings = {
   copyTranscriptToClipboard: boolean;
   idleUnloadMinutes: number;
   pauseMediaWhileRecording: boolean;
+  soundCues: boolean;
+  overlayPosition: OverlayPosition;
 };
 
 export type SetShortcutResult =
@@ -87,6 +97,8 @@ declare global {
         setCopyTranscript(enabled: boolean): Promise<StoredSettings>;
         setIdleUnloadMinutes(minutes: number): Promise<StoredSettings>;
         setPauseMediaWhileRecording(enabled: boolean): Promise<StoredSettings>;
+        setSoundCues(enabled: boolean): Promise<StoredSettings>;
+        setOverlayPosition(position: OverlayPosition): Promise<StoredSettings>;
       };
       vocabulary: {
         rescan(): Promise<VocabularyStatus>;

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -3,6 +3,7 @@ import HotkeySettings from "../HotkeySettings";
 import BreakSafeAppsSettings from "../BreakSafeAppsSettings";
 import TermCorrectionsSettings from "../TermCorrectionsSettings";
 import Toggle from "../components/Toggle";
+import type { OverlayPosition } from "../openstreamBridge";
 
 function CopyTranscriptSection() {
   const [enabled, setEnabled] = useState<boolean | null>(null);
@@ -119,6 +120,78 @@ function PauseMediaSection() {
   );
 }
 
+function SoundCuesSection() {
+  const [enabled, setEnabled] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    window.openstream.settings.get().then((settings) => setEnabled(settings.soundCues));
+  }, []);
+
+  return (
+    <div className="setting-item">
+      <h3 className="setting-item__name">Sound cues</h3>
+      <p className="setting-item__desc">
+        A short sound when a recording starts and when the text lands, so you don’t have to watch the overlay.
+      </p>
+      <div className="setting-item__control">
+        <Toggle
+          label="Play a sound at the start and end of a dictation"
+          checked={enabled ?? false}
+          disabled={enabled === null}
+          onChange={(next) => {
+            setEnabled(next);
+            window.openstream.settings.setSoundCues(next).then((settings) => setEnabled(settings.soundCues));
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+const OVERLAY_POSITION_OPTIONS: { value: OverlayPosition; label: string }[] = [
+  { value: "bottom", label: "Bottom centre" },
+  { value: "bottom-left", label: "Bottom left" },
+  { value: "bottom-right", label: "Bottom right" },
+  { value: "top", label: "Top centre" },
+  { value: "top-left", label: "Top left" },
+  { value: "top-right", label: "Top right" },
+];
+
+function OverlayPositionSection() {
+  const [position, setPosition] = useState<OverlayPosition | null>(null);
+
+  useEffect(() => {
+    window.openstream.settings.get().then((settings) => setPosition(settings.overlayPosition));
+  }, []);
+
+  return (
+    <div className="setting-item">
+      <h3 className="setting-item__name">Overlay position</h3>
+      <p className="setting-item__desc">Where the push-to-talk overlay sits while you’re speaking.</p>
+      <div className="setting-item__control">
+        <select
+          className="field"
+          value={position ?? "bottom"}
+          disabled={position === null}
+          onChange={(event) => {
+            const next = event.target.value as OverlayPosition;
+            setPosition(next);
+            window.openstream.settings
+              .setOverlayPosition(next)
+              .then((settings) => setPosition(settings.overlayPosition));
+          }}
+        >
+          {OVERLAY_POSITION_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
+  );
+}
+
 function StartupSection() {
   const [openAtLogin, setOpenAtLogin] = useState<boolean | null>(null);
 
@@ -175,6 +248,10 @@ export default function Settings() {
         <CopyTranscriptSection />
 
         <PauseMediaSection />
+
+        <SoundCuesSection />
+
+        <OverlayPositionSection />
 
         <IdleUnloadSection />
 


### PR DESCRIPTION
Closes #256. Two small polish items OpenSuperWhisper users keep asking for.

## Sound cues

Off by default. When on, a short system sound plays when a recording starts (`Pop`), when text lands (`Tink`), and when a result is held for manual paste (`Basso`). `electron/soundCues.js` shells out to `afplay` on the macOS system sounds — nothing to bundle. Fire-and-forget, every failure swallowed, so a cue can never delay or break a dictation. Wired into both the dictation and voice-edit paths.

## Overlay position

`electron/overlayPosition.js` now computes any of six anchors — bottom / top × centre / left / right — against the display work area (still clear of the Dock and menu bar). New `overlayPosition` setting, default `"bottom"` (unchanged behaviour). A dropdown in Settings. The overlay repositions on its next show, or immediately if it happens to be visible when you change it.

"Stays above full-screen apps" from the issue is already handled — the overlay window has `alwaysOnTop` + `setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true })`.

## Commits (7)

1. `overlayPosition`: compute any edge/corner
2. `soundCues` module
3. settings fields (both), defaults keep today's behaviour
4. wire sound cues into the lifecycle
5. wire overlay position
6. renderer plumbing
7. Settings UI

## Tests

`overlayPosition.test.js` (+4: every anchor, unknown-falls-back, the anchor list), `soundCues.test.js` (3: mapping, swallow failures, returns before play resolves), `settingsStore.test.js` (+2: defaults + validation for both). Full suite (331) + typecheck + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
