### PR TITLE
Voice edit: always request the English script hint (#400)

### DIFF
--- a/electron/voiceEditCoordinator.js
+++ b/electron/voiceEditCoordinator.js
@@ -52,7 +52,11 @@ function createVoiceEditIntake(options) {
 
     let commandText;
     try {
-      const transcript = await transcription.transcribe(wavBuffer);
+      // #400: the command grammar (voiceEditCommands.js) is fixed English
+      // phrases regardless of what language the user dictates in, so this
+      // always asks for the English script hint - independent of the
+      // inputLanguage setting dictationCoordinator reads (#252).
+      const transcript = await transcription.transcribe(wavBuffer, undefined, "en");
       if (typeof transcript !== "string") {
         throw new Error("transcription adapter returned a non-string transcript");
       }

--- a/electron/voiceEditCoordinator.test.js
+++ b/electron/voiceEditCoordinator.test.js
@@ -10,8 +10,8 @@ function fakeAdapters(overrides = {}) {
   return {
     calls,
     transcription: {
-      transcribe: async (buf) => {
-        calls.push(["transcribe", buf.byteLength]);
+      transcribe: async (buf, _prompt, language) => {
+        calls.push(["transcribe", buf.byteLength, language]);
         return overrides.transcript ?? "snake case";
       },
     },
@@ -43,12 +43,19 @@ const ctx = (selection, over = {}) => ({
 
 test.beforeEach(() => setBreakSafeApplications(DEFAULT_BREAK_SAFE_BUNDLE_IDS));
 
+test("#400: always asks for the English script hint, regardless of any dictation-language setting", async () => {
+  const a = fakeAdapters({ transcript: "snake case" });
+  await createVoiceEditIntake(a).complete(WAV, ctx("user profile name"));
+  const transcribeCall = a.calls.find((c) => c[0] === "transcribe");
+  assert.equal(transcribeCall[2], "en");
+});
+
 test("a recognised command transforms the selection and delivers it", async () => {
   const a = fakeAdapters({ transcript: "camel case" });
   const intake = createVoiceEditIntake(a);
   const result = await intake.complete(WAV, ctx("user profile name"));
   assert.deepEqual(result, { status: "delivered", commandId: "camel", text: "userProfileName" });
-  assert.deepEqual(a.calls[0], ["transcribe", 200]);
+  assert.deepEqual(a.calls[0], ["transcribe", 200, "en"]);
   assert.deepEqual(a.calls[1], ["diag", "voiceEdit.command", "camel"]);
   assert.deepEqual(a.calls[2], ["deliver", "userProfileName"]);
 });


### PR DESCRIPTION
Closes #400.

#252 changed the Swift helper so a missing/`"auto"` `lang` field means no hint (pure auto-detect) - correct, since it's what lets genuine auto-detect work. Before that, a missing `lang` always defaulted to `.english`.

`voiceEditCoordinator.js` never sent a `lang` field at all, so it silently inherited whichever default the Swift side happened to have. Voice-edit commands ("snake case", "wrap in quotes", "copy that"...) are always fixed English phrases regardless of what language the user dictates in - so it should always ask for the English hint, not follow the dictation-language setting or fall through to no hint.

Fix: `transcription.transcribe(wavBuffer, undefined, "en")` at the one call site, explicit and independent of `inputLanguage`.

## Tests

New test asserting the English hint is requested; updated one pre-existing assertion that checked the exact call shape. Full suite (349) + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
