### PR TITLE
Multiple languages + auto-detect (#252)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -65,7 +65,7 @@ _Avoid_: Eviction, unloading, timeout kill
 ### Cleanup
 
 **Rules cleanup**:
-Deterministic, non-model text tidying applied to every dictation. Costs under a millisecond. It does all cleanup except break placement, which it asks the rewrite model server to decide.
+Deterministic, non-model text tidying applied to every English dictation. Costs under a millisecond. It does all cleanup except break placement, which it asks the rewrite model server to decide. It is English-specific (spoken punctuation, filler words, capitalisation), so a dictation in another language (#252) skips it and gets whitespace tidy-up only.
 _Avoid_: Post-processing, formatting pass
 
 **Term correction**:

--- a/electron/cleanup/rules.js
+++ b/electron/cleanup/rules.js
@@ -549,6 +549,11 @@ function terminalPunct(text) {
  * @param {{heard: string, write: string}[]} [options.corrections] - #321
  *   user-maintained term corrections from Settings, applied after the
  *   built-in vocabulary.
+ * @param {boolean} [options.englishRules=true] - #252. When false (the
+ *   dictation is in another language), skip every English-specific rule -
+ *   spoken commands, fillers, capitalisation, terminal punctuation - and
+ *   just tidy whitespace, so the transcript is passed through rather than
+ *   mangled.
  */
 function cleanup(text, options = {}) {
   const oneLineBox = Boolean(options.oneLineBox);
@@ -561,6 +566,12 @@ function cleanup(text, options = {}) {
   // artifact, not something the speaker said, and must go before anything
   // else runs.
   text = text.replace(/\s*\n\s*/g, " ");
+
+  // #252: a non-English dictation gets whitespace tidy-up only. Everything
+  // below assumes English words and English punctuation conventions.
+  if (options.englishRules === false) {
+    return text.replace(/ {2,}/g, " ").trim();
+  }
 
   // Both #127 and #132 must run before collapseRepeats and stripFillers -
   // #132's spelled word with a doubled letter ("b o o k") would otherwise

--- a/electron/cleanup/rules.test.js
+++ b/electron/cleanup/rules.test.js
@@ -139,6 +139,18 @@ test("#321: corrections can override a built-in vocabulary rule", () => {
   assert.equal(cleanup("i run macos", { corrections: [{ heard: "macOS", write: "Mac OS" }] }), "I run Mac OS.");
 });
 
+test("#252: englishRules:false skips every English rule, tidies whitespace only", () => {
+  // Spoken-command words, fillers, "i", terminal punctuation - all left alone.
+  assert.equal(
+    cleanup("il  faut un point period ici um", { englishRules: false }),
+    "il faut un point period ici um",
+  );
+  // The helper's hard line wraps still collapse (an STT artifact, not speech).
+  assert.equal(cleanup("erste zeile\nzweite zeile", { englishRules: false }), "erste zeile zweite zeile");
+  // englishRules omitted or true keeps today's behaviour.
+  assert.equal(cleanup("run the tests period", { englishRules: true }), "Run the tests.");
+});
+
 test("handles spoken self-correction by discarding the preceding clause", () => {
   const cases = [
     ["buy milk, scratch that, buy oat milk", "Buy oat milk."],

--- a/electron/dictationCoordinator.js
+++ b/electron/dictationCoordinator.js
@@ -1,5 +1,6 @@
 const { cleanup } = require("./cleanup/rules");
 const { isBreakSafeApplication } = require("./breakSafety");
+const { usesEnglishCleanup } = require("./languages");
 
 // #375: a bare spoken "paste" is a command, not dictation. Strict
 // whole-utterance match - "paste the report" types literally, like any
@@ -50,6 +51,9 @@ function createDictationIntake(options) {
     // defaulting to none, same as vocabulary - callers/tests that don't wire
     // it get ordinary cleanup with only the built-in vocabulary.
     corrections = { getEntries: () => [] },
+    // #252: transcription input language. Optional; defaults to English, so
+    // callers/tests that don't wire it get today's behaviour.
+    language = { get: () => "en" },
     onDiagnostic = () => {},
     // #125: the spike found SmolLM2-1.7B over-triggers list detection (a list
     // flagged on 5 of 6 non-lists) and the live prompt is break-only for now,
@@ -70,6 +74,7 @@ function createDictationIntake(options) {
   assertAdapter("delivery", delivery, "deliver");
   assertAdapter("vocabulary", vocabulary, "getPrompt");
   assertAdapter("corrections", corrections, "getEntries");
+  assertAdapter("language", language, "get");
 
   let queue = Promise.resolve();
 
@@ -89,11 +94,17 @@ function createDictationIntake(options) {
       return { status: "empty" };
     }
 
+    // #252: the configured input language, both a hint for the transcriber
+    // and the switch for whether the English cleanup rules run.
+    const inputLanguage = language.get();
+    const englishCleanup = usesEnglishCleanup(inputLanguage);
+    emitDiagnostic("language.input", inputLanguage);
+
     let rawText;
     try {
       const vocabularyPrompt = vocabulary.getPrompt();
       emitDiagnostic("vocabulary.promptLength", vocabularyPrompt.length);
-      const transcript = await transcription.transcribe(wavBuffer, vocabularyPrompt);
+      const transcript = await transcription.transcribe(wavBuffer, vocabularyPrompt, inputLanguage);
       if (typeof transcript !== "string") {
         throw new Error("transcription adapter returned a non-string transcript");
       }
@@ -111,7 +122,8 @@ function createDictationIntake(options) {
     // paths), so a held transcript still gets the name spelled right.
     const correctionEntries = corrections.getEntries();
     emitDiagnostic("corrections.count", Array.isArray(correctionEntries) ? correctionEntries.length : 0);
-    const clean = (text, opts) => cleanup(text, { ...opts, corrections: correctionEntries });
+    const clean = (text, opts) =>
+      cleanup(text, { ...opts, corrections: correctionEntries, englishRules: englishCleanup });
 
     let focusContext;
     try {
@@ -255,7 +267,13 @@ function createDictationIntake(options) {
     const sentences = splitSentences(finishedText);
     const hasExplicitBreakCommand = /\bnew (?:line|paragraph)\b/i.test(rawText);
     const eligibleForBreakPlacement =
-      breakSafe && !focusContext.isOneLineField && !hasExplicitBreakCommand && sentences.length >= 3;
+      // #252: the rewrite model's break-placement prompt is English. Skip it
+      // for a non-English dictation rather than feed it text it can't parse.
+      englishCleanup &&
+      breakSafe &&
+      !focusContext.isOneLineField &&
+      !hasExplicitBreakCommand &&
+      sentences.length >= 3;
 
     if (eligibleForBreakPlacement) {
       try {

--- a/electron/dictationCoordinator.test.js
+++ b/electron/dictationCoordinator.test.js
@@ -20,6 +20,8 @@ function createIntake({
   vocabulary,
   // #321: undefined = no corrections adapter wired (the default no-op).
   corrections,
+  // #252: the transcription input language; undefined keeps the default "en".
+  language,
   onDiagnostic,
   listDetection,
   // #375: undefined = no clipboard adapter wired at all.
@@ -50,6 +52,7 @@ function createIntake({
     },
     vocabulary,
     ...(corrections !== undefined ? { corrections } : {}),
+    ...(language !== undefined ? { language: { get: () => language } } : {}),
     onDiagnostic: onDiagnostic || ((name, value) => diagnostics.push([name, value])),
     listDetection,
     clipboard: clipboardText !== undefined ? { readText: () => clipboardText } : null,
@@ -147,6 +150,46 @@ test("#321: with no corrections adapter, cleanup runs unchanged", async () => {
   const { result, delivered } = await deliveredText({ transcript: "hello nabeel" });
   assert.equal(result.status, "delivered");
   assert.deepEqual(delivered, ["Hello nabeel."]);
+});
+
+test("#252: the configured language is passed to the transcriber", async () => {
+  const seen = [];
+  const harness = createIntake({
+    language: "fr",
+    transcribe: async (_wav, _prompt, lang) => {
+      seen.push(lang);
+      return "bonjour tout le monde";
+    },
+  });
+  await harness.intake.complete(completedWav);
+  assert.deepEqual(seen, ["fr"]);
+});
+
+test("#252: a non-English dictation skips the English cleanup rules", async () => {
+  // "period" is a spoken-punctuation command in English cleanup; in French
+  // mode it must stay a literal word.
+  const { result, delivered } = await deliveredText({
+    language: "fr",
+    transcript: "il faut un point period ici",
+  });
+  assert.equal(result.status, "delivered");
+  assert.equal(delivered[0], "il faut un point period ici");
+});
+
+test("#252: auto and en both run the full English pass", async () => {
+  for (const language of ["auto", "en"]) {
+    const { delivered } = await deliveredText({ language, transcript: "run the tests period" });
+    assert.equal(delivered[0], "Run the tests.", language);
+  }
+});
+
+test("#252: a non-English dictation never calls the break-placement model", async () => {
+  const harness = createIntake({
+    language: "de",
+    transcript: "erster satz. zweiter satz. dritter satz. vierter satz.",
+  });
+  await harness.intake.complete(completedWav);
+  assert.equal(harness.breakCalls.length, 0);
 });
 
 test("a known unsafe application never receives spoken line breaks", async () => {
@@ -318,6 +361,7 @@ test("repairs malformed break indices without retrying and records format and re
     text: "First sentence. Second sentence.\n\nThird sentence. Fourth sentence.",
   });
   assert.deepEqual(harness.diagnostics, [
+    ["language.input", "en"],
     ["vocabulary.promptLength", 0],
     ["corrections.count", 0],
     ["context.bundleId", "com.apple.TextEdit"],
@@ -376,6 +420,7 @@ test("a flagged spoken list renders as bullets set off from the surrounding pros
     text: "Here is my shopping list.\n\n- Buy milk.\n- Buy eggs.\n- Buy bread.",
   });
   assert.deepEqual(harness.diagnostics, [
+    ["language.input", "en"],
     ["vocabulary.promptLength", 0],
     ["corrections.count", 0],
     ["context.bundleId", "com.apple.TextEdit"],
@@ -403,6 +448,7 @@ test("an out-of-range list range is clamped into the text and recorded as repair
     text: "First sentence.\n\n- Second sentence.\n- Third sentence.\n- Fourth sentence.",
   });
   assert.deepEqual(harness.diagnostics, [
+    ["language.input", "en"],
     ["vocabulary.promptLength", 0],
     ["corrections.count", 0],
     ["context.bundleId", "com.apple.TextEdit"],
@@ -430,6 +476,7 @@ test("a malformed LIST line fails closed to prose without dropping paragraph bre
     text: "First sentence. Second sentence.\n\nThird sentence. Fourth sentence.",
   });
   assert.deepEqual(harness.diagnostics, [
+    ["language.input", "en"],
     ["vocabulary.promptLength", 0],
     ["corrections.count", 0],
     ["context.bundleId", "com.apple.TextEdit"],
@@ -456,6 +503,7 @@ test("list detection is off by default: a valid range is parsed and reported but
     text: "Here is my shopping list. Buy milk. Buy eggs. Buy bread.",
   });
   assert.deepEqual(harness.diagnostics, [
+    ["language.input", "en"],
     ["vocabulary.promptLength", 0],
     ["corrections.count", 0],
     ["context.bundleId", "com.apple.TextEdit"],

--- a/electron/languages.js
+++ b/electron/languages.js
@@ -1,0 +1,54 @@
+// #252: the languages the transcription engine (Parakeet TDT 0.6b v3 via
+// FluidAudio) can be hinted towards. The codes must match FluidAudio's
+// `Language` enum in native/transcription-helper - see its
+// Shared/TokenLanguageFilter.swift. The hint biases the decoder's token
+// filter towards that language's script; the model auto-detects the
+// content regardless, so "auto" (no hint) is always valid.
+const LANGUAGE_NAMES = {
+  en: "English",
+  es: "Spanish",
+  fr: "French",
+  de: "German",
+  it: "Italian",
+  pt: "Portuguese",
+  ro: "Romanian",
+  nl: "Dutch",
+  da: "Danish",
+  sv: "Swedish",
+  fi: "Finnish",
+  hu: "Hungarian",
+  et: "Estonian",
+  lv: "Latvian",
+  lt: "Lithuanian",
+  mt: "Maltese",
+  pl: "Polish",
+  cs: "Czech",
+  sk: "Slovak",
+  sl: "Slovenian",
+  hr: "Croatian",
+  bs: "Bosnian",
+  ru: "Russian",
+  uk: "Ukrainian",
+  be: "Belarusian",
+  bg: "Bulgarian",
+  sr: "Serbian",
+  el: "Greek",
+};
+
+// Any of these, or "auto".
+const SUPPORTED_LANGUAGE_CODES = new Set(Object.keys(LANGUAGE_NAMES));
+
+// Everything is English cleanup for now (#252): the deterministic rules in
+// cleanup/rules.js are English-specific, so a dictation in another language
+// gets a near-no-op pass rather than being mangled. "auto" still runs the
+// full pass because it is overwhelmingly English in practice and the
+// English rules are harmless on other Latin-script text.
+function usesEnglishCleanup(language) {
+  return !language || language === "auto" || language === "en";
+}
+
+function isSupportedLanguage(language) {
+  return language === "auto" || SUPPORTED_LANGUAGE_CODES.has(language);
+}
+
+module.exports = { LANGUAGE_NAMES, SUPPORTED_LANGUAGE_CODES, isSupportedLanguage, usesEnglishCleanup };

--- a/electron/languages.test.js
+++ b/electron/languages.test.js
@@ -1,0 +1,24 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { isSupportedLanguage, usesEnglishCleanup, SUPPORTED_LANGUAGE_CODES } = require("./languages");
+
+test("isSupportedLanguage accepts auto and every listed code, nothing else", () => {
+  assert.ok(isSupportedLanguage("auto"));
+  assert.ok(isSupportedLanguage("en"));
+  assert.ok(isSupportedLanguage("uk"));
+  assert.ok(!isSupportedLanguage("klingon"));
+  assert.ok(!isSupportedLanguage(""));
+  assert.ok(!isSupportedLanguage(undefined));
+});
+
+test("usesEnglishCleanup: English and auto run the full pass, a named other language does not", () => {
+  assert.ok(usesEnglishCleanup("en"));
+  assert.ok(usesEnglishCleanup("auto"));
+  assert.ok(usesEnglishCleanup(undefined));
+  assert.ok(!usesEnglishCleanup("fr"));
+  assert.ok(!usesEnglishCleanup("ru"));
+});
+
+test("the code list matches FluidAudio's Language enum (28 European languages)", () => {
+  assert.equal(SUPPORTED_LANGUAGE_CODES.size, 28);
+});

--- a/electron/main.js
+++ b/electron/main.js
@@ -203,6 +203,8 @@ const dictationIntake = createDictationIntake({
   // #321: the user's term-correction table, read fresh from settings on every
   // dictation so an edit takes effect on the next utterance.
   corrections: { getEntries: () => (settingsStore ? settingsStore.get().termCorrections : []) },
+  // #252: the transcription input language, same fresh read.
+  language: { get: () => (settingsStore ? settingsStore.get().inputLanguage : "en") },
   onDiagnostic: recordDictationDiagnostic,
 });
 
@@ -1038,6 +1040,11 @@ ipcMain.handle("settings:set-overlay-position", (event, position) => {
   // without waiting for the next recording.
   if (overlayWin && !overlayWin.isDestroyed() && overlayWin.isVisible()) positionOverlay();
   return settings;
+});
+
+ipcMain.handle("settings:set-input-language", (event, language) => {
+  // #252: the store validates against the supported code list.
+  return settingsStore.setInputLanguage(language);
 });
 
 // #19: pick an app from disk instead of hunting down its bundle id by

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -67,6 +67,7 @@ contextBridge.exposeInMainWorld("openstream", {
     setPauseMediaWhileRecording: (enabled) => ipcRenderer.invoke("settings:set-pause-media", enabled),
     setSoundCues: (enabled) => ipcRenderer.invoke("settings:set-sound-cues", enabled),
     setOverlayPosition: (position) => ipcRenderer.invoke("settings:set-overlay-position", position),
+    setInputLanguage: (language) => ipcRenderer.invoke("settings:set-input-language", language),
   },
   vocabulary: {
     rescan: () => ipcRenderer.invoke("vocabulary:rescan"),

--- a/electron/settingsStore.js
+++ b/electron/settingsStore.js
@@ -3,6 +3,7 @@ const path = require("path");
 const { DEFAULT_BREAK_SAFE_BUNDLE_IDS } = require("./breakSafety");
 const { STANDALONE_OPTION_KEY_CODE, isSupportedSingleKeyShortcut } = require("./hotkeyDefinitions");
 const { OVERLAY_POSITIONS, DEFAULT_OVERLAY_POSITION } = require("./overlayPosition");
+const { isSupportedLanguage } = require("./languages");
 
 // Matches hotkeyHelper.js's standalone Option default and breakSafety.js's
 // own default allow-list. Existing settings are read as-is below so this
@@ -35,6 +36,9 @@ const DEFAULT_SETTINGS = {
   soundCues: false,
   // #256: which edge / corner the push-to-talk overlay sits at.
   overlayPosition: DEFAULT_OVERLAY_POSITION,
+  // #252: transcription input language. "en" (unchanged behaviour), "auto"
+  // to let the model detect it, or a specific code from languages.js.
+  inputLanguage: "en",
 };
 
 // #257: a whole number of minutes, 0 (off) to a day. A day is already well
@@ -51,6 +55,12 @@ function validateIdleUnloadMinutes(minutes) {
 function validateOverlayPosition(position) {
   if (!OVERLAY_POSITIONS.includes(position)) {
     throw new Error(`overlayPosition must be one of: ${OVERLAY_POSITIONS.join(", ")}`);
+  }
+}
+
+function validateInputLanguage(language) {
+  if (typeof language !== "string" || !isSupportedLanguage(language)) {
+    throw new Error('inputLanguage must be "auto" or a supported language code');
   }
 }
 
@@ -273,6 +283,11 @@ function createSettingsStore({ filePath }) {
     return commit({ ...load(), overlayPosition: position });
   }
 
+  function setInputLanguage(language) {
+    validateInputLanguage(language);
+    return commit({ ...load(), inputLanguage: language });
+  }
+
   function setWindowBounds(bounds) {
     validateWindowBounds(bounds);
     // Only the four geometry keys are kept - a caller passing a whole
@@ -306,6 +321,7 @@ function createSettingsStore({ filePath }) {
     setPauseMediaWhileRecording,
     setSoundCues,
     setOverlayPosition,
+    setInputLanguage,
     setWindowBounds,
     onChange,
   };
@@ -322,4 +338,5 @@ module.exports = {
   MAX_TERM_CORRECTION_LENGTH,
   validateIdleUnloadMinutes,
   MAX_IDLE_UNLOAD_MINUTES,
+  validateInputLanguage,
 };

--- a/electron/settingsStore.test.js
+++ b/electron/settingsStore.test.js
@@ -265,6 +265,17 @@ test("#256: overlayPosition defaults to bottom and rejects an unknown anchor", (
   assert.throws(() => store.setOverlayPosition("middle"), /overlayPosition must be one of/);
 });
 
+test("#252: inputLanguage defaults to en, accepts auto and codes, rejects junk", () => {
+  const store = createSettingsStore({ filePath: tempFilePath() });
+  assert.equal(store.get().inputLanguage, "en");
+  store.setInputLanguage("auto");
+  assert.equal(store.get().inputLanguage, "auto");
+  store.setInputLanguage("fr");
+  assert.equal(store.get().inputLanguage, "fr");
+  assert.throws(() => store.setInputLanguage("xx"), /inputLanguage/);
+  assert.throws(() => store.setInputLanguage(""), /inputLanguage/);
+});
+
 test("setVocabularyProjectPath persists a trimmed path and get() reflects it afterwards", () => {
   const filePath = tempFilePath();
   const store = createSettingsStore({ filePath });

--- a/electron/transcriptionHelper.js
+++ b/electron/transcriptionHelper.js
@@ -206,9 +206,14 @@ function createTranscriptionHelper({
   // biasing the way whisper did, so #16's vocabulary prompt does not apply
   // to this engine (FluidAudio exposes a separate vocabulary-boosting API
   // that a later pass can wire in).
-  async function transcribe(wavBuffer, _prompt) {
+  //
+  // #252: `language` is a script hint - "auto"/undefined lets the model
+  // detect the content, a code biases its token filter towards that script.
+  async function transcribe(wavBuffer, _prompt, language) {
     const buffer = Buffer.isBuffer(wavBuffer) ? wavBuffer : Buffer.from(wavBuffer);
-    const reply = await request("transcribe", { wav: buffer.toString("base64") });
+    const payload = { wav: buffer.toString("base64") };
+    if (typeof language === "string" && language) payload.lang = language;
+    const reply = await request("transcribe", payload);
     if (reply.status !== "ok" || typeof reply.text !== "string") {
       throw new Error(
         `transcription-helper transcription failed${reply.reason ? `: ${reply.reason}` : ""}`,

--- a/electron/transcriptionHelper.test.js
+++ b/electron/transcriptionHelper.test.js
@@ -76,6 +76,26 @@ test("transcribe sends the WAV as base64 and returns the trimmed text", async ()
 
   child.stdout.write('{"id":"1","status":"ok","text":"  Hello there.  ","ms":210}\n');
   assert.equal(await promise, "Hello there.");
+  assert.equal("lang" in requests[0], false, "no lang field when none is passed");
+  helper.stop();
+});
+
+test("#252: a language is forwarded as the lang field, and blank/undefined is omitted", async () => {
+  const child = fakeProcess();
+  const requests = readRequests(child);
+  const helper = createTranscriptionHelper({ spawnProcess: () => child });
+  helper.start();
+  child.stdout.write('{"event":"ready"}\n');
+
+  helper.transcribe(wav, null, "fr");
+  await nextTurn();
+  assert.equal(requests[0].lang, "fr");
+  child.stdout.write('{"id":"1","status":"ok","text":"bonjour","ms":10}\n');
+
+  helper.transcribe(wav, null, "");
+  await nextTurn();
+  assert.equal("lang" in requests[1], false);
+  child.stdout.write('{"id":"2","status":"ok","text":"hi","ms":10}\n');
   helper.stop();
 });
 

--- a/native/transcription-helper/Sources/transcription-helper/main.swift
+++ b/native/transcription-helper/Sources/transcription-helper/main.swift
@@ -101,10 +101,14 @@ while let line = readLine(strippingNewline: true) {
             continue
         }
 
-        // v3 auto-detects, but the app is English-first, so bias to English
-        // unless the request overrides it. An unknown code falls back rather
-        // than failing the dictation.
-        let language = (object["lang"] as? String).flatMap(Language.init(rawValue:)) ?? .english
+        // #252: `lang` is a script hint for v3's token filter, not a hard
+        // setting - the model auto-detects the content either way. "auto" or
+        // a missing/unknown code means no hint (pure auto-detect); a valid
+        // code biases the decoder towards that language's script.
+        let language: Language? = {
+            guard let code = object["lang"] as? String, code != "auto" else { return nil }
+            return Language(rawValue: code)
+        }()
 
         let scratch = FileManager.default.temporaryDirectory
             .appendingPathComponent("openstream-dictation-\(id).wav")

--- a/src/commandReference.ts
+++ b/src/commandReference.ts
@@ -28,7 +28,7 @@ export type CommandSection = {
 export const COMMAND_SECTIONS: CommandSection[] = [
   {
     title: "While dictating",
-    note: "Say these as part of a normal dictation.",
+    note: "Say these as part of a normal dictation. English only — a dictation in another language is passed through as spoken.",
     groups: [
       {
         title: "Line breaks & lists",

--- a/src/openstreamBridge.d.ts
+++ b/src/openstreamBridge.d.ts
@@ -20,6 +20,8 @@ export type StoredSettings = {
   pauseMediaWhileRecording: boolean;
   soundCues: boolean;
   overlayPosition: OverlayPosition;
+  /** #252: "auto", "en", or another supported language code. */
+  inputLanguage: string;
 };
 
 export type SetShortcutResult =
@@ -99,6 +101,7 @@ declare global {
         setPauseMediaWhileRecording(enabled: boolean): Promise<StoredSettings>;
         setSoundCues(enabled: boolean): Promise<StoredSettings>;
         setOverlayPosition(position: OverlayPosition): Promise<StoredSettings>;
+        setInputLanguage(language: string): Promise<StoredSettings>;
       };
       vocabulary: {
         rescan(): Promise<VocabularyStatus>;

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -89,6 +89,78 @@ function IdleUnloadSection() {
   );
 }
 
+// #252: mirrors electron/languages.js - keep the two in step. Sorted by
+// name; "auto" comes first.
+const LANGUAGE_OPTIONS: { value: string; label: string }[] = [
+  { value: "auto", label: "Detect automatically" },
+  { value: "bs", label: "Bosnian" },
+  { value: "bg", label: "Bulgarian" },
+  { value: "hr", label: "Croatian" },
+  { value: "cs", label: "Czech" },
+  { value: "da", label: "Danish" },
+  { value: "nl", label: "Dutch" },
+  { value: "en", label: "English" },
+  { value: "et", label: "Estonian" },
+  { value: "fi", label: "Finnish" },
+  { value: "fr", label: "French" },
+  { value: "de", label: "German" },
+  { value: "el", label: "Greek" },
+  { value: "hu", label: "Hungarian" },
+  { value: "it", label: "Italian" },
+  { value: "lv", label: "Latvian" },
+  { value: "lt", label: "Lithuanian" },
+  { value: "mt", label: "Maltese" },
+  { value: "pl", label: "Polish" },
+  { value: "pt", label: "Portuguese" },
+  { value: "ro", label: "Romanian" },
+  { value: "ru", label: "Russian" },
+  { value: "sr", label: "Serbian" },
+  { value: "sk", label: "Slovak" },
+  { value: "sl", label: "Slovenian" },
+  { value: "es", label: "Spanish" },
+  { value: "sv", label: "Swedish" },
+  { value: "uk", label: "Ukrainian" },
+  { value: "be", label: "Belarusian" },
+];
+
+function InputLanguageSection() {
+  const [language, setLanguage] = useState<string | null>(null);
+
+  useEffect(() => {
+    window.openstream.settings.get().then((settings) => setLanguage(settings.inputLanguage));
+  }, []);
+
+  return (
+    <div className="setting-item">
+      <h3 className="setting-item__name">Dictation language</h3>
+      <p className="setting-item__desc">
+        The model handles 28 European languages. Picking one improves accuracy for its alphabet; the automatic
+        cleanup (spoken punctuation, filler removal) only runs for English.
+      </p>
+      <div className="setting-item__control">
+        <select
+          className="field"
+          value={language ?? "en"}
+          disabled={language === null}
+          onChange={(event) => {
+            const next = event.target.value;
+            setLanguage(next);
+            window.openstream.settings
+              .setInputLanguage(next)
+              .then((settings) => setLanguage(settings.inputLanguage));
+          }}
+        >
+          {LANGUAGE_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
+  );
+}
+
 function PauseMediaSection() {
   const [enabled, setEnabled] = useState<boolean | null>(null);
 
@@ -235,6 +307,8 @@ export default function Settings() {
           </p>
           <BreakSafeAppsSettings />
         </div>
+
+        <InputLanguageSection />
 
         <div className="setting-item">
           <h3 className="setting-item__name">Names &amp; terms</h3>


### PR DESCRIPTION
Closes #252 (the core of it — menu-bar quick-switch and translate-to-English stay follow-ups, as the issue says).

Parakeet TDT 0.6b v3 (what we already run) handles **28 European languages** and auto-detects the content. The engine work was already done by #326's Parakeet swap; this exposes it.

## What changed

- **`native/transcription-helper`** already took a `lang` field but forced English on a missing/unknown code. `lang` is only a *script hint* for v3's token filter — the model detects the language regardless — so `"auto"` and unknown codes now mean no hint.
- **Setting `inputLanguage`**: `"en"` (default, unchanged behaviour), `"auto"`, or one of the 28 codes. Validated against `electron/languages.js`, which mirrors FluidAudio's `Language` enum.
- **`dictationCoordinator`**: a `language` adapter, read per-dictation. It passes the hint to the transcriber and decides whether the English rules run.
- **`cleanup(text, { englishRules: false })`**: for a non-English dictation, skip every English-specific rule (spoken punctuation, filler stripping, "i" → "I", terminal punctuation) and just tidy whitespace, so the transcript is passed through rather than mangled. `"en"` and `"auto"` still run the full pass (`"auto"` is overwhelmingly English in practice and the English rules are harmless on other Latin text).
- **Break placement is skipped** for non-English too — the rewrite model's prompt is English.
- **Settings UI**: a "Dictation language" dropdown.
- Docs: CONTEXT.md and the Commands page note that cleanup / spoken commands are English-only.

## Commits (8)

language table + Swift hint → setting → helper forwarding → cleanup pass → coordinator wiring → main/renderer plumbing → Settings UI → docs.

## Needs a Swift rebuild

The `main.swift` change needs `npm run build:transcription-helper` to take effect. The JS side works with the current binary for `"en"` / specific codes; only `"auto"` needs the rebuild.

## Tests

`languages.test.js` (3), `settingsStore.test.js` (+1), `transcriptionHelper.test.js` (+1), `rules.test.js` (+1), `dictationCoordinator.test.js` (+4: language forwarded, non-English skips cleanup, auto/en run it, non-English skips break placement). Full suite (348) + typecheck + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
